### PR TITLE
`CERT` Conformance

### DIFF
--- a/src/Interface/ComputationalRelation.agda
+++ b/src/Interface/ComputationalRelation.agda
@@ -168,20 +168,34 @@ Computational⇒Dec' ⦃ comp = comp ⦄ = Computational⇒Dec comp
 
 open Computational ⦃...⦄
 
+record InjectError Err₁ Err₂ : Set where
+  field injectError : Err₁ → Err₂
+
+open InjectError
+
 instance
+  InjectError-⊥ : InjectError ⊥ Err
+  InjectError-⊥ = λ where
+    .injectError ()
+
+  InjectError-Id : InjectError Err Err
+  InjectError-Id = λ where
+    .injectError → id
+
   Computational-Id : {C S : Set} → Computational (IdSTS {C} {S}) ⊥
   Computational-Id .computeProof _ s _ = success (s , Id-nop)
   Computational-Id .completeness _ _ _ _ Id-nop = refl
 
 module _ {BSTS : C → S → ⊤ → S → Set} ⦃ _ : Computational BSTS Err₁ ⦄ where
-  module _ {STS : C → S → Sig → S → Set} ⦃ _ : Computational STS Err₂ ⦄ where instance
-    Computational-ReflexiveTransitiveClosureᵇ : Computational (ReflexiveTransitiveClosureᵇ BSTS STS) (Err₁ ⊎ Err₂)
-    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s [] = bimap inj₁ (map₂′ BS-base) (computeProof c s tt)
+  module _ {STS : C → S → Sig → S → Set} ⦃ _ : Computational STS Err₂ ⦄
+     ⦃ _ : InjectError Err₁ Err ⦄ ⦃ _ : InjectError Err₂ Err ⦄ where instance
+    Computational-ReflexiveTransitiveClosureᵇ : Computational (ReflexiveTransitiveClosureᵇ BSTS STS) (Err)
+    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s [] = bimap (injectError it) (map₂′ BS-base) (computeProof c s tt)
     Computational-ReflexiveTransitiveClosureᵇ .computeProof c s (sig ∷ sigs) with computeProof c s sig 
     ... | success (s₁ , h) with computeProof c s₁ sigs
     ...   | success (s₂ , hs) = success (s₂ , BS-ind h hs)
-    ...   | failure a = failure a
-    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s (sig ∷ sigs) | failure a = failure (inj₂ a)
+    ...   | failure a = failure (injectError it a)
+    Computational-ReflexiveTransitiveClosureᵇ .computeProof c s (sig ∷ sigs) | failure a = failure (injectError it a)
     Computational-ReflexiveTransitiveClosureᵇ .completeness c s [] s' (BS-base p)
       with computeProof {STS = BSTS} c s tt | completeness _ _ _ _ p
     ... | success x | refl = refl
@@ -191,15 +205,17 @@ module _ {BSTS : C → S → ⊤ → S → Set} ⦃ _ : Computational BSTS Err�
       with computeProof ⦃ Computational-ReflexiveTransitiveClosureᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
     ... | success (s₂ , _) | p = p
 
-  module _ {STS : C × ℕ → S → Sig → S → Set} ⦃ Computational-STS : Computational STS Err₂ ⦄ where instance
-    Computational-ReflexiveTransitiveClosureᵢᵇ' : Computational (_⊢_⇀⟦_⟧ᵢ*'_ BSTS STS) (Err₁ ⊎ Err₂)
+  module _ {STS : C × ℕ → S → Sig → S → Set} ⦃ Computational-STS : Computational STS Err₂ ⦄
+    ⦃ InjectError-Err₁ : InjectError Err₁ Err ⦄ ⦃ InjectError-Err₂ : InjectError Err₂ Err ⦄
+    where instance
+    Computational-ReflexiveTransitiveClosureᵢᵇ' : Computational (_⊢_⇀⟦_⟧ᵢ*'_ BSTS STS) Err
     Computational-ReflexiveTransitiveClosureᵢᵇ' .computeProof c s [] =
-      bimap inj₁ (map₂′ BS-base) (computeProof (proj₁ c) s tt)
+      bimap (injectError it) (map₂′ BS-base) (computeProof (proj₁ c) s tt)
     Computational-ReflexiveTransitiveClosureᵢᵇ' .computeProof c s (sig ∷ sigs) with computeProof c s sig
     ... | success (s₁ , h) with computeProof (proj₁ c , suc (proj₂ c)) s₁ sigs
     ... | success (s₂ , hs) = success (s₂ , BS-ind h hs)
     ... | failure a = failure a
