### PR TITLE
PDF cleanup: hide `λ where` syntax

### DIFF
--- a/src/Ledger/NewPP.lagda
+++ b/src/Ledger/NewPP.lagda
@@ -16,6 +16,7 @@ record NewPParamEnv : Set where
 --  field
 \end{code}
 \begin{figure*}[h]
+\begin{AgdaMultiCode}
 \begin{code}
 record NewPParamState : Set where
   constructor ⟦_,_⟧ⁿᵖ
@@ -39,6 +40,7 @@ votedValue pup pparams quorum =
       (no  _)        → nothing
       (yes (u , _))  → just u
 \end{code}
+\end{AgdaMultiCode}
 \caption{Types and functions for the NEWPP transition system}
 \end{figure*}
 \begin{code}[hide]

--- a/src/Ledger/NewPP.lagda
+++ b/src/Ledger/NewPP.lagda
@@ -34,11 +34,11 @@ votedValue pup pparams quorum =
   case any? (λ u → lengthˢ (pup ↾ fromList [ u ]) ≥? quorum) (range pup) of
 \end{code}
 \begin{code}[hide]
-    λ where
+    λ  where
 \end{code}
 \begin{code}
-      (no  _)        → nothing
-      (yes (u , _))  → just u
+       (no  _)        → nothing
+       (yes (u , _))  → just u
 \end{code}
 \end{AgdaMultiCode}
 \caption{Types and functions for the NEWPP transition system}

--- a/src/Ledger/NewPP.lagda
+++ b/src/Ledger/NewPP.lagda
@@ -30,9 +30,14 @@ updatePPUp pparams record { fpup = fpup }
 
 votedValue : ProposedPPUpdates → PParams → ℕ → Maybe PParamsUpdate
 votedValue pup pparams quorum =
-  case any? (λ u → lengthˢ (pup ↾ fromList [ u ]) ≥? quorum) (range pup) of λ where
-    (no  _)        → nothing
-    (yes (u , _))  → just u
+  case any? (λ u → lengthˢ (pup ↾ fromList [ u ]) ≥? quorum) (range pup) of
+\end{code}
+\begin{code}[hide]
+    λ where
+\end{code}
+\begin{code}
+      (no  _)        → nothing
+      (yes (u , _))  → just u
 \end{code}
 \caption{Types and functions for the NEWPP transition system}
 \end{figure*}

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -81,6 +81,7 @@ required. A protocol parameter may or may not be in the
 
 Each of the $P_x$ and $Q_x$ are protocol parameters.
 \begin{figure*}[h]
+\begin{AgdaMultiCode}
 \begin{code}[hide]
 private
   ∣_∣_∣_∣ : {A : Set} → A → A → A → GovRole → A
@@ -108,7 +109,6 @@ maxThreshold x = foldl comb nothing (proj₁ $ finiteness x)
 ─ = nothing
 ✓† = vote defer
 \end{code}
-\begin{AgdaMultiCode}
 \begin{code}
 threshold : PParams → Maybe ℚ → GovAction → GovRole → Maybe ℚ
 threshold pp ccThreshold =
@@ -117,43 +117,43 @@ threshold pp ccThreshold =
   λ where
 \end{code}
 \begin{code}
