### PR TITLE
Computational errors

### DIFF
--- a/src/Interface/ComputationalRelation.agda
+++ b/src/Interface/ComputationalRelation.agda
@@ -3,54 +3,122 @@
 module Interface.ComputationalRelation where
 
 open import Prelude
-open import Data.Maybe.Properties using (map-nothing)
 open import Interface.STS public
 
 private variable
+  a : Level
   C S Sig : Set
+  Err Err₁ Err₂ : Set
   c : C
   s s' s'' : S
   sig : Sig
 
+data ComputationResult {a : Level} (Err : Set) (R : Set a) : Set a where
+  success : R → ComputationResult Err R
+  failure : Err → ComputationResult Err R
+
+isFailure : ∀ {A : Set a} → ComputationResult Err A → Set a
+isFailure x = ∃[ e ] x ≡ failure e
+
+module _ {a b} {E : Set} {A : Set a} {B : Set b} where
+  caseCR_∣_∣_ : (ma : ComputationResult E A) → (∀ {a} → ma ≡ success a → B) → (isFailure ma → B) → B
+  caseCR ma ∣ f ∣ g with ma
+  ... | success _ = f refl
+  ... | failure e = g (e , refl)
+
+  caseCR-success : ∀ {a} {ma : ComputationResult E A} {f : ∀ {a} → ma ≡ success a → B} {g : isFailure ma → B}
+    → (eq : ma ≡ success a)
+    → caseCR ma ∣ f ∣ g ≡ f eq
+  caseCR-success refl = refl
+
+  caseCR-failure : {ma : ComputationResult E A} {f : ∀ {a} → ma ≡ success a → B} {g : isFailure ma → B}
+    → (eq : isFailure ma)
+    → caseCR ma ∣ f ∣ g ≡ g eq
+  caseCR-failure (_ , refl) = refl
+
+instance
+  Bifunctor-ComputationResult : ∀ {a : Level} → Bifunctor {_} {a} ComputationResult
+  Bifunctor-ComputationResult .bimap _ f (success x) = success $ f x
+  Bifunctor-ComputationResult .bimap f _ (failure x) = failure $ f x
+  
+  Functor-ComputationResult : ∀ {E : Set} → Functor (ComputationResult E)
+  Functor-ComputationResult ._<$>_ f (success x) = success $ f x
+  Functor-ComputationResult ._<$>_ _ (failure x) = failure x
+
+  Applicative-ComputationResult : ∀ {E : Set} → Applicative (ComputationResult E)
+  Applicative-ComputationResult .pure = success
+  Applicative-ComputationResult ._<*>_ (success f) x = f <$> x
+  Applicative-ComputationResult ._<*>_ (failure e) _ = failure e
+
+  Monad-ComputationResult : ∀ {E : Set} → Monad (ComputationResult E)
+  Monad-ComputationResult .return = success
+  Monad-ComputationResult ._>>=_ (success a) m = m a
+  Monad-ComputationResult ._>>=_ (failure e) _ = failure e
+
+map-failure : ∀ {A B C : Set} {f : A → B} {x : C} {ma} → ma ≡ failure x → map f ma ≡ failure x
+map-failure refl = refl
+
+success-maybe : ∀ {R : Set} → ComputationResult Err R → Maybe R
+success-maybe (success x) = just x
+success-maybe (failure _) = nothing
+
+failure-maybe : ∀ {R : Set} → ComputationResult Err R → Maybe Err
+failure-maybe (success _) = nothing
+failure-maybe (failure x) = just x
+
+_≈ᶜʳ_ : ∀ {A} → ComputationResult Err A → ComputationResult Err A → Set
+x ≈ᶜʳ y = success-maybe x ≡ success-maybe y
+
 module _ (STS : C → S → Sig → S → Set) where
 
