### PR TITLE
Replace `allEnactable` with `hasParent` in `GOV`

### DIFF
--- a/src/Ledger/Gov/Properties.agda
+++ b/src/Ledger/Gov/Properties.agda
@@ -125,23 +125,23 @@ instance
             × d ≡ govActionDeposit
             × validHFAction prop s enactState
             × (∃[ u ] a ≡ ChangePParams u ⊎ ∃[ w ] a ≡ TreasuryWdrl w → p ≡ ppolicy)
-            × allEnactable' enactState (addAction s (govActionLifetime +ᵉ epoch) (txid , k) addr a prev) ¿
+            × hasParent' enactState s ((txid , k) , a) ¿
             ,′ isNewCommittee a
 
         computeProof = case H of λ where
-          (yes (wf , dep , vHFA , pol , AllEnactable' en) , yes (new , rem , q , refl)) →
+          (yes (wf , dep , vHFA , pol , HasParent' en) , yes (new , rem , q , refl)) →
             case ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ of λ where
               (yes newOk) → success (_ , GOV-Propose (wf , dep , pol , (λ where refl → newOk) , vHFA , en))
               (no ¬p)     → failure (genErrors ¬p)
-          (yes (wf , dep , vHFA , pol , AllEnactable' en) , no notNewComm) → success
+          (yes (wf , dep , vHFA , pol , HasParent' en) , no notNewComm) → success
             (-, GOV-Propose (wf , dep , pol , (λ isNewComm → ⊥-elim (notNewComm (-, -, -, isNewComm))) , vHFA , en))
           (no ¬p , _) → failure (genErrors ¬p)
 
         completeness : ∀ s' → Γ ⊢ s ⇀⦇ inj₂ prop ,GOV'⦈ s' → map proj₁ computeProof ≡ success s'
         completeness s' (GOV-Propose (wf , dep , pol , newOk , vHFA , en)) with H
-        ... | (no ¬p , _) = ⊥-elim (¬p (wf , dep , vHFA , pol , AllEnactable' en))
-        ... | (yes (_ , _ , _ , _ , AllEnactable' _) , no notNewComm) = refl
-        ... | (yes (_ , _ , _ , _ , AllEnactable' _) , yes (new , rem , q , refl))
+        ... | (no ¬p , _) = ⊥-elim (¬p (wf , dep , vHFA , pol , HasParent' en))
+        ... | (yes (_ , _ , _ , _ , HasParent' _) , no notNewComm) = refl
+        ... | (yes (_ , _ , _ , _ , HasParent' _) , yes (new , rem , q , refl))
           rewrite dec-yes ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ (newOk refl) .proj₂ = refl
 
       computeProof : (sig : GovVote ⊎ GovProposal) → _


### PR DESCRIPTION
# Description

This reduces runtime from O(n!) to O(n). We should then prove that `allEnactable` is an invariant of `GOV`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