-    NoConfidence           → ∣ ─   ∣ vote P1      ∣ vote Q1     ∣
-    (NewCommittee _ _ _)   → ∣ ─   ∥ P/Q2a/b                    ∣
-    (NewConstitution _ _)  → ∣ ✓   ∣ vote P3      ∣ ─           ∣
-    (TriggerHF _)          → ∣ ✓   ∣ vote P4      ∣ vote Q4     ∣
-    (ChangePParams x)      → ∣ ✓   ∥ P/Q5 x                     ∣
-    (TreasuryWdrl _)       → ∣ ✓   ∣ vote P6      ∣ ─           ∣
-    Info                   → ∣ ✓†  ∣ ✓†           ∣ ✓†          ∣
-  where
+      NoConfidence           → ∣ ─   ∣ vote P1      ∣ vote Q1     ∣
+      (NewCommittee _ _ _)   → ∣ ─   ∥ P/Q2a/b                    ∣
+      (NewConstitution _ _)  → ∣ ✓   ∣ vote P3      ∣ ─           ∣
+      (TriggerHF _)          → ∣ ✓   ∣ vote P4      ∣ vote Q4     ∣
+      (ChangePParams x)      → ∣ ✓   ∥ P/Q5 x                     ∣
+      (TreasuryWdrl _)       → ∣ ✓   ∣ vote P6      ∣ ─           ∣
+      Info                   → ∣ ✓†  ∣ ✓†           ∣ ✓†          ∣
+        where
 \end{code}
 \begin{code}[hide]
-    open PParams pp
-    open DrepThresholds drepThresholds
-    open PoolThresholds poolThresholds
+        open PParams pp
+        open DrepThresholds drepThresholds
+        open PoolThresholds poolThresholds
 
-    ✓ = ccThreshold
+        ✓ = ccThreshold
 \end{code}
 \begin{code}
-    P/Q2a/b : Maybe ℚ × Maybe ℚ
-    P/Q2a/b = case ccThreshold of
+        P/Q2a/b : Maybe ℚ × Maybe ℚ
+        P/Q2a/b =  case ccThreshold of
 \end{code}
 \begin{code}[hide]
-      λ where
+          λ where
 \end{code}
 \begin{code}
-        (just _) → (vote P2a , vote Q2a)
-        nothing  → (vote P2b , vote Q2b)
+                   (just _) → (vote P2a , vote Q2a)
+                   nothing  → (vote P2b , vote Q2b)
 
-    pparamThreshold : PParamGroup → Maybe ℚ × Maybe ℚ
-    pparamThreshold NetworkGroup     = (vote P5a  , ─         )
-    pparamThreshold EconomicGroup    = (vote P5b  , ─         )
-    pparamThreshold TechnicalGroup   = (vote P5c  , ─         )
-    pparamThreshold GovernanceGroup  = (vote P5d  , ─         )
-    pparamThreshold SecurityGroup    = (─         , vote Q5e  )
+        pparamThreshold : PParamGroup → Maybe ℚ × Maybe ℚ
+        pparamThreshold NetworkGroup     = (vote P5a  , ─         )
+        pparamThreshold EconomicGroup    = (vote P5b  , ─         )
+        pparamThreshold TechnicalGroup   = (vote P5c  , ─         )
+        pparamThreshold GovernanceGroup  = (vote P5d  , ─         )
+        pparamThreshold SecurityGroup    = (─         , vote Q5e  )
 
-    P/Q5 : PParamsUpdate → Maybe ℚ × Maybe ℚ
-    P/Q5 ppu = maxThreshold (mapˢ (proj₁ ∘ pparamThreshold) (updateGroups ppu))
-             , maxThreshold (mapˢ (proj₂ ∘ pparamThreshold) (updateGroups ppu))
+        P/Q5 : PParamsUpdate → Maybe ℚ × Maybe ℚ
+        P/Q5 ppu = maxThreshold (mapˢ (proj₁ ∘ pparamThreshold) (updateGroups ppu))
+                 , maxThreshold (mapˢ (proj₂ ∘ pparamThreshold) (updateGroups ppu))
 
 canVote : PParams → GovAction → GovRole → Set
 canVote pp a r = Is-just (threshold pp nothing a r)

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -296,7 +296,7 @@ restrictedDists coins rank dists = dists
         restrict dist = topNDRepDist rank dist ∪ˡ mostStakeDRepDist dist coins
 \end{code}
 \begin{figure*}[h!]
-\begin{AgdaAlign}
+\begin{AgdaMultiCode}
 \begin{code}
 actualVotes  : RatifyEnv → PParams → CCData → GovAction
              → (GovRole × Credential ⇀ Vote) → (VDeleg ⇀ Vote)
