### PR TITLE
Fix `hasParent`

### DIFF
--- a/src/Ledger/Gov/Properties.agda
+++ b/src/Ledger/Gov/Properties.agda
@@ -125,7 +125,7 @@ instance
             × d ≡ govActionDeposit
             × validHFAction prop s enactState
             × (∃[ u ] a ≡ ChangePParams u ⊎ ∃[ w ] a ≡ TreasuryWdrl w → p ≡ ppolicy)
-            × hasParent' enactState s ((txid , k) , a) ¿
+            × hasParent' enactState s a prev ¿
             ,′ isNewCommittee a
 
         computeProof = case H of λ where


### PR DESCRIPTION
# Description

`hasParent` was passed the current transaction ID instead of previous transaction ID in the `GOV` rule.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
