### PR TITLE
Added an API module to the executable spec, removed Lib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           cRet=$(echo "$closure" | tr '\n' ' ')
           echo "derivation=$dRet" >> $GITHUB_OUTPUT
           echo "closure=$cRet" >> $GITHUB_OUTPUT
-          rsync -r --exclude={'**/nix-support','**/lib'} outputs/ledger*/* docs/
+          rsync -r --exclude={'**/nix-support','**/lib'} outputs/ledger*/* docs/ledger/
 
       - name: Build midnight
         id: midnight
@@ -100,7 +100,7 @@ jobs:
           cRet=$(echo "$closure" | tr '\n' ' ')
           echo "derivation=$dRet" >> $GITHUB_OUTPUT
           echo "closure=$cRet" >> $GITHUB_OUTPUT
-          rsync -r --exclude={'**/nix-support','**/lib'} outputs/midnight*/* docs/
+          rsync -r --exclude={'**/nix-support','**/lib'} outputs/midnight*/* docs/midnight/
 
       - name: Export all derivations
         id: export-derivations

--- a/default.nix
+++ b/default.nix
@@ -71,7 +71,7 @@ rec {
 
   mkSpecDerivation = { project, main }: rec {
     docs = stdenv.mkDerivation {
-      pname = "docs";
+      pname = "${project}-docs";
       version = "0.1";
       src = "${formalLedger}";
       meta = { };
@@ -87,7 +87,7 @@ rec {
     };
 
     html = stdenv.mkDerivation {
-      pname = "html";
+      pname = "${project}-html";
       version = "0.1";
       src = "${formalLedger}";
       meta = { };
@@ -103,7 +103,7 @@ rec {
     };
 
     hsSrc = stdenv.mkDerivation {
-      pname = "hs-src";
+      pname = "${project}-hs-src";
       version = "0.1";
       src = "${formalLedger}";
       meta = { };
@@ -122,7 +122,10 @@ rec {
         test -n "$(find $out/haskell/ -type f -name '*.hs')"
         # OUT_DIR=$out make "${project}".hsTest
       '';
-      dontInstall = true;
+      installPhase = ''
+        mv $out/haskell/${main}/* $out
+        rm -rf $out/haskell
+      '';
     };
 
     # hsDocs = stdenv.mkDerivation {
@@ -144,7 +147,7 @@ rec {
     #   dontInstall = true;
     # };
 
-    hsExe = haskellPackages.callCabal2nix "${project}" "${hsSrc}/haskell/${main}" { };
+    hsExe = haskellPackages.callCabal2nix "${project}" "${hsSrc}" { };
 
   };
 

--- a/src/Ledger/hs-src/cardano-ledger-executable-spec.cabal
+++ b/src/Ledger/hs-src/cardano-ledger-executable-spec.cabal
@@ -47,12 +47,12 @@ test-suite test
 
 library
     import: globalOptions
-    hs-source-dirs: .
-    exposed-modules:
-        Lib
+    hs-source-dirs: src
     build-depends:
         text,
         ieee,
         tree-diff
+    exposed-modules:
+      MAlonzo.Code.Ledger.Foreign.API
 -- This will be generated automatically when building with nix
     other-modules:

--- a/src/Ledger/hs-src/src/MAlonzo/Code/Ledger/Foreign/API.hs
+++ b/src/Ledger/hs-src/src/MAlonzo/Code/Ledger/Foreign/API.hs
@@ -1,8 +1,7 @@
-module Lib
+module MAlonzo.Code.Ledger.Foreign.API
   ( module MAlonzo.Code.Ledger.Foreign.LedgerTypes
   , module MAlonzo.Code.Ledger.Foreign.HSLedger
   ) where
 
 import MAlonzo.Code.Ledger.Foreign.LedgerTypes
 import MAlonzo.Code.Ledger.Foreign.HSLedger
-

--- a/src/Ledger/hs-src/test/UtxowSpec.hs
+++ b/src/Ledger/hs-src/test/UtxowSpec.hs
@@ -7,7 +7,7 @@ import Control.Monad ( foldM )
 import Test.Hspec ( Spec, describe, it )
 import Test.HUnit ( (@?=) )
 
-import Lib
+import MAlonzo.Code.Ledger.Foreign.API
 
 (.->) = (,)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ PRE=$(addprefix $(LATEX_DIR)/,\
 PDF_DIR=$(OUT_DIR)/pdfs
 HTML_DIR=$(OUT_DIR)/html
 HS_DIR=$(OUT_DIR)/haskell
-MALONZO_DIR=MAlonzo/Code
+MALONZO_DIR=src/MAlonzo/Code
 CABAL_TEST=cabal run test
 LEDGER=Ledger
 MIDNIGHT=MidnightExample
@@ -50,8 +50,8 @@ define agdaToHs =
     mkdir -p $(HS_DIST)
     cp -r $(PROJECT)/hs-src/* $(HS_DIST)/
     cp $(PROJECT)/hs-src/$(CABAL_FILE) $(HS_DIST)/
-    $(AGDA) --transliterate -c --ghc-dont-call-ghc --compile-dir $(HS_DIST) $<
-    find $(HS_DIST)/MAlonzo -name "*.hs" -print\
+    $(AGDA) --transliterate -c --ghc-dont-call-ghc --compile-dir $(HS_DIST)/src $<
+    find $(HS_DIST)/src/MAlonzo -name "*.hs" -print\
       | sed "s#^$(HS_DIST)/#        #;s#\.hs##;s#/#.#g"\
       >> $(HS_DIST)/$(CABAL_FILE)
 endef


### PR DESCRIPTION
# Description

`Lib` is a bit too ambiguous to use in `cardano-ledger` conformance tests, so I exposed the `Foreign` modules directly instead. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