@@ -350,7 +350,7 @@ actualVotes Γ pparams cc ga votes
   actualSPOVotes (TriggerHF _)  = roleVotes SPO ∪ˡ constMap spos Vote.no
   actualSPOVotes _              = roleVotes SPO ∪ˡ constMap spos Vote.abstain
 \end{code}
-\end{AgdaAlign}
+\end{AgdaMultiCode}
 \caption{Vote counting}
 \label{fig:defs:ratify-actualvotes}
 \end{figure*}

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -111,7 +111,12 @@ maxThreshold x = foldl comb nothing (proj₁ $ finiteness x)
 \begin{AgdaMultiCode}
 \begin{code}
 threshold : PParams → Maybe ℚ → GovAction → GovRole → Maybe ℚ
-threshold pp ccThreshold = λ where
+threshold pp ccThreshold =
+\end{code}
+\begin{code}[hide]
+  λ where
+\end{code}
+\begin{code}
     NoConfidence           → ∣ ─   ∣ vote P1      ∣ vote Q1     ∣
     (NewCommittee _ _ _)   → ∣ ─   ∥ P/Q2a/b                    ∣
     (NewConstitution _ _)  → ∣ ✓   ∣ vote P3      ∣ ─           ∣
@@ -130,9 +135,14 @@ threshold pp ccThreshold = λ where
 \end{code}
 \begin{code}
     P/Q2a/b : Maybe ℚ × Maybe ℚ
-    P/Q2a/b = case ccThreshold of λ where
-      (just _) → (vote P2a , vote Q2a)
-      nothing  → (vote P2b , vote Q2b)
+    P/Q2a/b = case ccThreshold of
+\end{code}
+\begin{code}[hide]
+      λ where
+\end{code}
+\begin{code}
+        (just _) → (vote P2a , vote Q2a)
+        nothing  → (vote P2b , vote Q2b)
 
     pparamThreshold : PParamGroup → Maybe ℚ × Maybe ℚ
     pparamThreshold NetworkGroup     = (vote P5a  , ─         )
@@ -294,8 +304,12 @@ actualVotes Γ pparams cc ga votes
   =   mapKeys (credVoter CC) (actualCCVotes cc)  ∪ˡ actualPDRepVotes ga
   ∪ˡ  actualDRepVotes                            ∪ˡ actualSPOVotes ga
   where
+\end{code}
+\begin{code}[hide]
   open RatifyEnv Γ
   open PParams pparams
+\end{code}
+\begin{code}
 
   roleVotes : GovRole → VDeleg ⇀ Vote
   roleVotes r = mapKeys (uncurry credVoter) (filterᵐ (λ (x , _) → r ≡ proj₁ x) votes)
@@ -309,8 +323,13 @@ actualVotes Γ pparams cc ga votes
 
   actualCCVote : Credential → Epoch → Vote
   actualCCVote c e = case ¿ currentEpoch ≤ e ¿ᵇ , lookupᵐ? ccHotKeys c of
-    λ where  (true , just (just c'))  → maybe id Vote.no (lookupᵐ? votes (CC , c'))
-             _                        → Vote.abstain -- expired, no hot key or resigned
+\end{code}
+\begin{code}[hide]
+    λ where
+\end{code}
+\begin{code}
+      (true , just (just c'))  → maybe id Vote.no (lookupᵐ? votes (CC , c'))
+      _                        → Vote.abstain -- expired, no hot key or resigned
 
   actualCCVotes : CCData → Credential ⇀ Vote
   actualCCVotes nothing          =  ∅

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -65,7 +65,8 @@ record TokenAlgebra : Set₁ where
 \AgdaTarget{sumᵛ}
 \begin{code}
   sumᵛ : List Value → Value
