### PR TITLE
Deriving tactic for Convertible instances

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,10 +50,10 @@ let
     pname = "agda-stdlib-meta";
     version = "2.0-rc1";
     src = fetchFromGitHub {
-      repo = "agda-stdlib-meta";
-      owner = "omelkonian";
-      rev = "v2.0-rc1";
-      sha256 = "k9hQrNfLa3v0i0UXKrdVoasDm6GZflTweUuwykUE5pU=";
+      repo = "stdlib-meta";
+      owner = "input-output-hk";
+      rev = "4fc4b1ed6e47d180516917d04be87cbacbf7d314";
+      sha256 = "T+9vwccbDO1IGBcGLjgV/fOt+IN14KEV9ct/J6nQCsM=";
     };
     meta = { };
     libraryFile = "agda-stdlib-meta.agda-lib";

--- a/src/Everything.agda
+++ b/src/Everything.agda
@@ -13,3 +13,4 @@ import MidnightExample.HSLedger
 
 -- ** not currently used
 import Tactic.DeriveComp
+import Foreign.Convertible.DerivingTest

--- a/src/Foreign/Convertible.agda
+++ b/src/Foreign/Convertible.agda
@@ -67,3 +67,8 @@ instance
   Convertible-List = λ where
     .to   → map to
     .from → map from
+
+  Convertible-Fun : ∀ {A A' B B'} → ⦃ Convertible A A' ⦄ → ⦃ Convertible B B' ⦄ → Convertible (A → B) (A' → B')
+  Convertible-Fun = λ where
+    .to   → λ f → to   ∘ f ∘ from
+    .from → λ f → from ∘ f ∘ to