-    Computational-ReflexiveTransitiveClosureᵢᵇ' .computeProof c s (sig ∷ sigs) | failure a = failure (inj₂ a)
+    Computational-ReflexiveTransitiveClosureᵢᵇ' .computeProof c s (sig ∷ sigs) | failure a = failure (injectError it a)
     Computational-ReflexiveTransitiveClosureᵢᵇ' .completeness c s [] s' (BS-base p)
       with computeProof {STS = BSTS} (proj₁ c) s tt | completeness _ _ _ _ p
     ... | success x | refl = refl
@@ -209,16 +225,16 @@ module _ {BSTS : C → S → ⊤ → S → Set} ⦃ _ : Computational BSTS Err�
       with computeProof (proj₁ c , suc (proj₂ c)) s₁ sigs | completeness _ _ _ _ hs
     ...   | success (s₂ , _) | p = p
 
-    Computational-ReflexiveTransitiveClosureᵢᵇ : Computational (ReflexiveTransitiveClosureᵢᵇ BSTS STS) (Err₁ ⊎ Err₂)
+    Computational-ReflexiveTransitiveClosureᵢᵇ : Computational (ReflexiveTransitiveClosureᵢᵇ BSTS STS) Err
     Computational-ReflexiveTransitiveClosureᵢᵇ .computeProof c =
       Computational-ReflexiveTransitiveClosureᵢᵇ' .computeProof (c , 0)
     Computational-ReflexiveTransitiveClosureᵢᵇ .completeness c =
       Computational-ReflexiveTransitiveClosureᵢᵇ' .completeness (c , 0)
 
 Computational-ReflexiveTransitiveClosure : {STS : C → S → Sig → S → Set} → ⦃ Computational STS Err ⦄
-  → Computational (ReflexiveTransitiveClosure STS) (⊥ ⊎ Err)
+  → Computational (ReflexiveTransitiveClosure STS) Err
 Computational-ReflexiveTransitiveClosure = it
 
 Computational-ReflexiveTransitiveClosureᵢ : {STS : C × ℕ → S → Sig → S → Set} → ⦃ Computational STS Err ⦄
-  → Computational (ReflexiveTransitiveClosureᵢ STS) (⊥ ⊎ Err)
+  → Computational (ReflexiveTransitiveClosureᵢ STS) Err
 Computational-ReflexiveTransitiveClosureᵢ = it

--- a/src/Ledger/Chain/Properties.agda
+++ b/src/Ledger/Chain/Properties.agda
@@ -22,7 +22,7 @@ instance
   Computational-CHAIN : Computational _⊢_⇀⦇_,CHAIN⦈_ String
   Computational-CHAIN .computeProof Γ s b = do
     _ , neStep ← map₁ ⊥-elim $ computeProof {STS = _⊢_⇀⦇_,NEWEPOCH⦈_} _ _ _
-    _ , lsStep ← map₁ (λ where (inj₁ ()); (inj₂ x) → x) $ computeProof _ _ _
+    _ , lsStep ← computeProof _ _ _
     success (_ , CHAIN neStep lsStep)
   Computational-CHAIN .completeness Γ s b s' (CHAIN neStep lsStep)
     with recomputeProof neStep | completeness _ _ _ _ neStep

--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -148,9 +148,9 @@ data
 \begin{code}
 
   DELEG-delegate : let open PParams pp in
-    ∙ (c ∉ dom rwds → d ≡ poolDeposit)
+    ∙ (c ∉ dom rwds → d ≡ keyDeposit)
     ∙ (c ∈ dom rwds → d ≡ 0)
-    ∙ mc ∈ mapˢ just (dom pools)
+    ∙ mc ∈ mapˢ just (dom pools) ∪ ❴ nothing ❵
       ────────────────────────────────
       ⟦ pp , pools ⟧ᵈᵉ ⊢
         ⟦ vDelegs , sDelegs , rwds ⟧ᵈ ⇀⦇ delegate c mv mc d ,DELEG⦈

--- a/src/Ledger/Gov/Properties.agda
+++ b/src/Ledger/Gov/Properties.agda
@@ -152,7 +152,7 @@ instance
       completeness (inj₁ s) = GoVote.completeness s
       completeness (inj₂ s) = GoProp.completeness s
 
-Computational-GOV : Computational _⊢_⇀⦇_,GOV⦈_ (⊥ ⊎ String)
+Computational-GOV : Computational _⊢_⇀⦇_,GOV⦈_ String
 Computational-GOV = it
 
 allEnactable-singleton : ∀ {aid s es} → getHash (s .prevAction) ≡ getHashES es (s .action)