-  sumᵛ = foldr _+ᵛ_ (inject 0)
+  sumᵛ [] = inject 0
+  sumᵛ (x ∷ l) = x + sumᵛ l
 \end{code}
 \end{AgdaAlign}
 \caption{Token algebras, used for multi-assets}

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -16,7 +16,7 @@ open import Ledger.ScriptValidation txs abs
 \end{code}
 
 \begin{figure*}[h]
-\begin{AgdaAlign}
+\begin{AgdaMultiCode}
 \begin{code}
 getVKeys : ℙ Credential → ℙ KeyHash
 getVKeys = mapPartial isInj₁
@@ -31,14 +31,14 @@ credsNeeded utxo txb
   ∪  mapˢ (λ c → (Cert     c , cwitness c)) (fromList txcerts)
   ∪  mapˢ (λ x → (Mint     x , inj₂ x)) (policies mint)
   ∪  mapˢ (λ v → (Vote     v , proj₂ v)) (fromList $ map GovVote.voter txvote)
-  ∪  mapPartial (λ p → case p .GovProposal.policy of
+  ∪  mapPartial (λ p →  case p .GovProposal.policy of
 \end{code}
 \begin{code}[hide]
     λ where
 \end{code}
 \begin{code}
-      (just sh)  → just (Propose  p , inj₂ sh)
-      nothing    → nothing) (fromList txprop)
+                        (just sh)  → just (Propose  p , inj₂ sh)
+                        nothing    → nothing) (fromList txprop)
 \end{code}
 \begin{code}[hide]
   where open TxBody txb
@@ -51,7 +51,7 @@ witsVKeyNeeded = getVKeys ∘₂ mapˢ proj₂ ∘₂ credsNeeded
 scriptsNeeded  : UTxO → TxBody → ℙ ScriptHash
 scriptsNeeded = getScripts ∘₂ mapˢ proj₂ ∘₂ credsNeeded
 \end{code}
-\end{AgdaAlign}
+\end{AgdaMultiCode}
 \caption{Functions used for witnessing}
 \label{fig:functions:utxow}
 \end{figure*}

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -30,10 +30,19 @@ credsNeeded utxo txb
   ∪  mapˢ (λ c → (Cert     c , cwitness c)) (fromList txcerts)
   ∪  mapˢ (λ x → (Mint     x , inj₂ x)) (policies mint)
   ∪  mapˢ (λ v → (Vote     v , proj₂ v)) (fromList $ map GovVote.voter txvote)
-  ∪  mapPartial (λ p → case p .GovProposal.policy of λ where
-    (just sh)  → just (Propose  p , inj₂ sh)
-    nothing    → nothing) (fromList txprop)
+  ∪  mapPartial (λ p → case p .GovProposal.policy of
+\end{code}
+\begin{code}[hide]
+    λ where
+\end{code}
+\begin{code}
+      (just sh)  → just (Propose  p , inj₂ sh)
+      nothing    → nothing) (fromList txprop)
+\end{code}
+\begin{code}[hide]
   where open TxBody txb
+\end{code}
+\begin{code}
 
 witsVKeyNeeded : UTxO → TxBody → ℙ KeyHash
 witsVKeyNeeded = getVKeys ∘₂ mapˢ proj₂ ∘₂ credsNeeded

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -16,6 +16,7 @@ open import Ledger.ScriptValidation txs abs
 \end{code}
 
 \begin{figure*}[h]
+\begin{AgdaAlign}
 \begin{code}
 getVKeys : ℙ Credential → ℙ KeyHash
 getVKeys = mapPartial isInj₁
@@ -50,6 +51,7 @@ witsVKeyNeeded = getVKeys ∘₂ mapˢ proj₂ ∘₂ credsNeeded
 scriptsNeeded  : UTxO → TxBody → ℙ ScriptHash
 scriptsNeeded = getScripts ∘₂ mapˢ proj₂ ∘₂ credsNeeded
 \end{code}
+\end{AgdaAlign}
 \caption{Functions used for witnessing}
 \label{fig:functions:utxow}
 \end{figure*}


### PR DESCRIPTION
# Description

This addresses one item of issue #282.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