--- a/src/Foreign/Convertible/Deriving.agda
+++ b/src/Foreign/Convertible/Deriving.agda
@@ -1,0 +1,168 @@
+module Foreign.Convertible.Deriving where
+
+open import Level
+open import MetaPrelude
+open import Meta
+
+import Data.List as L
+import Data.List.NonEmpty as NE
+import Data.String as S
+import Data.Product as P
+
+open import Relation.Nullary
+open import Relation.Nullary.Decidable
+
+open import Reflection.Tactic
+open import Reflection.AST.Term
+open import Reflection.AST.DeBruijn
+import Reflection.TCM as R
+open import Reflection.Utils
+open import Reflection.Utils.TCI
+import Function.Identity.Effectful as Identity
+
+open import Class.DecEq
+open import Class.DecEq
+open import Class.Functor
+open import Class.Monad
+open import Class.MonadTC.Instances
+open import Class.Traversable
+open import Class.Show
+open import Class.MonadReader
+
+open import Foreign.Convertible
+
+private instance
+  _ = Functor-M {TC}
+
+liftTC : ∀ {a} {A : Set a} → R.TC A → TC A
+liftTC m _ = m
+
+private
+
+  open MonadReader ⦃...⦄
+
+  variable
+    A B C : Set
+
+  Subst : Set → Set
+  Subst A = ℕ → Term → A → A
+
+  substTerm : Subst Term
+  substArgs : Subst (Args Term)
+  substArg : Subst (Arg Term)
+  substAbs : Subst (Abs Term)
+  substSort : Subst Sort
+
+  substTerm x s (var y args) =
+    case compare x y of λ where
+      (less _ _)    → var (y ∸ 1) (substArgs x s args)
+      (equal _)     → s  -- cheating and dropping the args!
+      (greater _ _) → var y (substArgs x s args)
+  substTerm x s (con c args) = con c (substArgs x s args)
+  substTerm x s (def f args) = def f (substArgs x s args)
+  substTerm x s (lam v t) = lam v (substAbs x s t)
+  substTerm x s (pat-lam cs args₁) = unknown  -- ignoring for now
+  substTerm x s (pi a b) = pi (substArg x s a) (substAbs x s b)
+  substTerm x s (agda-sort s₁) = agda-sort (substSort x s s₁)
+  substTerm x s (lit l) = lit l
+  substTerm x s (meta m args) = meta m (substArgs x s args)
+  substTerm x s unknown = unknown
+
+  substArgs x s [] = []
+  substArgs x s (a ∷ as) = substArg x s a ∷ substArgs x s as
+
+  substArg x s (arg i t) = arg i (substTerm x s t)
+
+  substAbs x s (abs z t) = abs z (substTerm (ℕ.suc x) s t)
+
+  substSort x s (set t) = set (substTerm x s t)
+  substSort x s (lit n) = lit n
+  substSort x s (prop t) = prop (substTerm x s t)
+  substSort x s (propLit n) = propLit n
+  substSort x s (inf n) = inf n
+  substSort x s unknown = unknown
+
+  TyViewTel = List (Abs (Arg Type))
+
+  substTel : Subst TyViewTel
+  substTel x s [] = []
+  substTel x s (abs z t ∷ tel) = abs z (substArg x s t) ∷ (substTel (ℕ.suc x) s tel)
+    -- `abs` is abused here and doesn't actually scope over the `t`
+
+  -- Substitute leading level parameters with lzero
+  smashLevels : TyViewTel → ℕ × TyViewTel
+  smashLevels (abs s (arg i (def (quote Level) [])) ∷ tel) =
+    P.map ℕ.suc (substTel 0 (quote 0ℓ ∙)) $ smashLevels tel
+  smashLevels tel = (0 , tel)
+
+  conversionClauses : (conv : Name) (fromDef : Definition) (toDef : Definition) → TC (List Clause)
+  conversionClauses conv fromDef toDef = return []
+
+  tyViewToTel : TyViewTel → Telescope
+  tyViewToTel = L.map λ where (abs s a) → s , a
+
+  -- liftTC₁ : (R.TC A → R.TC B) → TC A → TC B
+  -- liftTC₁ f m = do
+  --   env ← ask
+  --   liftTC $ f (m env)
+
+  -- reallyExtendContext : Telescope -> TC A → TC A
+  -- reallyExtendContext [] k = k
+  -- reallyExtendContext ((x , a) ∷ tel) k =
+  --   extendContext (x , a) $ do
+  --     env ← ask
+  --     liftTC $ R.extendContext x a (k env)
+
+  hideTyView : Abs (Arg A) → Abs (Arg A)
+  hideTyView (abs s (arg (arg-info _ m) x)) = abs s (arg (arg-info hidden m) x)
+
+  instanceType : (agdaName hsName : Name) → TC TypeView
+  instanceType agdaName hsName = do
+    aLvls , agdaParams ← smashLevels <$> getParamsAndIndices agdaName
+    hLvls , hsParams   ← smashLevels <$> getParamsAndIndices hsName
+    true ← return (length agdaParams == length hsParams)
+      where false → liftTC $ R.typeErrorFmt "%q and %q have different number of parameters" agdaName hsName
+    let n = length agdaParams
+        l₀ = quote 0ℓ ∙
+    agdaTy ← applyWithVisibility agdaName $ L.replicate aLvls l₀ ++ L.map ♯ (take n (downFrom (n + n)))
+    hsTy   ← applyWithVisibility hsName   $ L.replicate hLvls l₀ ++ L.map ♯ (downFrom n)
+    let instHead = weaken n $ quote Convertible ∙⟦ agdaTy ∣ hsTy ⟧
+        tel      = L.map hideTyView (agdaParams ++ hsParams) ++
+                   L.replicate n (abs "_" (iArg (quote Convertible ∙⟦ ♯ (n + n ∸ 1) ∣ ♯ (n ∸ 1) ⟧)))
+    return $ tel , instHead
+
+  conversionClause : TyViewTel → Name → Name → ℕ → ℕ → (Name × Type) × (Name × Type) → TC Clause
+  conversionClause tel prjP prjE fromPars toPars ((fromC , fromTy) , (toC , toTy)) = do
+    let fromTel = drop fromPars (proj₁ (viewTy fromTy))
+        toTel   = drop toPars   (proj₁ (viewTy toTy))
+        n       = length fromTel
+        mkCon  c mkArg = Term.con c    $ L.map (vArg ∘ mkArg ∘ ♯)  (downFrom n)
+        mkConP c mkArg = Pattern.con c $ L.map (vArg ∘ mkArg ∘ `_) (downFrom n)
+    true ← return (n == length toTel)
+      where false → liftTC $ R.typeErrorFmt "%q and %q have different number of arguments" fromC toC
+    return $ clause (tyViewToTel $ L.map (λ where (abs x (arg i _)) → abs x (arg i unknown)) fromTel)
+                    (vArg (proj prjP) ∷ vArg (mkConP fromC id) ∷ [])
+                    (mkCon toC (prjE ∙⟦_⟧))
+
+  instanceClauses : (agdaName hsName : Name) → TyViewTel → TC (List Clause)
+  instanceClauses agdaName hsName tel = do
+    agdaCons ← getConstrs agdaName
+    hsCons   ← getConstrs hsName
+    agdaPars ← length <$> getParamsAndIndices agdaName
+    hsPars   ← length <$> getParamsAndIndices hsName
+    true ← return (length agdaCons == length hsCons)
+      where false → liftTC $ R.typeErrorFmt "%q and %q have different number of constructors" agdaName hsName
+    toClauses   ← mapM (conversionClause tel (quote Convertible.to)   (quote to)   agdaPars hsPars) (L.zip agdaCons hsCons)
+    fromClauses ← mapM (conversionClause tel (quote Convertible.from) (quote from) hsPars agdaPars) (L.zip hsCons agdaCons)
+    return $ toClauses ++ fromClauses
+
+deriveConvertible : Name → Name → Name → R.TC ⊤
+deriveConvertible instName agdaName hsName = initUnquoteWithGoal ⦃ defaultTCOptions ⦄ (agda-sort (lit 0)) do
+  agdaDef ← getDefinition agdaName
+  hsDef   ← getDefinition hsName
+  -- instName ← freshName $ "Convertible" S.++ show hsName
+  instTel , instTy ← instanceType agdaName hsName
+  inst    ← declareDef (iArg instName) (tyView (instTel , instTy))
+  clauses ← instanceClauses agdaName hsName instTel
+  defineFun instName clauses
+  return _

--- a/src/Foreign/Convertible/Deriving.agda
+++ b/src/Foreign/Convertible/Deriving.agda
@@ -146,7 +146,7 @@ private
     fromClauses ← mapM (conversionClause (quote Convertible.from) (quote from)) (L.zip hsCons agdaCons)
     return $ toClauses ++ fromClauses
 
-  -- Compute just the conversion lambda, given the type.
+  -- Compute just the conversion lambda
   patternLambda : TC Term
   patternLambda = do
     quote Convertible ∙⟦ `A ∣ `B ⟧ ← reduce =<< goalTy
@@ -170,5 +170,9 @@ deriveConvertible instName agdaName hsName = initUnquoteWithGoal ⦃ defaultTCOp
 
 macro
   autoConvertible : Tactic
-  autoConvertible = initTac ⦃ defaultTCOptions ⦄ do
+  autoConvertible = initTac ⦃ defaultTCOptions ⦄ $
     unifyWithGoal =<< patternLambda
+
+  ConvertibleType : Name → Name → Tactic
+  ConvertibleType agdaName hsName = initTac ⦃ defaultTCOptions ⦄ $
+    unifyWithGoal ∘ tyView =<< instanceType agdaName hsName

--- a/src/Foreign/Convertible/Deriving.agda
+++ b/src/Foreign/Convertible/Deriving.agda
@@ -137,7 +137,6 @@ private
         n       = length fromTel
         mkCon  c mkArg = Term.con c    $ L.map (vArg ∘ mkArg ∘ ♯)  (downFrom n)
         mkConP c mkArg = Pattern.con c $ L.map (vArg ∘ mkArg ∘ `_) (downFrom n)
