### PR TITLE
PDF cleanup 282: rename `_≗_` to `_≡_`

### DIFF
--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -13,7 +13,7 @@ module Ledger.TokenAlgebra (
 \end{code}
 \begin{code}[hide]
   : Set) where
-open import Ledger.Prelude
+open import Ledger.Prelude hiding (_≡_) renaming (_≗_ to _≡_)
 
 open import Algebra              using (CommutativeMonoid ; Monoid)
 open import Algebra.Morphism     using (module MonoidMorphisms )
@@ -49,7 +49,7 @@ record TokenAlgebra : Set₁ where
          _≤ᵗ_                      : Value → Value → Set
          AssetName                 : Set
          specialAsset              : AssetName
-         property                  : coin ∘ inject ≗ id -- FIXME: rename!
+         property                  : coin ∘ inject ≡ id
          coinIsMonoidHomomorphism  : IsMonoidHomomorphism coin
 \end{code}
 \end{AgdaSuppressSpace}


### PR DESCRIPTION
# Description

Addresses one item in issue #282 

I'm conflicted about this change since, while it might make the pdf easier for non-Agda/non-TT folks to read, it could cause confusion for Agda/TT folks who know that the usual `_≡_` wouldn't work here.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
