### PR TITLE
PDF cleanup 282: remove `foldr` from code appearing in pdf

### DIFF
--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -65,7 +65,8 @@ record TokenAlgebra : Set₁ where
 \AgdaTarget{sumᵛ}
 \begin{code}
   sumᵛ : List Value → Value
-  sumᵛ = foldr _+ᵛ_ (inject 0)
+  sumᵛ [] = inject 0
+  sumᵛ (x ∷ l) = x + sumᵛ l
 \end{code}
 \end{AgdaAlign}
 \caption{Token algebras, used for multi-assets}


### PR DESCRIPTION
# Description

remove occurrences of `foldr` that appear in pdf as requested in issue #282 

(there was only one pdf-visible occurrence of `foldr`---in the `sum` function of the `TokenAlgebra` module; changed to a simple recursive function)

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
