### PR TITLE
PDF cleanup 282: hide `Σ`

### DIFF
--- a/src/Ledger/Address.lagda
+++ b/src/Ledger/Address.lagda
@@ -55,13 +55,19 @@ record RwdAddr : Set where
 \end{code}
 \begin{code}[hide]
 open BaseAddr; open BootstrapAddr; open BaseAddr; open BootstrapAddr
+private variable
+  a b : Level
+  A : Set a
+Σ-syntax' : (A : Set a) → (A → Set b) → Set _
+Σ-syntax' = Σ
+syntax Σ-syntax' A (λ x → B) = x ∈ A ﹐ B
 \end{code}
 \begin{code}
 
-VKeyBaseAddr         = Σ[ addr ∈ BaseAddr       ] isVKey    (addr .pay)
-VKeyBootstrapAddr    = Σ[ addr ∈ BootstrapAddr  ] isVKey    (addr .pay)
-ScriptBaseAddr       = Σ[ addr ∈ BaseAddr       ] isScript  (addr .pay)
-ScriptBootstrapAddr  = Σ[ addr ∈ BootstrapAddr  ] isScript  (addr .pay)
+VKeyBaseAddr         = addr ∈ BaseAddr      ﹐ isVKey   (addr .pay)
+VKeyBootstrapAddr    = addr ∈ BootstrapAddr ﹐ isVKey   (addr .pay)
+ScriptBaseAddr       = addr ∈ BaseAddr      ﹐ isScript (addr .pay)
+ScriptBootstrapAddr  = addr ∈ BootstrapAddr ﹐ isScript (addr .pay)
 
 Addr        = BaseAddr        ⊎ BootstrapAddr
 VKeyAddr    = VKeyBaseAddr    ⊎ VKeyBootstrapAddr

--- a/src/Ledger/Address.lagda
+++ b/src/Ledger/Address.lagda
@@ -55,19 +55,13 @@ record RwdAddr : Set where
 \end{code}
 \begin{code}[hide]
 open BaseAddr; open BootstrapAddr; open BaseAddr; open BootstrapAddr
-private variable
-  a b : Level
-  A : Set a
-Σ-syntax' : (A : Set a) → (A → Set b) → Set _
-Σ-syntax' = Σ
-syntax Σ-syntax' A (λ x → B) = x ∈ A ﹐ B
 \end{code}
 \begin{code}
 
-VKeyBaseAddr         = addr ∈ BaseAddr      ﹐ isVKey   (addr .pay)
-VKeyBootstrapAddr    = addr ∈ BootstrapAddr ﹐ isVKey   (addr .pay)
-ScriptBaseAddr       = addr ∈ BaseAddr      ﹐ isScript (addr .pay)
-ScriptBootstrapAddr  = addr ∈ BootstrapAddr ﹐ isScript (addr .pay)
+VKeyBaseAddr         = Σ[ addr ∈ BaseAddr       ] isVKey    (addr .pay)
+VKeyBootstrapAddr    = Σ[ addr ∈ BootstrapAddr  ] isVKey    (addr .pay)
+ScriptBaseAddr       = Σ[ addr ∈ BaseAddr       ] isScript  (addr .pay)
+ScriptBootstrapAddr  = Σ[ addr ∈ BootstrapAddr  ] isScript  (addr .pay)
 
 Addr        = BaseAddr        ⊎ BootstrapAddr
 VKeyAddr    = VKeyBaseAddr    ⊎ VKeyBootstrapAddr

--- a/src/Ledger/Introduction.lagda
+++ b/src/Ledger/Introduction.lagda
@@ -186,6 +186,12 @@ we use here to form a type of sets with elements in a given type.
 \begin{figure*}[h]
 \begin{code}[hide]
 module _ (ℙ_ : Set → Set) (_∈_ : ∀ {A : Set} → A → ℙ A → Set) where
+  private variable
+    a c : Level
+    A : Set a
+  Σ-syntax' : (A : Set a) → (A → Set c) → Set _
+  Σ-syntax' = Σ
+  syntax Σ-syntax' A (λ x → B) = x ∈ A ﹐ B
 \end{code}
 \begin{code}
   _⊆_ : {A : Set} → ℙ A → ℙ A → Set
@@ -201,7 +207,7 @@ module _ (ℙ_ : Set → Set) (_∈_ : ∀ {A : Set} → A → ℙ A → Set) wh
   left-unique R = ∀ {a b b'} → (a , b) ∈ R → (a , b') ∈ R → b ≡ b'
 
   _⇀_ : Set → Set → Set
-  A ⇀ B = Σ[ m ∈ Rel A B ] left-unique m
+  A ⇀ B = r ∈ Rel A B ﹐ left-unique r
 \end{code}
 \end{figure*}
 


### PR DESCRIPTION
# Description

This addresses one item of issue #282.

One way to hide `Σ` is to simply use an alternative `Σ-syntax` definition.  

This PR does this in the two places where `Σ` had appeared in a pdf figure (`Ledger.Introduction` and `Ledger.Address`).

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