--- a/src/Ledger/Ledger/Properties.agda
+++ b/src/Ledger/Ledger/Properties.agda
@@ -48,8 +48,8 @@ instance
       computeProof = case isValid ≟ true of λ where
         (yes p) → do
           (utxoSt' , utxoStep) ← computeUtxow utxoΓ utxoSt tx
-          (certSt' , certStep) ← map₁ (λ where (inj₁ x) → x; (inj₂ x) → x) $ computeCerts certΓ certSt txcerts
-          (govSt'  , govStep)  ← map₁ (λ where (inj₁ ());    (inj₂ x) → x) $ computeGov   govΓ  govSt  (txgov txb)
+          (certSt' , certStep) ← computeCerts certΓ certSt txcerts
+          (govSt'  , govStep)  ← computeGov   govΓ  govSt  (txgov txb)
           success (_ , LEDGER-V⋯ p utxoStep certStep govStep)
         (no ¬p) → do
           (utxoSt' , utxoStep) ← computeUtxow utxoΓ utxoSt tx
@@ -73,7 +73,7 @@ instance
         with computeUtxow utxoΓ utxoSt tx | complete _ _ _ _ utxoStep
       ... | success (utxoSt' , _) | refl = refl
 
-Computational-LEDGERS : Computational _⊢_⇀⦇_,LEDGERS⦈_ (⊥ ⊎ String)
+Computational-LEDGERS : Computational _⊢_⇀⦇_,LEDGERS⦈_ String
 Computational-LEDGERS = it
 
 instance

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -77,6 +77,7 @@ record PParams : Set where
 \begin{code}
         a b                           : ℕ
         minUTxOValue poolDeposit      : Coin
+        keyDeposit                    : Coin
         coinsPerUTxOWord              : Coin
         minFeeRefScriptCoinsPerByte   : ℚ
         prices                        : Prices

--- a/src/Ledger/Ratify/Properties.agda
+++ b/src/Ledger/Ratify/Properties.agda
@@ -72,7 +72,7 @@ instance
   Computational-RATIFY' : Computational _⊢_⇀⦇_,RATIFY'⦈_ ⊥
   Computational-RATIFY' = record {Implementation}
 
-Computational-RATIFY : Computational _⊢_⇀⦇_,RATIFY⦈_ (⊥ ⊎ ⊥)
+Computational-RATIFY : Computational _⊢_⇀⦇_,RATIFY⦈_ ⊥
 Computational-RATIFY = it
 
 RATIFY-total : ∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,RATIFY⦈ s'
@@ -80,4 +80,4 @@ RATIFY-total = ReflexiveTransitiveClosure-total (Implementation.RATIFY'-total _ 
 
 RATIFY-complete : ∀ {Γ s sig s'} →
   Γ ⊢ s ⇀⦇ sig ,RATIFY⦈ s' → RATIFY-total {Γ} {s} {sig} .proj₁ ≡ s'
-RATIFY-complete = computational⇒rightUnique it (RATIFY-total .proj₂)
+RATIFY-complete = computational⇒rightUnique Computational-RATIFY (RATIFY-total .proj₂)

--- a/src/Ledger/hs-src/test/UtxowSpec.hs
+++ b/src/Ledger/hs-src/test/UtxowSpec.hs
@@ -42,7 +42,7 @@ a2 :: Addr
 a2 = 2
 
 initUTxO :: UTxO
-initUTxO = [ (MkTxId 0,  0) .-> (a0, (1000, (Nothing, Nothing))) ]
+initUTxO = MkHSMap [ (MkTxId 0,  0) .-> (a0, (1000, (Nothing, Nothing))) ]
 
 initState :: UTxOState
 initState = MkUTxOState {utxo = initUTxO, fees = 0}
@@ -50,7 +50,7 @@ initState = MkUTxOState {utxo = initUTxO, fees = 0}
 data SimpleTxBody = MkSimpleTxBody
   { stxins     :: [TxIn]
   , srefInputs :: [TxIn]
-  , stxouts    :: [(Ix, TxOut)]
+  , stxouts    :: HSMap Ix TxOut
   , stxvldt    :: (Maybe Integer, Maybe Integer)
   , stxid      :: TxId
   , stxcerts   :: [TxCert]}
@@ -70,8 +70,9 @@ testTxBody1 :: TxBody
 testTxBody1 = bodyFromSimple initParams $ MkSimpleTxBody
   { stxins     = [(MkTxId 0, 0)]
   , srefInputs = []
-  , stxouts    = [ 0 .-> (a0, (890, (Nothing, Nothing)))
-                 , 1 .-> (a1, (100, (Nothing, Nothing))) ]
+  , stxouts    = MkHSMap
+                   [ 0 .-> (a0, (890, (Nothing, Nothing)))
+                   , 1 .-> (a1, (100, (Nothing, Nothing))) ]
   , stxvldt    = (Nothing, Just 10)
   , stxid      = MkTxId 1
   , stxcerts   = []}
@@ -79,15 +80,16 @@ testTxBody1 = bodyFromSimple initParams $ MkSimpleTxBody
 testTx1 :: Tx
 testTx1 = MkTx
   { body = testTxBody1
-  , wits = MkTxWitnesses { vkSigs = [(0, 1)], scripts = [], txdats = [], txrdmrs = [] }
+  , wits = MkTxWitnesses { vkSigs = [(0, 1)], scripts = [], txdats = MkHSMap [], txrdmrs = MkHSMap [] }
   , txAD = Nothing }
 
 testTxBody2 :: TxBody
 testTxBody2 = bodyFromSimple initParams $ MkSimpleTxBody
   { stxins     = [(MkTxId 1, 1)]
   , srefInputs = [(MkTxId 1, 0)]
-  , stxouts    = [ 0 .-> (a2, (10, (Nothing, Nothing)))
-                 , 1 .-> (a1, (80, (Nothing, Nothing))) ]
+  , stxouts    = MkHSMap 
+                   [ 0 .-> (a2, (10, (Nothing, Nothing)))
+                   , 1 .-> (a1, (80, (Nothing, Nothing))) ]
   , stxvldt    = (Nothing, Just 10)
   , stxid      = MkTxId 2
   , stxcerts   = []}
@@ -95,7 +97,7 @@ testTxBody2 = bodyFromSimple initParams $ MkSimpleTxBody
 testTx2 :: Tx
 testTx2 = MkTx
   { body = testTxBody2
-  , wits = MkTxWitnesses { vkSigs = [(1, 3)], scripts = [], txdats = [], txrdmrs = [] }
+  , wits = MkTxWitnesses { vkSigs = [(1, 3)], scripts = [], txdats = MkHSMap [], txrdmrs = MkHSMap [] }
   , txAD = Nothing }
 
 utxowSteps :: UTxOEnv -> UTxOState -> [Tx] -> ComputationResult Text UTxOState
@@ -108,8 +110,9 @@ spec = do
   describe "utxowSteps" $
     it "results in the expected state" $
       utxowSteps initEnv initState [testTx1, testTx2] @?= Success (MkUTxOState
-        { utxo = [ (MkTxId 1,0) .-> (a0, (890, (Nothing, Nothing)))
-                 , (MkTxId 2,0) .-> (a2, (10,  (Nothing, Nothing)))
-                 , (MkTxId 2,1) .-> (a1, (80,  (Nothing, Nothing))) ]
+        { utxo = MkHSMap
+                   [ (MkTxId 1,0) .-> (a0, (890, (Nothing, Nothing)))
+                   , (MkTxId 2,0) .-> (a2, (10,  (Nothing, Nothing)))
+                   , (MkTxId 2,1) .-> (a1, (80,  (Nothing, Nothing))) ]
         , fees = 20
         })

--- a/src/ScriptVerification/Lib.agda
+++ b/src/ScriptVerification/Lib.agda
@@ -32,6 +32,7 @@ createEnv s = record { slot = s ;
                                ; b = 155381
                                ; minUTxOValue = 0
                                ; poolDeposit = 500000000 -- lovelace
+                               ; keyDeposit = 500000000 -- lovelace
                                ; coinsPerUTxOWord = 4310 --lovelace (coinsPetUTxoByte)
                                ; minFeeRefScriptCoinsPerByte = 1ℚ -- unknown for now
                                ; prices = tt -- fix this


### PR DESCRIPTION
# Description

Makes some changes for conformance testing the `CERT` rule:
 * Added necessary `LedgerTypes` and `Convertible` instances
 * Added a newtype wrapper for `HSMap` to make it easier to work with maps in conformance testing
 * ~~Removed `CommutativeMonoid` requirement from `_∪⁺_` and `aggregate₊` (I ended up not actually needing this, but I think it still makes sense)~~
 * Replaced some hard-coded error messages with `genErrors`
 * Added `InjectError` to simplify error message types

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
