### PR TITLE
Don't parameterise the HasEmptySet class on a Theory

### DIFF
--- a/src/Interface/HasEmptySet.agda
+++ b/src/Interface/HasEmptySet.agda
@@ -1,21 +1,9 @@
 {-# OPTIONS --safe #-}
 
-open import Axiom.Set using (Theory)
-
-module Interface.HasEmptySet (th : Theory) where
-
-open Theory th renaming (Set to ℙ_; ∅ to ∅ˢ)
-open import Axiom.Set.Map th
+module Interface.HasEmptySet where
 
 record HasEmptySet (A : Set) : Set where
   field
     ∅ : A
-
-instance
-  HasEmptySet-Set : {A : Set} → HasEmptySet (ℙ A)
-  HasEmptySet-Set = record { ∅ = ∅ˢ }
-
-  HasEmptySet-Map : {A B : Set} → HasEmptySet (Map A B)
-  HasEmptySet-Map = record { ∅ = ∅ᵐ }
 
 open HasEmptySet ⦃...⦄ public

--- a/src/Interface/HasEmptySet/Instances.agda
+++ b/src/Interface/HasEmptySet/Instances.agda
@@ -1,0 +1,16 @@
+{-# OPTIONS --safe #-}
+
+open import Axiom.Set using (Theory)
+
+module Interface.HasEmptySet.Instances (th : Theory) where
+
+open import Interface.HasEmptySet
+open Theory th renaming (Set to ℙ_; ∅ to ∅ˢ)
+open import Axiom.Set.Map th
+
+instance
+  HasEmptySet-Set : {A : Set} → HasEmptySet (ℙ A)
+  HasEmptySet-Set = record { ∅ = ∅ˢ }
+
+  HasEmptySet-Map : {A B : Set} → HasEmptySet (Map A B)
+  HasEmptySet-Map = record { ∅ = ∅ᵐ }

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -33,7 +33,8 @@ open import Tactic.Premises public
 
 open import Ledger.Set renaming (∅ to ∅ˢ; ❴_❵ to ❴_❵ˢ) public
 open import Interface.HasSingleton th public
-open import Interface.HasEmptySet th public
+open import Interface.HasEmptySet public
+open import Interface.HasEmptySet.Instances th public
 
 dec-de-morgan : ∀{P Q : Set} → ⦃ P ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
 dec-de-morgan ⦃ ⁇ no ¬p ⦄ ¬pq = inj₁ ¬p


### PR DESCRIPTION
Only the instances need a theory, so I split them out into `Interface.HasEmptySet.Instances`. With this change instance search doesn't have to consider the particular theory, only the set representation.

It does mean that we can't have different empty sets for different theories with the same underlying set representation, but I don't think that's something we are likely to need.