### PR TITLE
PDF cleanup 282: hide `module` syntax

### DIFF
--- a/src/Ledger/Script.lagda
+++ b/src/Ledger/Script.lagda
@@ -82,30 +82,22 @@ open import Data.List.Relation.Binary.Sublist.Propositional as S
 import Data.Maybe.Relation.Unary.Any as M
 \end{code}
 \begin{code}[hide]
-module _
+data
 \end{code}
 \begin{code}
-  (khs : ℙ KeyHash) (I : Maybe Slot × Maybe Slot)
-\end{code}
-\begin{code}[hide]
-  where
-  data
-\end{code}
-\begin{code}
-
-    evalTimelock : Timelock → Set where
-    evalAll  : All evalTimelock ss
-             → evalTimelock (RequireAllOf ss)
-    evalAny  : Any evalTimelock ss
-             → evalTimelock (RequireAnyOf ss)
-    evalMOf  : MOf m evalTimelock ss
-             → evalTimelock (RequireMOf m ss)
-    evalSig  : x ∈ khs
-             → evalTimelock (RequireSig x)
-    evalTSt  : M.Any (a ≤_) (I .proj₁)
-             → evalTimelock (RequireTimeStart a)
-    evalTEx  : M.Any (_≤ a) (I .proj₂)
-             → evalTimelock (RequireTimeExpire a)
+  evalTimelock (khs : ℙ KeyHash) (I : Maybe Slot × Maybe Slot) : Timelock → Set where
+  evalAll  : All (evalTimelock khs I) ss
+           → (evalTimelock khs I) (RequireAllOf ss)
+  evalAny  : Any (evalTimelock khs I) ss
+           → (evalTimelock khs I) (RequireAnyOf ss)
+  evalMOf  : MOf m (evalTimelock khs I) ss
+           → (evalTimelock khs I) (RequireMOf m ss)
+  evalSig  : x ∈ khs
+           → (evalTimelock khs I) (RequireSig x)
+  evalTSt  : M.Any (a ≤_) (I .proj₁)
+           → (evalTimelock khs I) (RequireTimeStart a)
+  evalTEx  : M.Any (_≤ a) (I .proj₂)
+           → (evalTimelock khs I) (RequireTimeExpire a)
 \end{code}
 \caption{Timelock scripts and their evaluation}
 \label{fig:defs:timelock}

--- a/src/Ledger/Script.lagda
+++ b/src/Ledger/Script.lagda
@@ -81,9 +81,19 @@ open import Data.List.Relation.Binary.Sublist.Ext
 open import Data.List.Relation.Binary.Sublist.Propositional as S
 import Data.Maybe.Relation.Unary.Any as M
 \end{code}
+\begin{code}[hide]
+module _
+\end{code}
 \begin{code}
-module _ (khs : ℙ KeyHash) (I : Maybe Slot × Maybe Slot) where
-  data evalTimelock : Timelock → Set where
+  (khs : ℙ KeyHash) (I : Maybe Slot × Maybe Slot)
+\end{code}
+\begin{code}[hide]
+  where
+  data
+\end{code}
+\begin{code}
+
+    evalTimelock : Timelock → Set where
     evalAll  : All evalTimelock ss
              → evalTimelock (RequireAllOf ss)
     evalAny  : Any evalTimelock ss

--- a/src/Ledger/TokenAlgebra/ValueSet.lagda
+++ b/src/Ledger/TokenAlgebra/ValueSet.lagda
@@ -61,8 +61,12 @@ open CommutativeMonoid renaming (_∙_ to _⋆_) hiding (refl ; sym ; trans)
 
 AssetId  = PolicyId × AssetName
 Quantity = ℕ
-
+\end{code}
+\begin{code}[hide]
 module _
+\end{code}
+\begin{code}
+
   {X : ℙ AssetId}
   {⋁A : isMaximal X}
   ⦃ DecEq-PolicyId  : DecEq PolicyId ⦄
@@ -70,10 +74,14 @@ module _
   ⦃ DecEq-Tot : DecEq (AssetId ⇒ ℕ) ⦄
   (Dec-lookup≤ : ∀ {u v : AssetId ⇒ ℕ}
     → (∀ {a p q} → lookup u (a , p) ≤ lookup v (a , q)) ⁇)
+\end{code}
+\begin{code}[hide]
   where
 
   open ≡-Reasoning
   open FunTot X ⋁A
+\end{code}
+\begin{code}
 
   _⊕_ : Op₂ (AssetId ⇒ Quantity)
   u ⊕ v = Fun⇒TotalMap λ aa → (lookup u) aa + (lookup v) aa


### PR DESCRIPTION
# Description

This addresses one item of issue #282.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