-  ExtendedRel : C → S → Sig → Maybe S → Set
-  ExtendedRel c s sig (just s') = STS c s sig s'
-  ExtendedRel c s sig nothing   = ∀ s' → ¬ STS c s sig s'
+  ExtendedRel : C → S → Sig → ComputationResult Err S → Set
+  ExtendedRel c s sig (success s') = STS c s sig s'
+  ExtendedRel c s sig (failure _ ) = ∀ s' → ¬ STS c s sig s'
 
-  record Computational : Set where
+  record Computational Err : Set₁ where
     constructor MkComputational
     field
-      computeProof : (c : C) (s : S) (sig : Sig) → Maybe (∃[ s' ] STS c s sig s')
+      computeProof : (c : C) (s : S) (sig : Sig) → ComputationResult Err (∃[ s' ] STS c s sig s')
 
-    compute : C → S → Sig → Maybe S
-    compute c s sig = proj₁ <$> computeProof c s sig
+    compute : C → S → Sig → ComputationResult Err S
+    compute c s sig = map proj₁ $ computeProof c s sig
 
     field
       completeness : (c : C) (s : S) (sig : Sig) (s' : S)
-        → STS c s sig s' → compute c s sig ≡ just s'
+        → STS c s sig s' → compute c s sig ≡ success s'
 
     open ≡-Reasoning
 
-    ≡-just⇔STS : compute c s sig ≡ just s' ⇔ STS c s sig s'
-    ≡-just⇔STS {c} {s} {sig} {s'} with computeProof c s sig in eq
-    ... | just (s'' , h) = mk⇔ (λ where refl → h) λ h' →
-      begin just s''        ≡˘⟨ completeness _ _ _ _ h ⟩
-            compute c s sig ≡⟨ completeness _ _ _ _ h' ⟩
-            just s'         ∎
-    ... | nothing = mk⇔ (λ ()) λ h →
-      begin nothing         ≡˘⟨ map-nothing eq ⟩
-            compute c s sig ≡⟨ completeness _ _ _ _ h ⟩
-            just s'         ∎
+    computeFail : C → S → Sig → Set
+    computeFail c s sig = isFailure $ compute c s sig
 
-    nothing⇒∀¬STS : compute c s sig ≡ nothing → ∀ s' → ¬ STS c s sig s'
-    nothing⇒∀¬STS comp≡nothing s' h rewrite ≡-just⇔STS .Equivalence.from h =
+    ≡-success⇔STS : compute c s sig ≡ success s' ⇔ STS c s sig s'
+    ≡-success⇔STS {c} {s} {sig} {s'} with computeProof c s sig in eq
+    ... | success (s'' , h) = mk⇔ (λ where refl → h) λ h' →
+      begin success s''     ≡˘⟨ completeness _ _ _ _ h ⟩
+            compute c s sig ≡⟨ completeness _ _ _ _ h' ⟩
+            success s'      ∎
+    ... | failure y = mk⇔ (λ ()) λ h →
+      begin failure _       ≡˘⟨ map-failure eq ⟩
+            compute c s sig ≡⟨ completeness _ _ _ _ h ⟩
+            success s'      ∎
+
+    failure⇒∀¬STS : computeFail c s sig → ∀ s' → ¬ STS c s sig s'
+    failure⇒∀¬STS comp≡nothing s' h rewrite ≡-success⇔STS .Equivalence.from h =
       case comp≡nothing of λ ()
 
-    recomputeProof : ∀ {Γ s sig s'} → STS Γ s sig s' → Maybe (∃[ s'' ] STS Γ s sig s'')
+    ∀¬STS⇒failure : (∀ s' → ¬ STS c s sig s') → computeFail c s sig
+    ∀¬STS⇒failure {c = c} {s} {sig} ¬sts with computeProof c s sig
+    ... | success (x , y) = ⊥-elim (¬sts x y)
+    ... | failure y = (y , refl)
+
+    failure⇔∀¬STS : computeFail c s sig ⇔ ∀ s' → ¬ STS c s sig s'
+    failure⇔∀¬STS = mk⇔ failure⇒∀¬STS ∀¬STS⇒failure
+
+    recomputeProof : ∀ {Γ s sig s'} → STS Γ s sig s' → ComputationResult Err (∃[ s'' ] STS Γ s sig s'')
     recomputeProof _ = computeProof _ _ _
 
-module _ {STS : C → S → Sig → S → Set} (comp : Computational STS) where
+module _ {STS : C → S → Sig → S → Set} (comp : Computational STS Err) where
 
   open Computational comp
 
@@ -58,15 +126,19 @@ module _ {STS : C → S → Sig → S → Set} (comp : Computational STS) where
 
   ExtendedRel-compute : ExtendedRelSTS c s sig (compute c s sig)
   ExtendedRel-compute {c} {s} {sig} with compute c s sig in eq
-  ... | just s' = Equivalence.to ≡-just⇔STS eq
-  ... | nothing = λ s' h → case trans (sym $ Equivalence.from ≡-just⇔STS h) eq of λ ()
+  ... | success s' = Equivalence.to ≡-success⇔STS eq
+  ... | failure _  = λ s' h → case trans (sym $ Equivalence.from ≡-success⇔STS h) eq of λ ()
 
-  ExtendedRel-rightUnique : ExtendedRelSTS c s sig s' → ExtendedRelSTS c s sig s'' → s' ≡ s''
-  ExtendedRel-rightUnique {s' = just x}  {just x'} h h' =
-    trans (sym $ Equivalence.from ≡-just⇔STS h) (Equivalence.from ≡-just⇔STS h')
-  ExtendedRel-rightUnique {s' = just x}  {nothing} h h' = ⊥-elim $ h' x h
-  ExtendedRel-rightUnique {s' = nothing} {just x'} h h' = ⊥-elim $ h x' h'
-  ExtendedRel-rightUnique {s' = nothing} {nothing} h h' = refl
+  open ≡-Reasoning
+
+  ExtendedRel-rightUnique : ExtendedRelSTS c s sig s' → ExtendedRelSTS c s sig s'' → _≈ᶜʳ_ {Err = Err} s' s''
+  ExtendedRel-rightUnique {s' = success x}  {success x'} h h'
+    with trans (sym $ Equivalence.from ≡-success⇔STS h) (Equivalence.from ≡-success⇔STS h')
+  ... | refl = refl
+    
+  ExtendedRel-rightUnique {s' = success x} {failure _}  h h' = ⊥-elim $ h' x h
+  ExtendedRel-rightUnique {s' = failure _} {success x'} h h' = ⊥-elim $ h x' h'
+  ExtendedRel-rightUnique {s' = failure a} {failure b}  h h' = refl
 
   computational⇒rightUnique : STS c s sig s' → STS c s sig s'' → s' ≡ s''
   computational⇒rightUnique h h' with ExtendedRel-rightUnique h h'
@@ -75,71 +147,71 @@ module _ {STS : C → S → Sig → S → Set} (comp : Computational STS) where
   Computational⇒Dec : ⦃ _ : DecEq S ⦄ → Dec (STS c s sig s')
   Computational⇒Dec {c} {s} {sig} {s'}
     with compute c s sig | ExtendedRel-compute {c} {s} {sig}
-  ... | nothing | ExSTS = no (ExSTS s')
-  ... | just x  | ExSTS with x ≟ s'
+  ... | failure _ | ExSTS = no (ExSTS s')
+  ... | success x  | ExSTS with x ≟ s'
   ... | no ¬p    = no  λ h → ¬p $ sym $ computational⇒rightUnique h ExSTS
   ... | yes refl = yes ExSTS
 
-module _ {STS : C → S → Sig → S → Set} (comp comp' : Computational STS) where
+module _ {STS : C → S → Sig → S → Set} (comp comp' : Computational STS Err) where
 
   open Computational comp  renaming (compute to compute₁)
   open Computational comp' renaming (compute to compute₂)
 
-  compute-ext≡ : compute₁ c s sig ≡ compute₂ c s sig
+  compute-ext≡ : compute₁ c s sig ≈ᶜʳ compute₂ c s sig
   compute-ext≡ = ExtendedRel-rightUnique comp
     (ExtendedRel-compute comp) (ExtendedRel-compute comp')
 
 Computational⇒Dec' :
-  ⦃ _ : DecEq S ⦄ {STS : C → S → Sig → S → Set} ⦃ comp : Computational STS ⦄
+  ⦃ _ : DecEq S ⦄ {STS : C → S → Sig → S → Set} ⦃ comp : Computational STS Err ⦄
   → Dec (STS c s sig s')
 Computational⇒Dec' ⦃ comp = comp ⦄ = Computational⇒Dec comp
 
 open Computational ⦃...⦄
 
 instance
-  Computational-Id : {C S : Set} → Computational (IdSTS {C} {S})
-  Computational-Id .computeProof _ s _ = just (s , Id-nop)
+  Computational-Id : {C S : Set} → Computational (IdSTS {C} {S}) ⊥
+  Computational-Id .computeProof _ s _ = success (s , Id-nop)
   Computational-Id .completeness _ _ _ _ Id-nop = refl
 
-module _ {BSTS : C → S → ⊤ → S → Set} ⦃ _ : Computational BSTS ⦄ where
-  module _ {STS : C → S → Sig → S → Set} ⦃ _ : Computational STS ⦄ where instance
-    Computational-ReflexiveTransitiveClosureᵇ : Computational (ReflexiveTransitiveClosureᵇ BSTS STS)
-    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s [] =
-      map (map₂′ BS-base) (computeProof c s tt)
-    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s (sig ∷ sigs) = do
-      s₁ , h  ← computeProof c s sig
-      s₂ , hs ← computeProof c s₁ sigs
-      just (s₂ , BS-ind h hs)
+module _ {BSTS : C → S → ⊤ → S → Set} ⦃ _ : Computational BSTS Err₁ ⦄ where
+  module _ {STS : C → S → Sig → S → Set} ⦃ _ : Computational STS Err₂ ⦄ where instance
+    Computational-ReflexiveTransitiveClosureᵇ : Computational (ReflexiveTransitiveClosureᵇ BSTS STS) (Err₁ ⊎ Err₂)
+    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s [] = bimap inj₁ (map₂′ BS-base) (computeProof c s tt)
+    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s (sig ∷ sigs) with computeProof c s sig 
+    ... | success (s₁ , h) with computeProof c s₁ sigs
+    ...   | success (s₂ , hs) = success (s₂ , BS-ind h hs)
+    ...   | failure a = failure a
+    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s (sig ∷ sigs) | failure a = failure (inj₂ a)
     Computational-ReflexiveTransitiveClosureᵇ .completeness c s [] s' (BS-base p)
       with computeProof {STS = BSTS} c s tt | completeness _ _ _ _ p
-    ... | just x | p' = p'
+    ... | success x | refl = refl
     Computational-ReflexiveTransitiveClosureᵇ .completeness c s (sig ∷ sigs) s' (BS-ind h hs)
       with computeProof c s sig | completeness _ _ _ _ h
-    ... | just (s₁ , _) | refl
+    ... | success (s₁ , _) | refl
       with computeProof ⦃ Computational-ReflexiveTransitiveClosureᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
-    ... | just (s₂ , _) | p = p
+    ... | success (s₂ , _) | p = p
 
-  module _ {STS : C × ℕ → S → Sig → S → Set} ⦃ _ : Computational STS ⦄ where instance
-    Computational-ReflexiveTransitiveClosureᵢᵇ : Computational (ReflexiveTransitiveClosureᵢᵇ BSTS STS)
-    Computational-ReflexiveTransitiveClosureᵢᵇ .computeProof c s [] =
-      map (map₂′ BS-base) (computeProof c s tt)
-    Computational-ReflexiveTransitiveClosureᵢᵇ .computeProof c s (sig ∷ sigs) = do
-      s₁ , h  ← computeProof (c , length sigs) s sig
-      s₂ , hs ← computeProof c s₁ sigs
-      just (s₂ , BS-ind h hs)
+  module _ {STS : C × ℕ → S → Sig → S → Set} ⦃ Computational-STS : Computational STS Err₂ ⦄ where instance
+    Computational-ReflexiveTransitiveClosureᵢᵇ : Computational (ReflexiveTransitiveClosureᵢᵇ BSTS STS) (Err₁ ⊎ Err₂)
+    Computational-ReflexiveTransitiveClosureᵢᵇ .computeProof c s [] = bimap inj₁ (map₂′ BS-base) (computeProof c s tt)
+    Computational-ReflexiveTransitiveClosureᵢᵇ .computeProof c s (sig ∷ sigs) with computeProof (c , length sigs) s sig
+    ... | success (s₁ , h) with computeProof c s₁ sigs
+    ...   | success (s₂ , hs) = success (s₂ , BS-ind h hs)
+    ...   | failure a = failure a
+    Computational-ReflexiveTransitiveClosureᵢᵇ .computeProof c s (sig ∷ sigs) | failure a = failure (inj₂ a)
     Computational-ReflexiveTransitiveClosureᵢᵇ .completeness c s [] s' (BS-base p)
       with computeProof {STS = BSTS} c s tt | completeness _ _ _ _ p
-    ... | just x | p' = p'
+    ... | success x | refl = refl
     Computational-ReflexiveTransitiveClosureᵢᵇ .completeness c s (sig ∷ sigs) s' (BS-ind h hs)
       with computeProof {STS = STS} (c , length sigs) s sig | completeness _ _ _ _ h
-    ... | just (s₁ , _) | refl
+    ... | success (s₁ , _) | refl
       with computeProof ⦃ Computational-ReflexiveTransitiveClosureᵢᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
-    ...   | just (s₂ , _) | p = p
+    ...   | success (s₂ , _) | p = p
 
-Computational-ReflexiveTransitiveClosure : {STS : C → S → Sig → S → Set} → ⦃ Computational STS ⦄
-  → Computational (ReflexiveTransitiveClosure STS)
+Computational-ReflexiveTransitiveClosure : {STS : C → S → Sig → S → Set} → ⦃ Computational STS Err ⦄
+  → Computational (ReflexiveTransitiveClosure STS) (⊥ ⊎ Err)
 Computational-ReflexiveTransitiveClosure = it
 
-Computational-ReflexiveTransitiveClosureᵢ : {STS : C × ℕ → S → Sig → S → Set} → ⦃ Computational STS ⦄
-  → Computational (ReflexiveTransitiveClosureᵢ STS)
+Computational-ReflexiveTransitiveClosureᵢ : {STS : C × ℕ → S → Sig → S → Set} → ⦃ Computational STS Err ⦄
+  → Computational (ReflexiveTransitiveClosureᵢ STS) (⊥ ⊎ Err)
 Computational-ReflexiveTransitiveClosureᵢ = it

--- a/src/Ledger/Chain/Properties.agda
+++ b/src/Ledger/Chain/Properties.agda
@@ -19,13 +19,13 @@ open Computational ⦃...⦄
 module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
 
 instance
-  Computational-CHAIN : Computational _⊢_⇀⦇_,CHAIN⦈_
+  Computational-CHAIN : Computational _⊢_⇀⦇_,CHAIN⦈_ String
   Computational-CHAIN .computeProof Γ s b = do
-    _ , neStep ← computeProof {STS = _⊢_⇀⦇_,NEWEPOCH⦈_} _ _ _
-    _ , lsStep ← computeProof _ _ _
-    just (_ , CHAIN neStep lsStep)
+    _ , neStep ← map₁ ⊥-elim $ computeProof {STS = _⊢_⇀⦇_,NEWEPOCH⦈_} _ _ _
+    _ , lsStep ← map₁ (λ where (inj₁ ()); (inj₂ x) → x) $ computeProof _ _ _
+    success (_ , CHAIN neStep lsStep)
   Computational-CHAIN .completeness Γ s b s' (CHAIN neStep lsStep)
     with recomputeProof neStep | completeness _ _ _ _ neStep
-  ... | _      | refl
+  ... | _         | refl
     with recomputeProof lsStep | completeness _ _ _ _ lsStep
-  ... | just _ | refl = refl
+  ... | success _ | refl = refl

--- a/src/Ledger/Deleg/Properties.agda
+++ b/src/Ledger/Deleg/Properties.agda
@@ -16,17 +16,17 @@ open import Ledger.Deleg gs
 open Computational ⦃...⦄
 
 instance
-  Computational-DELEG : Computational _⊢_⇀⦇_,DELEG⦈_
+  Computational-DELEG : Computational _⊢_⇀⦇_,DELEG⦈_ String
   Computational-DELEG .computeProof ⟦ pp , pools ⟧ᵈᵉ ⟦ _ , _ , rwds ⟧ᵈ = λ where
     (delegate c mv mc d) → case ¿ (c ∉ dom rwds → d ≡ pp .PParams.poolDeposit)
                                 × (c ∈ dom rwds → d ≡ 0)
                                 × mc ∈ mapˢ just (dom pools) ¿ of λ where
-      (yes (p₁ , p₂ , p₃)) → just (-, DELEG-delegate p₁ p₂ p₃)
-      _ → nothing
+      (yes (p₁ , p₂ , p₃)) → success (-, DELEG-delegate p₁ p₂ p₃)
+      _ → failure "Failed in DELEG at delegate"
     (dereg c) → case ¿ (c , 0) ∈ rwds ¿ of λ where
-      (yes p) → just (-, DELEG-dereg p)
-      _       → nothing
-    _ → nothing
+      (yes p) → success (-, DELEG-dereg p)
+      _       → failure "Failed in DELEG at (c , 0) ∈ rwds"
+    _ → failure "Unexpected certificate in DELEG"
   Computational-DELEG .completeness ⟦ pp , pools ⟧ᵈᵉ ⟦ _ , _ , rwds ⟧ᵈ (delegate c mv mc d)
     s' (DELEG-delegate p₁ p₂ p₃) rewrite dec-yes (¿ (c ∉ dom rwds → d ≡ pp .PParams.poolDeposit)
                                 × (c ∈ dom rwds → d ≡ 0)
@@ -34,33 +34,33 @@ instance
   Computational-DELEG .completeness ⟦ _ , _ ⟧ᵈᵉ ⟦ _ , _ , rwds ⟧ᵈ (dereg c) _ (DELEG-dereg p)
     rewrite dec-yes (¿ (c , 0) ∈ rwds ¿) p .proj₂ = refl
 
-  Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_
+  Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
   Computational-POOL .computeProof _ ⟦ pools , _ ⟧ᵖ (regpool c _) =
     case c ∈? dom pools of λ where
-      (yes _) → nothing
-      (no p)  →  just (-, POOL-regpool p)
-  Computational-POOL .computeProof _ _ (retirepool c e) = just (-, POOL-retirepool)
-  Computational-POOL .computeProof _ _ _ = nothing
+      (yes _) → failure "Pool already registered"
+      (no p)  → success (-, POOL-regpool p)
+  Computational-POOL .computeProof _ _ (retirepool c e) = success (-, POOL-retirepool)
+  Computational-POOL .computeProof _ _ _ = failure "Failed in POOL"
   Computational-POOL .completeness _ ⟦ pools , _ ⟧ᵖ (regpool c _) _ (POOL-regpool ¬p)
     rewrite dec-no (c ∈? dom pools) ¬p = refl
   Computational-POOL .completeness _ _ (retirepool _ _) _ POOL-retirepool = refl
 
-  Computational-GOVCERT : Computational _⊢_⇀⦇_,GOVCERT⦈_
+  Computational-GOVCERT : Computational _⊢_⇀⦇_,GOVCERT⦈_ String
   Computational-GOVCERT .computeProof ⟦ _ , pp , _ , _ ⟧ᶜ ⟦ dReps , _ ⟧ᵛ (regdrep c d _) =
     let open PParams pp in
     case ¿ (d ≡ drepDeposit × c ∉ dom dReps)
          ⊎ (d ≡ 0 × c ∈ dom dReps) ¿ of λ where
-      (yes p) → just (-, GOVCERT-regdrep p)
-      (no _)  → nothing
+      (yes p) → success (-, GOVCERT-regdrep p)
+      (no _)  → failure "GOVCERT failed at (d ≡ drepDeposit × c ∉ dom dReps) ⊎ (d ≡ 0 × c ∈ dom dReps)"
   Computational-GOVCERT .computeProof _ ⟦ dReps , _ ⟧ᵛ (deregdrep c) =
     case c ∈? dom dReps of λ where
-      (yes p) → just (-, GOVCERT-deregdrep p)
-      (no _)  → nothing
+      (yes p) → success (-, GOVCERT-deregdrep p)
+      (no _)  → failure "GOVCERT failed at (c ∈? dom dReps)"
   Computational-GOVCERT .computeProof _ ⟦ _ , ccKeys ⟧ᵛ (ccreghot c _) =
     case (c , nothing) ∈? (ccKeys ˢ) of λ where
-      (yes _) → nothing
-      (no p)  → just (-, GOVCERT-ccreghot p)
-  Computational-GOVCERT .computeProof _ _ _ = nothing
+      (yes _) → failure "GOVCERT failed at (c , nothing) ∈? (ccKeys ˢ)"
+      (no p)  → success (-, GOVCERT-ccreghot p)
+  Computational-GOVCERT .computeProof _ _ _ = failure "Unexpected certificate in GOVCERT"
   Computational-GOVCERT .completeness ⟦ _ , pp , _ , _ ⟧ᶜ ⟦ dReps , _ ⟧ᵛ
     (regdrep c d _) _ (GOVCERT-regdrep p)
     rewrite dec-yes
@@ -74,26 +74,26 @@ instance
     (ccreghot c _) _ (GOVCERT-ccreghot ¬p)
     rewrite dec-no ((c , nothing) ∈? (ccKeys ˢ)) ¬p = refl
 
-  Computational-CERT : Computational _⊢_⇀⦇_,CERT⦈_
+  Computational-CERT : Computational _⊢_⇀⦇_,CERT⦈_ String
   Computational-CERT .computeProof Γ@(⟦ e , pp , vs , _ ⟧ᶜ) ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ dCert
     with computeProof ⟦ pp , PState.pools stᵖ ⟧ᵈᵉ stᵈ dCert
        | computeProof pp stᵖ dCert | computeProof Γ stᵍ dCert
-  ... | just (_ , h) | _            | _            = just (-, CERT-deleg h)
-  ... | nothing      | just (_ , h) | _            = just (-, CERT-pool h)
-  ... | nothing      | nothing      | just (_ , h) = just (-, CERT-vdel h)
-  ... | nothing      | nothing      | nothing      = nothing
+  ... | success (_ , h) | _               | _               = success (-, CERT-deleg h)
+  ... | failure _       | success (_ , h) | _               = success (-, CERT-pool h)
+  ... | failure _       | failure _       | success (_ , h) = success (-, CERT-vdel h)
+  ... | failure _       | failure _       | failure _       = failure "Failed at CERT"
   Computational-CERT .completeness ⟦ _ , pp , _ , wdrls ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
     dCert@(delegate c mv mc d) ⟦ stᵈ' , stᵖ , stᵍ ⟧ᶜˢ (CERT-deleg h)
     with computeProof ⟦ pp , PState.pools stᵖ ⟧ᵈᵉ stᵈ dCert | completeness _ _ _ _ h
-  ... | just _ | refl = refl
+  ... | success _ | refl = refl
   Computational-CERT .completeness ⟦ _ , pp , _ , wdrls ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
     dCert@(dereg c) ⟦ stᵈ' , stᵖ , stᵍ ⟧ᶜˢ (CERT-deleg h)
     with computeProof ⟦ pp , PState.pools stᵖ ⟧ᵈᵉ stᵈ dCert | completeness _ _ _ _ h
-  ... | just _ | refl = refl
+  ... | success _ | refl = refl
   Computational-CERT .completeness ⟦ _ , pp , _ , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
     dCert@(regpool c poolParams) ⟦ stᵈ , stᵖ' , stᵍ ⟧ᶜˢ (CERT-pool h)
     with computeProof pp stᵖ dCert | completeness _ _ _ _ h
-  ... | just _ | refl = refl
+  ... | success _ | refl = refl
   Computational-CERT .completeness ⟦ _ , pp , _ , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
     dCert@(retirepool c e) ⟦ stᵈ , stᵖ' , stᵍ ⟧ᶜˢ (CERT-pool h)
     with completeness _ _ _ _ h
@@ -102,28 +102,28 @@ instance
     dCert@(regdrep c d an)
     ⟦ stᵈ , stᵖ , stᵍ' ⟧ᶜˢ (CERT-vdel h)
     with computeProof Γ stᵍ dCert | completeness _ _ _ _ h
-  ... | just _ | refl = refl
+  ... | success _ | refl = refl
   Computational-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
     dCert@(deregdrep c) ⟦ stᵈ , stᵖ , stᵍ' ⟧ᶜˢ (CERT-vdel h)
     with computeProof Γ stᵍ dCert | completeness _ _ _ _ h
-  ... | just _ | refl = refl
+  ... | success _ | refl = refl
   Computational-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
     dCert@(ccreghot c mkh) ⟦ stᵈ , stᵖ , stᵍ' ⟧ᶜˢ (CERT-vdel h)
     with computeProof Γ stᵍ dCert | completeness _ _ _ _ h
-  ... | just _ | refl = refl
+  ... | success _ | refl = refl
 
-  Computational-CERTBASE : Computational _⊢_⇀⦇_,CERTBASE⦈_
+  Computational-CERTBASE : Computational _⊢_⇀⦇_,CERTBASE⦈_ String
   Computational-CERTBASE .computeProof ⟦ e , pp , vs , wdrls ⟧ᶜ st _ =
     let open PParams pp; open CertState st; open GState gState; open DState dState
         refresh = mapPartial getDRepVote (fromList vs)
         wdrlCreds = mapˢ RwdAddr.stake (dom wdrls)
     in case ¿ wdrlCreds ⊆ dom voteDelegs × mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿ of λ where
-      (yes (p₁ , p₂)) → just (-, CERT-base p₁ p₂)
-      (no ¬p)         → nothing
+      (yes (p₁ , p₂)) → success (-, CERT-base p₁ p₂)
+      (no ¬p)         → failure "CERTBASE Failed at (mapˢ RwdAddr.stake (dom wdrls) ⊆ dom voteDelegs × wdrls ˢ ⊆ rewards ˢ)"
   Computational-CERTBASE .completeness ⟦ e , pp , vs , wdrls ⟧ᶜ st _ st' (CERT-base p₁ p₂)
     rewrite let dState = CertState.dState st; open DState dState in
       dec-yes ¿ mapˢ RwdAddr.stake (dom wdrls) ⊆ dom voteDelegs × mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿
         (p₁ , p₂) .proj₂ = refl
 
-Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_
+Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_ (String ⊎ String)
 Computational-CERTS = it

--- a/src/Ledger/Epoch/Properties.agda
+++ b/src/Ledger/Epoch/Properties.agda
@@ -41,9 +41,9 @@ module _ {Γ : NewEpochEnv} {eps : EpochState} {e : Epoch} where
     EPOCH-complete' = EPOCH-complete
 
 instance
-  Computational-EPOCH : Computational _⊢_⇀⦇_,EPOCH⦈_
-  Computational-EPOCH .computeProof Γ s sig = just EPOCH-total'
-  Computational-EPOCH .completeness Γ s sig s' h = cong just (EPOCH-complete' s' h)
+  Computational-EPOCH : Computational _⊢_⇀⦇_,EPOCH⦈_ ⊥
+  Computational-EPOCH .computeProof Γ s sig = success EPOCH-total'
+  Computational-EPOCH .completeness Γ s sig s' h = cong success (EPOCH-complete' s' h)
 
 module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
 
@@ -62,6 +62,6 @@ module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
   ... | no ¬p | NEWEPOCH-Not-New x = refl
 
 instance
-  Computational-NEWEPOCH : Computational _⊢_⇀⦇_,NEWEPOCH⦈_
-  Computational-NEWEPOCH .computeProof Γ s sig = just NEWEPOCH-total
-  Computational-NEWEPOCH .completeness Γ s sig s' h = cong just (NEWEPOCH-complete s' h)
+  Computational-NEWEPOCH : Computational _⊢_⇀⦇_,NEWEPOCH⦈_ ⊥
+  Computational-NEWEPOCH .computeProof Γ s sig = success NEWEPOCH-total
+  Computational-NEWEPOCH .completeness Γ s sig s' h = cong success (NEWEPOCH-complete s' h)

--- a/src/Ledger/Foreign/LedgerTypes.agda
+++ b/src/Ledger/Foreign/LedgerTypes.agda
@@ -1,6 +1,7 @@
 module Ledger.Foreign.LedgerTypes where
 {-# FOREIGN GHC
   {-# LANGUAGE DeriveGeneric #-}
+  {-# LANGUAGE DeriveFunctor #-}
   {-# LANGUAGE EmptyDataDeriving #-}
 #-}
 
@@ -20,6 +21,28 @@ data Empty : Set where
   data AgdaEmpty deriving (Show, Generic)
   instance ToExpr AgdaEmpty
 #-}
+
+data ComputationResult E A : Set where
+  Success : A → ComputationResult E A
+  Failure : E → ComputationResult E A
+{-# FOREIGN GHC
+  data ComputationResult e a = Success a | Failure e
+    deriving (Functor, Eq, Show, Generic)
+
+  instance Applicative (ComputationResult e) where
+    pure = Success
+    (Success f) <*> x = f <$> x
+    (Failure e) <*> _ = Failure e
+
+  instance Monad (ComputationResult e) where
+    return = pure
+    (Success a) >>= m = m a
+    (Failure e) >>= _ = Failure e
+
+  instance (ToExpr e, ToExpr a) => ToExpr (ComputationResult e a)
+#-}
+{-# COMPILE GHC ComputationResult = data ComputationResult (Success | Failure) #-}
+
 {-# COMPILE GHC Empty = data AgdaEmpty () #-}
 
 HSMap : Set → Set → Set

--- a/src/Ledger/Gov/Properties.agda
+++ b/src/Ledger/Gov/Properties.agda
@@ -61,22 +61,22 @@ private
     validHFAction? {record { action = Info }} = Dec-⊤
 
 instance
-  Computational-GOV' : Computational _⊢_⇀⦇_,GOV'⦈_
+  Computational-GOV' : Computational _⊢_⇀⦇_,GOV'⦈_ String
   Computational-GOV' .computeProof (⟦ _ , _ , pparams , _ ⟧ᵍ , k) s (inj₁ record { gid = aid ; role = role }) =
     case lookupActionId pparams role aid s of λ where
       (yes p) →
         case Any↔ .from p of λ where
-          (_ , mem , refl , cV) → just (_ , GOV-Vote (∈-fromList .to mem) cV)
-      (no _)  → nothing
+          (_ , mem , refl , cV) → success (_ , GOV-Vote (∈-fromList .to mem) cV)
+      (no _)  → failure "Failed at GOV'"
   Computational-GOV' .computeProof (⟦ _ , epoch , pparams , e ⟧ᵍ , k) s (inj₂ prop@(record { action = a ; deposit = d })) =
     case ¿ actionWellFormed a ≡ true × d ≡ pparams .PParams.govActionDeposit × validHFAction prop s e ¿
          ,′ isNewCommittee a of λ where
       (yes (wf , dep , vHFA) , yes (new , rem , q , refl)) →
         case ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ of λ where
-          (yes newOk) → just (_ , GOV-Propose wf dep (λ where refl → newOk) vHFA)
-          (no _)      → nothing
-      (yes (wf , dep , vHFA) , no notNewComm) → just (_ , GOV-Propose wf dep (λ isNewComm → ⊥-elim (notNewComm (_ , _ , _ , isNewComm))) vHFA)
-      _ → nothing
+          (yes newOk) → success (_ , GOV-Propose wf dep (λ where refl → newOk) vHFA)
+          (no _)      → failure "GOV' failed at ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅"
+      (yes (wf , dep , vHFA) , no notNewComm) → success (_ , GOV-Propose wf dep (λ isNewComm → ⊥-elim (notNewComm (_ , _ , _ , isNewComm))) vHFA)
+      _ → failure "GOV' failed at actionWellFormed a ≡ true × d ≡ pparams .PParams.govActionDeposit × validHFAction prop s e"
   Computational-GOV' .completeness (⟦ _ , _ , pparams , _ ⟧ᵍ , k) s (inj₁ record { gid = aid ; role = role }) s' (GOV-Vote mem cV)
     with lookupActionId pparams role aid s
   ... | no ¬p = ⊥-elim (¬p (Any↔ .to (_ , ∈-fromList .from mem , refl , cV)))
@@ -89,5 +89,5 @@ instance
   ... | yes _ | yes (new , rem , q , refl)
    rewrite dec-yes ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ (newOk refl) .proj₂ = refl
 
-Computational-GOV : Computational _⊢_⇀⦇_,GOV⦈_
+Computational-GOV : Computational _⊢_⇀⦇_,GOV⦈_ (⊥ ⊎ String)
 Computational-GOV = it

--- a/src/Ledger/GovernanceActions/Properties.agda
+++ b/src/Ledger/GovernanceActions/Properties.agda
@@ -16,22 +16,22 @@ instance
 
 open Computational ⦃...⦄
 instance
-  Computational-ENACT : Computational _⊢_⇀⦇_,ENACT⦈_
+  Computational-ENACT : Computational _⊢_⇀⦇_,ENACT⦈_ String
   Computational-ENACT .computeProof ⟦ _ , t , e ⟧ᵉ s = λ where
-    NoConfidence             → just (_ , Enact-NoConf)
+    NoConfidence             → success (_ , Enact-NoConf)
     (NewCommittee new rem q) →
       case ¿ ∀[ term ∈ range new ]
                term ≤ s .pparams .proj₁ .PParams.ccMaxTermLength +ᵉ e ¿ of λ where
-      (yes p) → just (-, Enact-NewComm p)
-      (no ¬p) → nothing
-    (NewConstitution dh sh)  → just (-, Enact-NewConst)
-    (TriggerHF v)            → just (-, Enact-HF)
-    (ChangePParams up)       → just (-, Enact-PParams)
-    Info                     → just (-, Enact-Info)
+      (yes p) → success (-, Enact-NewComm p)
+      (no ¬p) → failure "ENACT failed at ∀[ term ∈ range new ] term ≤ (s .pparams .proj₁ .PParams.ccMaxTermLength +ᵉ e)"
+    (NewConstitution dh sh)  → success (-, Enact-NewConst)
+    (TriggerHF v)            → success (-, Enact-HF)
+    (ChangePParams up)       → success (-, Enact-PParams)
+    Info                     → success (-, Enact-Info)
     (TreasuryWdrl wdrl) →
       case ¿ ∑[ x ← s .withdrawals ∪⁺ wdrl ] x ≤ t ¿ of λ where
-        (yes p)             → just (-, Enact-Wdrl p)
-        (no _)              → nothing
+        (yes p)             → success (-, Enact-Wdrl p)
+        (no _)              → failure "ENACT failed at ∑[ x ← (s .withdrawals ∪⁺ wdrl) ᶠᵐ ] x ≤ t"
   Computational-ENACT .completeness ⟦ _ , t , e ⟧ᵉ s action _ p
     with action | p
   ... | .NoConfidence           | Enact-NoConf   = refl

--- a/src/Ledger/NewPP/Properties.agda
+++ b/src/Ledger/NewPP/Properties.agda
@@ -11,14 +11,14 @@ open import Ledger.PPUp txs
 open import Ledger.NewPP txs
 
 instance
-  Computational-NEWPP : Computational _⊢_⇀⦇_,NEWPP⦈_
+  Computational-NEWPP : Computational _⊢_⇀⦇_,NEWPP⦈_ String
   Computational-NEWPP = record {M} where module M Γ s (open NewPParamState s) where
     computeProof = λ where
-      nothing → just (_ , NEWPP-Reject)
+      nothing → success (_ , NEWPP-Reject)
       (just upd) → let newpp = applyUpdate pparams upd in
         case ¿ viablePParams newpp ¿ of λ where
-          (yes p) → just (_ , NEWPP-Accept p)
-          (no _)  → nothing
+          (yes p) → success (_ , NEWPP-Accept p)
+          (no _)  → failure "Failed in NEWPP"
 
     completeness : _
     completeness sig s' h with sig | h

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -29,15 +29,15 @@ private
       × sucᵉ (epoch slot) ≡ e
 
 instance
-  Computational-PPUP : Computational _⊢_⇀⦇_,PPUP⦈_
+  Computational-PPUP : Computational _⊢_⇀⦇_,PPUP⦈_ String
   Computational-PPUP .computeProof Γ s = λ where
     (just (pup , e)) →
       case ¿ Current-Property Γ (pup , e) ¿
         ,′ ¿ Future-Property Γ (pup , e) ¿ of λ where
-        (yes (p₁ , p₂ , p₃ , p₄) , _) → just (-, PPUpdateCurrent p₁ p₂ p₃ p₄)
-        (_ , yes (p₁ , p₂ , p₃ , p₄)) → just (-, PPUpdateFuture p₁ p₂ p₃ p₄)
-        (no _ , no _)                 → nothing
-    nothing → just (-, PPUpdateEmpty)
+        (yes (p₁ , p₂ , p₃ , p₄) , _) → success (-, PPUpdateCurrent p₁ p₂ p₃ p₄)
+        (_ , yes (p₁ , p₂ , p₃ , p₄)) → success (-, PPUpdateFuture p₁ p₂ p₃ p₄)
+        (no _ , no _)                 → failure "Failed in PPUP"
+    nothing → success (-, PPUpdateEmpty)
 
   Computational-PPUP .completeness Γ _ .nothing  _     PPUpdateEmpty = refl
   Computational-PPUP .completeness Γ _ (just up) _ p   with p

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -34,3 +34,8 @@ open import Tactic.Premises public
 open import Ledger.Set renaming (∅ to ∅ˢ; ❴_❵ to ❴_❵ˢ) public
 open import Interface.HasSingleton th public
 open import Interface.HasEmptySet th public
+
+dec-de-morgan : ∀{P Q : Set} → ⦃ P ⁇ ⦄ → ⦃ Q ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
+dec-de-morgan ⦃ ⁇ no ¬p ⦄ ⦃ _ ⦄ ¬pq = inj₁ ¬p
+dec-de-morgan ⦃ _ ⦄ ⦃ ⁇ no ¬q ⦄ ¬pq = inj₂ ¬q
+dec-de-morgan ⦃ ⁇ yes p ⦄ ⦃ ⁇ yes q ⦄ ¬pq = contradiction (p , q) ¬pq

--- a/src/Ledger/Ratify/Properties.agda
+++ b/src/Ledger/Ratify/Properties.agda
@@ -11,22 +11,6 @@ open import Ledger.Ratify txs
 
 open Computational ⦃...⦄ hiding (computeProof; completeness)
 
-module _ {a b} {A : Set a} {B : Set b} where
-  caseMaybe_∣_∣_ : (ma : Maybe A) → (∀ {a} → ma ≡ just a → B) → (ma ≡ nothing → B) → B
-  caseMaybe ma ∣ f ∣ g with ma
-  ... | just _  = f refl
-  ... | nothing = g refl
-
-  caseMaybe-just : ∀ {a} {ma : Maybe A} {f : ∀ {a} → ma ≡ just a → B} {g : ma ≡ nothing → B}
-    → (eq : ma ≡ just a)
-    → caseMaybe ma ∣ f ∣ g ≡ f eq
-  caseMaybe-just refl = refl
-
-  caseMaybe-nothing : ∀ {ma : Maybe A} {f : ∀ {a} → ma ≡ just a → B} {g : ma ≡ nothing → B}
-    → (eq : ma ≡ nothing)
-    → caseMaybe ma ∣ f ∣ g ≡ g eq
-  caseMaybe-nothing refl = refl
-
 pattern RATIFY-Continue₁  x y = RATIFY-Continue (inj₁ (x , y))
 pattern RATIFY-Continue₂  x y = RATIFY-Continue (inj₂ (x , y))
 pattern RATIFY-Continue₂₁ x y = RATIFY-Continue₂ x (inj₁ y)
@@ -51,11 +35,11 @@ private
     ... | no ¬acc | yes exp | _ = -, RATIFY-Reject ¬acc exp
     ... | yes acc | _ | yes del = -, RATIFY-Continue₂₁ acc del
     ... | yes acc | _ | no ¬del
-      = caseMaybe es'
-        ∣ (λ eq → -, RATIFY-Accept acc ¬del (≡-just⇔STS .Equivalence.to eq))
-        ∣ (λ eq → -, RATIFY-Continue₂₂ acc (nothing⇒∀¬STS eq))
+      = caseCR es'
+        ∣ (λ eq → -, RATIFY-Accept acc ¬del (≡-success⇔STS .Equivalence.to eq))
+        ∣ (λ eq → -, RATIFY-Continue₂₂ acc (failure⇒∀¬STS eq))
 
-    computeProof = just RATIFY'-total
+    computeProof = success {Err = ⊥} RATIFY'-total
 
     RATIFY'-completeness : ∀ s' → Γ ⊢ s ⇀⦇ sig ,RATIFY'⦈ s' → RATIFY'-total .proj₁ ≡ s'
     RATIFY'-completeness s' (RATIFY-Continue₁ ¬acc ¬exp)
@@ -67,7 +51,7 @@ private
     RATIFY'-completeness s' (RATIFY-Accept acc ¬del eq)
       rewrite dec-yes acc? acc .proj₂ | dec-no del? ¬del
       = cong proj₁
-      $ caseMaybe-just
+      $ caseCR-success
       $ Computational-ENACT .Computational.completeness _ _ _ _ eq
     RATIFY'-completeness s' (RATIFY-Continue₂₂ acc h)
       with del?
@@ -76,18 +60,18 @@ private
     ... | no ¬del
       rewrite dec-yes acc? acc .proj₂ | dec-no del? ¬del
       = cong proj₁
-      $ caseMaybe-nothing
-      $ caseMaybe es'
-        ∣ ⊥-elim ∘ h _ ∘ ≡-just⇔STS .Equivalence.to
+      $ caseCR-failure
+      $ caseCR es'
+        ∣ ⊥-elim ∘ h _ ∘ ≡-success⇔STS .Equivalence.to
         ∣ id
 
-    completeness = cong just ∘₂ RATIFY'-completeness
+    completeness = cong (success {Err = ⊥}) ∘₂ RATIFY'-completeness
 
 instance
-  Computational-RATIFY' : Computational _⊢_⇀⦇_,RATIFY'⦈_
+  Computational-RATIFY' : Computational _⊢_⇀⦇_,RATIFY'⦈_ ⊥
   Computational-RATIFY' = record {Implementation}
 
-Computational-RATIFY : Computational _⊢_⇀⦇_,RATIFY⦈_
+Computational-RATIFY : Computational _⊢_⇀⦇_,RATIFY⦈_ (⊥ ⊎ ⊥)
 Computational-RATIFY = it
 
 RATIFY-total : ∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,RATIFY⦈ s'

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -331,23 +331,6 @@ data _⊢_⇀⦇_,UTXO⦈_ where
 pattern UTXO-inductive⋯ tx Γ s x y z w k l m n o p q r
       = UTXO-inductive {tx}{Γ}{s} (x , y , z , w , k , l , m , n , o , p , q , r)
 unquoteDecl UTXO-premises = genPremises UTXO-premises (quote UTXO-inductive)
-
-instance
-  Computational-UTXO : Computational _⊢_⇀⦇_,UTXO⦈_
-  Computational-UTXO = record {Go}
-    where module Go Γ s tx (let H , ⁇ H? = UTXO-premises {tx}{Γ}{s}) where
-
-    computeProof = case H? of λ where
-      (yes p) → just (-, UTXO-inductive p)
-      (no _)  → nothing
-
-    completeness : ∀ s' → Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s' → _
-    completeness s' (UTXO-inductive p) = QED
-      where
-      QED : map proj₁ computeProof ≡ just s'
-      QED with H?
-      ... | yes _ = refl
-      ... | no ¬p = ⊥-elim $ ¬p p
 \end{code}
 \caption{UTXO inference rules}
 \label{fig:rules:utxo-shelley}

--- a/src/Ledger/hs-src/cardano-ledger-executable-spec.cabal
+++ b/src/Ledger/hs-src/cardano-ledger-executable-spec.cabal
@@ -37,7 +37,8 @@ test-suite test
     build-depends:
         cardano-ledger-executable-spec,
         hspec,
-        HUnit
+        HUnit,
+        text
     build-tool-depends: hspec-discover:hspec-discover
     type: exitcode-stdio-1.0
     ghc-options:

--- a/src/Ledger/hs-src/test/UtxowSpec.hs
+++ b/src/Ledger/hs-src/test/UtxowSpec.hs
@@ -4,6 +4,8 @@ module UtxowSpec (spec) where
 
 import Control.Monad ( foldM )
 
+import Data.Text
+
 import Test.Hspec ( Spec, describe, it )
 import Test.HUnit ( (@?=) )
 
@@ -92,7 +94,7 @@ testTx2 = MkTx
   , wits = MkTxWitnesses { vkSigs = [(1, 3)], scripts = [] }
   , txAD = Nothing }
 
-utxowSteps :: UTxOEnv -> UTxOState -> [Tx] -> Maybe UTxOState
+utxowSteps :: UTxOEnv -> UTxOState -> [Tx] -> ComputationResult Text UTxOState
 utxowSteps = foldM . utxowStep
 
 deriving instance Eq UTxOState
@@ -101,7 +103,7 @@ spec :: Spec
 spec = do
   describe "utxowSteps" $
     it "results in the expected state" $
-      utxowSteps initEnv initState [testTx1, testTx2] @?= Just (MkUTxOState
+      utxowSteps initEnv initState [testTx1, testTx2] @?= Success (MkUTxOState
         { utxo = [ (1,0) .-> (a0, (890, Nothing))
                  , (2,0) .-> (a2, (10,  Nothing))
                  , (2,1) .-> (a1, (80,  Nothing)) ]

--- a/src/MidnightExample/HSLedger.agda
+++ b/src/MidnightExample/HSLedger.agda
@@ -3,6 +3,7 @@ module MidnightExample.HSLedger where
 open import Prelude hiding (_++_; dec; Show-List; Show-×)
 
 open import Interface.Hashable
+open import Interface.ComputationalRelation
 
 open import Data.Integer hiding (show)
 open import Data.String using (_++_)
@@ -90,7 +91,7 @@ instance
       ; snapshot2 = snapshot2 }
 
 ledgerStep : F.LedgerState → F.Block → Maybe F.LedgerState
-ledgerStep s b = to <$> LEDGER-step _ (from s) (from b)
+ledgerStep s b = to ∘ success-maybe $ LEDGER-step _ (from s) (from b)
 
 {-# COMPILE GHC ledgerStep as ledgerStep #-}
 

--- a/src/MidnightExample/Ledger.lagda
+++ b/src/MidnightExample/Ledger.lagda
@@ -185,12 +185,12 @@ unquoteDecl LEDGER-inductive-premises =
   genPremises LEDGER-inductive-premises (quote LEDGER-inductive)
 
 instance
-  Computational-LEDGER : Computational _⊢_⇀⦇_,LEDGER⦈_
+  Computational-LEDGER : Computational _⊢_⇀⦇_,LEDGER⦈_ ⊤
   Computational-LEDGER = record {Go}
     where module Go Γ s b (let H , ⁇ H? = LEDGER-inductive-premises {b}) where
       computeProof = case H? of λ where
-        (yes p) → just (-, LEDGER-inductive p)
-        (no _)  → nothing
+        (yes p) → success (-, LEDGER-inductive p)
+        (no _)  → failure tt
 
       completeness : _
       completeness s' (LEDGER-inductive p) rewrite dec-yes H? p .proj₂ = refl
@@ -199,7 +199,7 @@ open Computational ⦃...⦄
 \end{code}
 \begin{figure*}[h]
 \begin{code}
-LEDGER-step : ⊤ → LedgerState → Block → Maybe LedgerState
+LEDGER-step : ⊤ → LedgerState → Block → ComputationResult ⊤ LedgerState
 LEDGER-step = compute
 
 applyBlockTo : Block → LedgerState → Maybe LedgerState
@@ -242,10 +242,10 @@ lemma y≢0 eq = y≢0 (identityʳ-unique _ _ (sym eq))
 LEDGER-property₁ : _ ⊢ s ⇀⦇ b ,LEDGER⦈ s' → count s ≢ count s'
 LEDGER-property₁ (LEDGER-inductive⋯ acc≢0 _) = lemma acc≢0
 
-LEDGER-property₂ : LEDGER-step _ s b ≡ just s' → count s ≢ count s'
+LEDGER-property₂ : LEDGER-step _ s b ≡ success s' → count s ≢ count s'
 LEDGER-property₂ {s} {b} eq
   = LEDGER-property₁
-  $ Equivalence.to (≡-just⇔STS {s = s} {sig = b}) eq
+  $ Equivalence.to (≡-success⇔STS {s = s} {sig = b}) eq
 
 LEDGER-property₃ : applyBlockTo b s ≡ just s' → count s ≢ count s'
 LEDGER-property₃ {b = b} h with

--- a/src/MidnightExample/hs-src/midnight-example.cabal
+++ b/src/MidnightExample/hs-src/midnight-example.cabal
@@ -52,6 +52,7 @@ library
         Lib
     build-depends:
         text,
+        tree-diff,
         ieee
 -- This will be generated automatically when building with nix
     other-modules:


### PR DESCRIPTION
# Description

This PR changes the output type of `computeProof` to `ComputationResult` which can return an error value if the computation fails.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
