### PR TITLE
Add `minFeeRefScriptsCoinsPerByte`

### DIFF
--- a/src/Interface/HasAdd.agda
+++ b/src/Interface/HasAdd.agda
@@ -2,7 +2,7 @@
 module Interface.HasAdd where
 
 record HasAdd (A : Set) : Set where
-  infixl 7 _+_
+  infixl 6 _+_
   field _+_ : A → A → A
 
 open HasAdd ⦃ ... ⦄ public

--- a/src/Interface/HasSubtract.agda
+++ b/src/Interface/HasSubtract.agda
@@ -2,7 +2,7 @@
 module Interface.HasSubtract where
 
 record HasSubtract (A : Set) : Set where
-  infixl 7 _-_
+  infixl 6 _-_
   field _-_ : A → A → A
 
 open HasSubtract ⦃ ... ⦄ public

--- a/src/Ledger/Abstract.agda
+++ b/src/Ledger/Abstract.agda
@@ -17,7 +17,8 @@ record indexOf : Set where
     indexOfProposal : GovProposal → List GovProposal → Maybe Ix
 
 record AbstractFunctions : Set where
-  field txscriptfee : Prices → ExUnits → Coin
-        serSize     : Value → MemoryEstimate
-        indexOfImp  : indexOf
+  field txscriptfee  : Prices → ExUnits → Coin
+        serSize      : Value → MemoryEstimate
+        indexOfImp   : indexOf
         runPLCScript : CostModel → P2Script → ExUnits → List Data → Bool
+        scriptSize   : Script → ℕ

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -2,7 +2,7 @@ module Ledger.Foreign.HSLedger where
 
 open import Ledger.Prelude hiding (fromList; ε); open Computational
 
-open import Data.Rational using (½)
+open import Data.Rational using (0ℚ; ½)
 
 open import Algebra             using (CommutativeMonoid)
 open import Algebra.Morphism    using (module MonoidMorphisms)
@@ -197,6 +197,7 @@ HSAbstractFunctions = record
     ; indexOfProposal = λ _ _ → nothing
     }
   ; runPLCScript = λ _ _ _ _ → false
+  ; scriptSize = λ _ → 0
   }
 instance _ = HSAbstractFunctions
 
@@ -372,36 +373,37 @@ instance
       ; maxCollateralInputs = maxCollateralInputs
       }
     .from pp → let open F.PParams pp in record
