### PR TITLE
PDF cleanup 282: rename `sucᵉ` to `1 +ᵉ_`

### DIFF
--- a/src/Ledger/Epoch.lagda
+++ b/src/Ledger/Epoch.lagda
@@ -99,7 +99,7 @@ its results, i.e:
       certState' =
         ⟦ record dState { rewards = rewards ∪⁺ refunds }
         , ⟦ pools ∣ retired ᶜ , retiring ∣ retired ᶜ ⟧ᵖ
-        , ⟦ if null govSt' then mapValues sucᵉ dreps else dreps
+        , ⟦ if null govSt' then mapValues (1 +ᵉ_) dreps else dreps
           , ccHotKeys ∣ ccCreds (es .EnactState.cc) ⟧ᵛ ⟧ᶜˢ
 
       utxoSt' = ⟦ utxo , 0 , deposits ∣ mapˢ (proj₁ ∘ proj₂) removedGovActions ᶜ , 0 ⟧ᵘ
@@ -131,13 +131,13 @@ data
 \end{code}
 \begin{code}
   NEWEPOCH-New :
-    e ≡ sucᵉ lastEpoch
+    e ≡ 1 +ᵉ lastEpoch
     → Γ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
     ────────────────────────────────
     Γ ⊢ ⟦ lastEpoch , eps ⟧ⁿᵉ ⇀⦇ e ,NEWEPOCH⦈ ⟦ e , eps' ⟧ⁿᵉ
 
   NEWEPOCH-Not-New :
-    e ≢ sucᵉ lastEpoch
+    e ≢ 1 +ᵉ lastEpoch
     ────────────────────────────────
     Γ ⊢ ⟦ lastEpoch , eps ⟧ⁿᵉ ⇀⦇ e ,NEWEPOCH⦈ ⟦ lastEpoch , eps ⟧ⁿᵉ
 \end{code}

--- a/src/Ledger/Epoch/Properties.agda
+++ b/src/Ledger/Epoch/Properties.agda
@@ -50,12 +50,12 @@ module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
   open NewEpochState nes
 
   NEWEPOCH-total : ∃[ nes' ] Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes'
-  NEWEPOCH-total with e ≟ sucᵉ lastEpoch
+  NEWEPOCH-total with e ≟ 1 +ᵉ lastEpoch
   ... | yes p = ⟦ e , proj₁ EPOCH-total' ⟧ⁿᵉ , NEWEPOCH-New p (EPOCH-total' .proj₂)
   ... | no ¬p = -, NEWEPOCH-Not-New ¬p
 
   NEWEPOCH-complete : ∀ nes' → Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes' → proj₁ NEWEPOCH-total ≡ nes'
-  NEWEPOCH-complete nes' h with e ≟ sucᵉ lastEpoch | h
+  NEWEPOCH-complete nes' h with e ≟ 1 +ᵉ lastEpoch | h
   ... | yes p | NEWEPOCH-New x x₁  rewrite EPOCH-complete' _ x₁ = refl
   ... | yes p | NEWEPOCH-Not-New x = ⊥-elim $ x p
   ... | no ¬p | NEWEPOCH-New x x₁  = ⊥-elim $ ¬p x

--- a/src/Ledger/PPUp.lagda
+++ b/src/Ledger/PPUp.lagda
@@ -71,7 +71,7 @@ data _⊢_⇀⦇_,PPUP⦈_ : PPUpdateEnv → PPUpdateState → Maybe Update → 
   PPUpdateCurrent : let open PPUpdateEnv Γ in
     dom pup ⊆ dom genDelegs
     → All (isViableUpdate pparams) (range pup)
-    → slot + (2 * StabilityWindow) < firstSlot (sucᵉ (epoch slot))
+    → slot + (2 * StabilityWindow) < firstSlot (1 +ᵉ (epoch slot))
     → epoch slot ≡ e
     ────────────────────────────────
     Γ ⊢ record { pup = pupˢ ; fpup = fpupˢ } ⇀⦇ just (pup , e) ,PPUP⦈
@@ -80,8 +80,8 @@ data _⊢_⇀⦇_,PPUP⦈_ : PPUpdateEnv → PPUpdateState → Maybe Update → 
   PPUpdateFuture : let open PPUpdateEnv Γ in
     dom pup ⊆ dom genDelegs
     → All (isViableUpdate pparams) (range pup)
-    → firstSlot (sucᵉ (epoch slot)) ≤ slot + (2 * StabilityWindow)
-    → sucᵉ (epoch slot) ≡ e
+    → firstSlot (1 +ᵉ (epoch slot)) ≤ slot + (2 * StabilityWindow)
+    → 1 +ᵉ (epoch slot) ≡ e
     ────────────────────────────────
     Γ ⊢ record { pup = pupˢ ; fpup = fpupˢ } ⇀⦇ just (pup , e) ,PPUP⦈
         record { pup = pupˢ ; fpup = pup ∪ˡ fpupˢ }

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -13,20 +13,22 @@ private
   open import Agda.Builtin.FromNat
   open import Algebra; open Semiring Slotʳ hiding (refl)
   open import Algebra.Literals; open Semiring-Lit Slotʳ
+  import Data.Nat.Literals as ℕ
+  instance _ = ℕ.number
 
   Current-Property : PPUpdateEnv → Update → Set
   Current-Property Γ (pup , e) = let open PPUpdateEnv Γ in
       dom pup ⊆ dom genDelegs
       × All (isViableUpdate pparams) (range pup)
-      × (slot + (2 * StabilityWindow)) < firstSlot (sucᵉ (epoch slot))
+      × (slot + (2 * StabilityWindow)) < firstSlot (1 +ᵉ (epoch slot))
       × epoch slot ≡ e
 
   Future-Property : PPUpdateEnv → Update → Set
   Future-Property Γ (pup , e) = let open PPUpdateEnv Γ in
       dom pup ⊆ dom genDelegs
       × All (isViableUpdate pparams) (range pup)
-      × firstSlot (sucᵉ (epoch slot)) ≤ (slot + (2 * StabilityWindow))
-      × sucᵉ (epoch slot) ≡ e
+      × firstSlot (1 +ᵉ (epoch slot)) ≤ (slot + (2 * StabilityWindow))
+      × 1 +ᵉ (epoch slot) ≡ e
 
 instance
   Computational-PPUP : Computational _⊢_⇀⦇_,PPUP⦈_ String


### PR DESCRIPTION
# Description

Second attempt to rename `sucᵉ`, this time using a simpler approach---simply replace it with `1 +ᵉ_`.

This addresses one item of issue #282.

Maybe this is not idea, but I'm not sure there's a better alternative if we can't identify `Epoch` as one of the simple/standard types of algebraic structures for which there is already support for literals.

It was suggested in the comments of previous PR #315 (since closed) that `Epoch` has a module structure, but I don't see it.  To me `Epoch` looks more like a G-set, where the group acting on `Epoch` is ℕ` ...and I don't know if there's support for G-set literals ...yet.  If there is
 not, then we could develop it, but I'm not sure it's worth doing for the sole purpose of renaming one symbol.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