-    liftTC $ R.debugPrintFmt "tactic" 10 "%q : %t" fromC fromTy
     true ← return (n == length toTel)
       where false → liftTC $ R.typeErrorFmt "%q and %q have different number of arguments" fromC toC
     return $ clause (tyViewToTel $ L.map (λ where (abs x (arg i _)) → abs x (arg i unknown)) fromTel)

--- a/src/Foreign/Convertible/DerivingTest.agda
+++ b/src/Foreign/Convertible/DerivingTest.agda
@@ -1,0 +1,63 @@
+{-# OPTIONS -v tc.unquote.def:10 -v tc.unquote.decl:10 -v tactic:2 #-}
+module Foreign.Convertible.DerivingTest where
+
+open import Level
+open import MetaPrelude
+open import Meta
+
+import Data.List as L
+import Data.List.NonEmpty as NE
+import Data.String as S
+import Data.Product as P
+
+open import Relation.Nullary
+open import Relation.Nullary.Decidable
+
+open import Reflection.Tactic
+open import Reflection.AST.Term
+open import Reflection.AST.DeBruijn
+import Reflection.TCM as R
+open import Reflection.Utils
+open import Reflection.Utils.TCI
+import Function.Identity.Effectful as Identity
+
+open import Class.DecEq
+open import Class.DecEq
+open import Class.Functor
+open import Class.Monad
+open import Class.MonadTC.Instances
+open import Class.Traversable
+open import Class.Show
+open import Class.MonadReader
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+
+-- Tests
+
+open import Data.Maybe.Base
+open import Data.Sum.Base
+
+data HsMaybe (a : Set) : Set where
+  just    : (x : a) → HsMaybe a
+  nothing : HsMaybe a
+
+data HsEither (a b : Set) : Set where
+  left : a → HsEither a b
+  right : b → HsEither a b
+
+-- We should be able to generate this
+ConvertibleMaybe : ∀ {a a'} → ⦃ Convertible a a' ⦄ → Convertible (Maybe a) (HsMaybe a')
+ConvertibleMaybe .to (just x)   = just (to x)
+ConvertibleMaybe .to nothing    = nothing
+ConvertibleMaybe .from (just x) = just (from x)
+ConvertibleMaybe .from nothing  = nothing
+
+unquoteDecl iConvertMaybe  = deriveConvertible iConvertMaybe (quote Maybe) (quote HsMaybe)
+unquoteDecl iConvertEither = deriveConvertible iConvertEither (quote _⊎_) (quote HsEither)
+
+instance
+  ConvertibleNat = Convertible-Refl {ℕ}
+
+test : ℕ ⊎ Maybe ℕ → HsEither ℕ (HsMaybe ℕ)
+test = to

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -10,6 +10,7 @@ open import Data.Nat.Properties using (+-0-commutativeMonoid; +-0-isCommutativeM
 open import Relation.Binary.Morphism.Structures
 
 open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
 
 import Foreign.Haskell as F
 import Ledger.Foreign.LedgerTypes as F
@@ -221,29 +222,13 @@ instance
     .from n → inj₁ record { net = _ ; pay = inj₁ n ; stake = inj₁ 0 }
 
   Convertible-Credential : Convertible Credential F.Credential
-  Convertible-Credential = λ where
-    .to (inj₁ x) → F.KeyHashObj (to x)
-    .to (inj₂ y) → F.ScriptObj (to y)
-    .from (F.ScriptObj x) → inj₁ (from x)
-    .from (F.KeyHashObj x) → inj₂ (from x)
+  Convertible-Credential = autoConvertible
 
   Convertible-GovRole : Convertible GovRole F.GovRole
-  Convertible-GovRole = λ where
-    .to CC → F.CC
-    .to DRep → F.DRep
-    .to SPO → F.SPO
-    .from F.CC → GovRole.CC
-    .from F.DRep → GovRole.DRep
-    .from F.SPO → GovRole.SPO
+  Convertible-GovRole = autoConvertible
 
   Convertible-VDeleg : Convertible VDeleg F.VDeleg
-  Convertible-VDeleg = λ where
-    .to (credVoter x x₁) → F.CredVoter (to x) (to x₁)
-    .to abstainRep → F.AbstainRep
-    .to noConfidenceRep → F.NoConfidenceRep
-    .from (F.CredVoter x x₁) → VDeleg.credVoter (from x) (from x₁)
-    .from F.AbstainRep → VDeleg.abstainRep
-    .from F.NoConfidenceRep → VDeleg.noConfidenceRep
+  Convertible-VDeleg = autoConvertible
 
   Convertible-PoolParams : Convertible PoolParams F.PoolParams
   Convertible-PoolParams = λ where
@@ -256,21 +241,7 @@ instance
     .from tt → record { url = "bogus" ; hash = tt }
 
   Convertible-DCert : Convertible DCert F.TxCert
-  Convertible-DCert = λ where
-    .to (delegate x x₁ x₂ x₃) → F.Delegate (to x) (to x₁) (to x₂) (to x₃)
-    .to (dereg x) → F.Dereg (to x)
-    .to (regpool x x₁) → F.RegPool (to x) (to x₁)
-    .to (retirepool x x₁) → F.RetirePool (to x) (to x₁)
-    .to (regdrep x x₁ x₂) → F.RegDRep (to x) (to x₁) (to x₂)
-    .to (deregdrep x) → F.DeRegDRep (to x)
-    .to (ccreghot x x₁) → F.CCRegHot (to x) (to x₁)
-    .from (F.Delegate x x₁ x₂ x₃) → DCert.delegate (from x) (from x₁) (from x₂) (from x₃)
-    .from (F.Dereg x) → DCert.dereg (from x)
-    .from (F.RegPool x x₁) → DCert.regpool (from x) (from x₁)
-    .from (F.RetirePool x x₁) → DCert.retirepool (from x) (from x₁)
-    .from (F.RegDRep x x₁ x₂) → DCert.regdrep (from x) (from x₁) (from x₂)
-    .from (F.DeRegDRep x) → DCert.deregdrep (from x)
-    .from (F.CCRegHot x x₁) → DCert.ccreghot (from x) (from x₁)
+  Convertible-DCert = autoConvertible
 
   Convertible-TxBody : Convertible TxBody F.TxBody
   Convertible-TxBody = λ where
@@ -308,10 +279,7 @@ instance
       }
 
   Convertible-Tag : Convertible Tag F.Tag
-  Convertible-Tag = λ where
-    .to   → λ{ Spend → Spend; Mint → Mint; Cert → Cert; Rewrd → Rewrd; Vote → Vote; Propose → Propose }
-    .from → λ{ Spend → Spend; Mint → Mint; Cert → Cert; Rewrd → Rewrd; Vote → Vote; Propose → Propose }
-   where open F.Tag
+  Convertible-Tag = autoConvertible
 
   Convertible-TxWitnesses : Convertible TxWitnesses F.TxWitnesses
   Convertible-TxWitnesses = λ where
@@ -407,11 +375,7 @@ instance
       }
 
   Convertible-UTxOEnv : Convertible UTxOEnv F.UTxOEnv
-  Convertible-UTxOEnv = λ where
-    .to record { slot = slot ; pparams = pparams } →
-        record { slot = slot ; pparams = to pparams }
-    .from e → let open F.UTxOEnv e in record
-      { slot = slot ; pparams = from pparams }
+  Convertible-UTxOEnv = autoConvertible
 
   Convertible-UTxOState : Convertible UTxOState F.UTxOState
   Convertible-UTxOState = λ where
@@ -424,15 +388,8 @@ instance
       ; donations = ε
       }
 
-  Convertible-ComputationResult : ∀ {e e' a a'}
-    → ⦃ Convertible e e' ⦄
-    → ⦃ Convertible a a' ⦄
-    → Convertible (ComputationResult e a) (F.ComputationResult e' a')
-  Convertible-ComputationResult = λ where
-    .to (success a) → F.Success (to a)
-    .to (failure a) → F.Failure (to a)
-    .from (F.Success a) → success (from a)
-    .from (F.Failure a) → failure (from a)
+  Convertible-ComputationResult : ConvertibleType ComputationResult F.ComputationResult
+  Convertible-ComputationResult = autoConvertible
 
 utxo-step : F.UTxOEnv → F.UTxOState → F.Tx → F.ComputationResult String F.UTxOState
 utxo-step = to UTXO-step

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -435,11 +435,11 @@ instance
     .from (F.Failure a) → failure (from a)
 
 utxo-step : F.UTxOEnv → F.UTxOState → F.Tx → F.ComputationResult String F.UTxOState
-utxo-step e s tx = to $ UTXO-step (from e) (from s) (from tx)
+utxo-step = to UTXO-step
 
 {-# COMPILE GHC utxo-step as utxoStep #-}
 
 utxow-step : F.UTxOEnv → F.UTxOState → F.Tx → F.ComputationResult String F.UTxOState
-utxow-step e s tx = to $ compute Computational-UTXOW (from e) (from s) (from tx)
+utxow-step = to (compute Computational-UTXOW)
 
 {-# COMPILE GHC utxow-step as utxowStep #-}

--- a/src/Tactic/Inline.agda
+++ b/src/Tactic/Inline.agda
@@ -17,6 +17,7 @@ open Debug ("tactic.inline" , 100)
 open import Class.Show
 
 open import Algebra.Core using (Op₁)
+open import Algebra.Definitions.RawMagma using (_,_)
 
 private
   pattern `case_of_ x y = quote case_of_ ∙⟦ x ∣ y ⟧

--- a/src/Tactic/Inline.agda
+++ b/src/Tactic/Inline.agda
@@ -17,7 +17,6 @@ open Debug ("tactic.inline" , 100)
 open import Class.Show
 
 open import Algebra.Core using (Op₁)
-open import Algebra.Definitions.RawMagma using (_,_)
 
 private
   pattern `case_of_ x y = quote case_of_ ∙⟦ x ∣ y ⟧


### PR DESCRIPTION
I had to make a small fix to agda-stdlib-meta to work around agda/agda#7187. I put it on our fork here: input-output-hk/stdlib-meta@4fc4b1ed on top of the `v2.0-rc1` tag.