-      { a                    = a
-      ; b                    = b
-      ; maxBlockSize         = maxBlockSize
-      ; maxTxSize            = maxTxSize
-      ; maxHeaderSize        = maxHeaderSize
-      ; maxValSize           = maxValSize
-      ; minUTxOValue         = minUTxOValue
-      ; poolDeposit          = poolDeposit
-      ; Emax                 = Emax
-      ; collateralPercentage = 0
-      ; pv                   = from pv
+      { a                           = a
+      ; b                           = b
+      ; maxBlockSize                = maxBlockSize
+      ; maxTxSize                   = maxTxSize
+      ; maxHeaderSize               = maxHeaderSize
+      ; maxValSize                  = maxValSize
+      ; minUTxOValue                = minUTxOValue
+      ; poolDeposit                 = poolDeposit
+      ; minFeeRefScriptCoinsPerByte = 0ℚ
+      ; Emax                        = Emax
+      ; collateralPercentage        = 0
+      ; pv                          = from pv
         -- TODO: translate these once they are implemented in F.PParams
       ; drepThresholds    = record
         { P1  = ½ ; P2a = ½ ; P2b = ½ ; P3  = ½ ; P4 = ½
         ; P5a = ½ ; P5b = ½ ; P5c = ½ ; P5d = ½ ; P6 = ½}
       ; poolThresholds    = record
         { Q1 = ½ ; Q2a = ½ ; Q2b = ½ ; Q4 = ½ }
-      ; govActionLifetime = govActionLifetime
-      ; govActionDeposit  = govActionDeposit
-      ; drepDeposit       = drepDeposit
-      ; drepActivity      = drepActivity
-      ; ccMinSize         = ccMinSize
-      ; ccMaxTermLength   = ccMaxTermLength
-      ; minimumAVS        = 0
-      ; costmdls            = from costmdls
-      ; prices              = prices
-      ; maxTxExUnits        = from maxTxExUnits
-      ; maxBlockExUnits     = from maxBlockExUnits
-      ; coinsPerUTxOWord    = coinsPerUTxOWord
-      ; maxCollateralInputs = maxCollateralInputs
+      ; govActionLifetime           = govActionLifetime
+      ; govActionDeposit            = govActionDeposit
+      ; drepDeposit                 = drepDeposit
+      ; drepActivity                = drepActivity
+      ; ccMinSize                   = ccMinSize
+      ; ccMaxTermLength             = ccMaxTermLength
+      ; minimumAVS                  = 0
+      ; costmdls                    = from costmdls
+      ; prices                      = prices
+      ; maxTxExUnits                = from maxTxExUnits
+      ; maxBlockExUnits             = from maxBlockExUnits
+      ; coinsPerUTxOWord            = coinsPerUTxOWord
+      ; maxCollateralInputs         = maxCollateralInputs
       }
 
   Convertible-UTxOEnv : Convertible UTxOEnv F.UTxOEnv

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -79,6 +79,7 @@ record PParams : Set where
         a b                           : ℕ
         minUTxOValue poolDeposit      : Coin
         coinsPerUTxOWord              : Coin
+        minFeeRefScriptCoinsPerByte   : ℚ
         prices                        : Prices
 \end{code}
 \emph{Technical group}\vskip-3mm

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -35,7 +35,6 @@ open import Ledger.Set renaming (∅ to ∅ˢ; ❴_❵ to ❴_❵ˢ) public
 open import Interface.HasSingleton th public
 open import Interface.HasEmptySet th public
 
-dec-de-morgan : ∀{P Q : Set} → ⦃ P ⁇ ⦄ → ⦃ Q ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
-dec-de-morgan ⦃ ⁇ no ¬p ⦄ ⦃ _ ⦄ ¬pq = inj₁ ¬p
-dec-de-morgan ⦃ _ ⦄ ⦃ ⁇ no ¬q ⦄ ¬pq = inj₂ ¬q
-dec-de-morgan ⦃ ⁇ yes p ⦄ ⦃ ⁇ yes q ⦄ ¬pq = contradiction (p , q) ¬pq
+dec-de-morgan : ∀{P Q : Set} → ⦃ P ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
+dec-de-morgan ⦃ ⁇ no ¬p ⦄ ¬pq = inj₁ ¬p
+dec-de-morgan ⦃ ⁇ yes p ⦄ ¬pq = inj₂ λ q → ¬pq (p , q)

--- a/src/Ledger/Set/Theory.agda
+++ b/src/Ledger/Set/Theory.agda
@@ -120,4 +120,8 @@ open import Interface.IsCommutativeMonoid
 indexedSumᵛ' : ⦃ DecEq A ⦄ → ⦃ DecEq B ⦄ → ⦃ IsCommutativeMonoid' 0ℓ 0ℓ C ⦄ → (B → C) → A ⇀ B → C
 indexedSumᵛ' f m = indexedSumᵛ ⦃ fromCommMonoid' it ⦄ f (m ᶠᵐ)
 
+indexedSum' : ⦃ DecEq A ⦄ → ⦃ IsCommutativeMonoid' 0ℓ 0ℓ B ⦄ → (A → B) → ℙ A → B
+indexedSum' f s = indexedSum ⦃ fromCommMonoid' it ⦄ f (s ᶠˢ)
+
 syntax indexedSumᵛ' (λ a → x) m = ∑[ a ← m ] x
+syntax indexedSum'  (λ a → x) m = ∑ˢ[ a ← m ] x

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -49,7 +49,7 @@ record TokenAlgebra : Set₁ where
          _≤ᵗ_                      : Value → Value → Set
          AssetName                 : Set
          specialAsset              : AssetName
-         property                  : coin ∘ inject ≗ id
+         property                  : coin ∘ inject ≗ id -- FIXME: rename!
          coinIsMonoidHomomorphism  : IsMonoidHomomorphism coin
 \end{code}
 \end{AgdaSuppressSpace}

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -60,14 +60,14 @@ instance
           (_     , _    ) → failure "isValid check failed"
 
       completeness : ∀ s' → Γ ⊢ s ⇀⦇ tx ,UTXOS⦈ s' → map proj₁ computeProof ≡ success s'
-      completeness _ (Scripts-Yes p) rewrite dec-yes H-Yes? p .proj₂ with H-No?
-      ... | no            _ = refl
-      ... | yes (p₁ , refl) with proj₂ p
-      ... | ()
-      completeness _ (Scripts-No p) rewrite dec-yes H-No? p .proj₂ with H-Yes?
-      ... | no            _ = refl
-      ... | yes (p₁ , refl) with proj₂ p
-      ... | ()
+      completeness _ (Scripts-Yes p) with H-No? | H-Yes?
+      ... | yes (_ , refl) | _     = case proj₂ p of λ ()
+      ... | no _           | yes _ = refl
+      ... | no _           | no ¬p = case ¬p p of λ ()
+      completeness _ (Scripts-No p) with H-Yes? | H-No?
+      ... | yes (_ , refl) | _     = case proj₂ p of λ ()
+      ... | no _           | yes _ = refl
+      ... | no _           | no ¬p = case ¬p p of λ ()
 
 instance
   Computational-UTXO' : Computational _⊢_⇀⦇_,UTXO⦈_ String

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -393,26 +393,33 @@ module DepositHelpers
       ∎ where open IsEquivalence ≡ᵉ-isEquivalence renaming (trans to infixl 4 _≡ᵉ-∘_)
 
   rearrange0 :
-      deposits' ≡ updateDeposits pp txb deposits
-    → txfee + txdonation + (tot + remDepTot) + fees
-    ≡ fees + txfee + getCoin deposits' + txdonation
-  rearrange0 h = begin
-    txfee + txdonation + (tot + remDepTot) + fees
-      ≡⟨ +-comm _ fees ⟩
-    fees ℕ.+ (txfee ℕ.+ txdonation ℕ.+ (tot ℕ.+ remDepTot))
+      (bal : ℕ)
+    → deposits' ≡ updateDeposits pp txb deposits
+    → bal + txfee + txdonation + tot + (remDepTot + fees)
+    ≡ bal + (fees + txfee + getCoin deposits' + txdonation)
+  rearrange0 bal h = begin
+    bal ℕ.+ txfee ℕ.+ txdonation ℕ.+ tot ℕ.+ (remDepTot ℕ.+ fees)
       ≡t⟨⟩
-    (fees ℕ.+ txfee) ℕ.+ (txdonation ℕ.+ (tot ℕ.+ remDepTot))
-      ≡⟨ cong ((fees + txfee) +_) $ +-comm txdonation (tot + remDepTot) ⟩
-    (fees + txfee) ℕ.+ ((tot + remDepTot) ℕ.+ txdonation)
-      ≡t⟨⟩
-    (fees + txfee) ℕ.+ (tot + remDepTot) ℕ.+ txdonation
-      ≡⟨ cong (λ x → (fees + txfee) + x + txdonation)
-       $ begin tot + (dep - ref) ≡˘⟨ +-∸-assoc tot ref≤dep ⟩
-               (tot + dep) - ref ≡⟨ cong (_- ref) $ +-comm tot dep ⟩
-               (dep + tot) - ref ≡˘⟨ deposits-change ⟩
-               uDep              ≡⟨ cong getCoin $ sym h ⟩
-               getCoin deposits' ∎ ⟩
-    (fees + txfee) + getCoin deposits' + txdonation
+    bal ℕ.+ (txfee ℕ.+ txdonation ℕ.+ (tot ℕ.+ remDepTot) ℕ.+ fees)
+      ≡⟨ cong (bal +_) $ begin
+        txfee + txdonation + (tot + remDepTot) + fees
+          ≡⟨ +-comm _ fees ⟩
+        fees ℕ.+ (txfee ℕ.+ txdonation ℕ.+ (tot ℕ.+ remDepTot))
+          ≡t⟨⟩
+        (fees ℕ.+ txfee) ℕ.+ (txdonation ℕ.+ (tot ℕ.+ remDepTot))
+          ≡⟨ cong ((fees + txfee) +_) $ +-comm txdonation (tot + remDepTot) ⟩
+        (fees + txfee) ℕ.+ ((tot + remDepTot) ℕ.+ txdonation)
+          ≡t⟨⟩
+        (fees + txfee) ℕ.+ (tot + remDepTot) ℕ.+ txdonation
+          ≡⟨ cong (λ x → (fees + txfee) + x + txdonation)
+          $ begin tot + (dep - ref) ≡˘⟨ +-∸-assoc tot ref≤dep ⟩
+                  (tot + dep) - ref ≡⟨ cong (_- ref) $ +-comm tot dep ⟩
+                  (dep + tot) - ref ≡˘⟨ deposits-change ⟩
+                  uDep              ≡⟨ cong getCoin $ sym h ⟩
+                  getCoin deposits' ∎ ⟩
+        (fees + txfee) + getCoin deposits' + txdonation
+          ∎ ⟩
+    bal + ((fees + txfee) + getCoin deposits' + txdonation)
       ∎
 
   utxo-ref-prop' :
@@ -496,7 +503,7 @@ pov {tx}{utxo}{_}{fees}{deposits}{donations}
        $ begin
           cbalance utxo ℕ.+ fees ℕ.+ dep
             ≡tˡ⟨ cong (cbalance utxo ℕ.+_) $ +-comm fees dep ⟩
-          cbalance utxo + (dep + fees)
+          cbalance utxo ℕ.+ (dep ℕ.+ fees)
             ≡˘⟨ cong (λ x → cbalance utxo + (x + fees)) $ m+[n∸m]≡n ref≤dep ⟩
           cbalance utxo ℕ.+ ((ref ℕ.+ remDepTot) ℕ.+ fees)
             ≡t⟨⟩
@@ -504,10 +511,7 @@ pov {tx}{utxo}{_}{fees}{deposits}{donations}
             ≡⟨ cong (_+ (remDepTot + fees)) utxo-ref-prop ⟩
           (cbalance ((utxo ∣ txins ᶜ) ∪ˡ outs txb) ℕ.+ txfee)
             ℕ.+ txdonation ℕ.+ tot ℕ.+ (remDepTot ℕ.+ fees)
-            ≡t⟨⟩
-          cbalance ((utxo ∣ txins ᶜ) ∪ˡ outs txb)
-            ℕ.+ (txfee ℕ.+ txdonation ℕ.+ (tot ℕ.+ remDepTot) ℕ.+ fees)
-            ≡⟨ cong (cbalance ((utxo ∣ txins ᶜ) ∪ˡ outs txb) +_) $ rearrange0 refl ⟩
+            ≡⟨ rearrange0 (cbalance ((utxo ∣ txins ᶜ) ∪ˡ outs txb)) refl ⟩
           cbalance ((utxo ∣ txins ᶜ) ∪ˡ outs txb)
             + ((fees + txfee) + getCoin deposits' + txdonation)
             ∎ ⟩

--- a/src/Ledger/hs-src/test/UtxowSpec.hs
+++ b/src/Ledger/hs-src/test/UtxowSpec.hs
@@ -76,7 +76,7 @@ testTxBody1 = bodyFromSimple initParams $ MkSimpleTxBody
 testTx1 :: Tx
 testTx1 = MkTx
   { body = testTxBody1
-  , wits = MkTxWitnesses { vkSigs = [(0, 1)], scripts = [] }
+  , wits = MkTxWitnesses { vkSigs = [(0, 1)], scripts = [], txdats = [], txrdmrs = [] }
   , txAD = Nothing }
 
 testTxBody2 :: TxBody
@@ -91,7 +91,7 @@ testTxBody2 = bodyFromSimple initParams $ MkSimpleTxBody
 testTx2 :: Tx
 testTx2 = MkTx
   { body = testTxBody2
-  , wits = MkTxWitnesses { vkSigs = [(1, 3)], scripts = [] }
+  , wits = MkTxWitnesses { vkSigs = [(1, 3)], scripts = [], txdats = [], txrdmrs = [] }
   , txAD = Nothing }
 
 utxowSteps :: UTxOEnv -> UTxOState -> [Tx] -> ComputationResult Text UTxOState


### PR DESCRIPTION
# Description

This is a small addition to the fee calculation in Conway. Since we don't have Babbage features the `refScripts` function is just the constant empty set ATM. Also, since we don't have a way to compute a size for scripts in general, `scriptSize` is just an abstract function.

One annoyance is that we don't have types & functions to deal with rational numbers in the unit interval. So the new parameter doesn't have that constraint for now, but we should probably add that later.

Closes #345 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
