### PR TITLE
Make Credential a proper data type

### DIFF
--- a/src/Ledger/Foreign/HSLedger/BaseTypes.agda
+++ b/src/Ledger/Foreign/HSLedger/BaseTypes.agda
@@ -46,18 +46,14 @@ instance
   -- Since the foreign address is just a number, we do bad stuff here
   Convertible-Addr : Convertible Addr F.Addr
   Convertible-Addr = λ where
-    .to → λ where (inj₁ record { pay = inj₁ x }) → x
-                  (inj₁ record { pay = inj₂ x }) → x
-                  (inj₂ record { pay = inj₁ x }) → x
-                  (inj₂ record { pay = inj₂ x }) → x
-    .from n → inj₁ record { net = _ ; pay = inj₁ n ; stake = inj₁ 0 }
+    .to → λ where (inj₁ record { pay = KeyHashObj x }) → x
+                  (inj₁ record { pay = ScriptObj  x }) → x
+                  (inj₂ record { pay = KeyHashObj x }) → x
+                  (inj₂ record { pay = ScriptObj  x }) → x
+    .from n → inj₁ record { net = _ ; pay = KeyHashObj n ; stake = KeyHashObj 0 }
 
   Convertible-Credential : Convertible Credential F.Credential
-  Convertible-Credential = λ where
-    .to (inj₁ kh) → F.KeyHashObj kh
-    .to (inj₂ sh) → F.ScriptObj sh
-    .from (F.ScriptObj sh) → inj₂ sh
-    .from (F.KeyHashObj kh) → inj₁ kh
+  Convertible-Credential = autoConvertible
 
   Convertible-GovRole : Convertible GovRole F.GovRole
   Convertible-GovRole = autoConvertible

--- a/src/Ledger/ScriptValidation.agda
+++ b/src/Ledger/ScriptValidation.agda
@@ -121,14 +121,14 @@ rwdScripts a =
 certScripts : DCert → Maybe (ScriptPurpose × ScriptHash)
 certScripts d with ¿ DelegateOrDeReg d ¿
 ... | no ¬p = nothing
-certScripts c@(delegate  (inj₁ x) _ _ _) | yes p = nothing
-certScripts c@(delegate  (inj₂ y) _ _ _) | yes p = just (Cert c , y)
-certScripts c@(dereg     (inj₁ x))       | yes p = nothing
-certScripts c@(dereg     (inj₂ y))       | yes p = just (Cert c , y)
-certScripts c@(regdrep   (inj₁ x) _ _)   | yes p = nothing
-certScripts c@(regdrep   (inj₂ y) _ _)   | yes p = just (Cert c , y)
-certScripts c@(deregdrep (inj₁ x))       | yes p = nothing
-certScripts c@(deregdrep (inj₂ y))       | yes p = just (Cert c , y)
+certScripts c@(delegate  (KeyHashObj x) _ _ _) | yes p = nothing
+certScripts c@(delegate  (ScriptObj  y) _ _ _) | yes p = just (Cert c , y)
+certScripts c@(dereg     (KeyHashObj x))       | yes p = nothing
+certScripts c@(dereg     (ScriptObj  y))       | yes p = just (Cert c , y)
+certScripts c@(regdrep   (KeyHashObj x) _ _)   | yes p = nothing
+certScripts c@(regdrep   (ScriptObj  y) _ _)   | yes p = just (Cert c , y)
+certScripts c@(deregdrep (KeyHashObj x))       | yes p = nothing
+certScripts c@(deregdrep (ScriptObj  y))       | yes p = just (Cert c , y)
 
 private
   scriptsNeeded : UTxO → TxBody → ℙ (ScriptPurpose × ScriptHash)

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -66,7 +66,7 @@ the transaction body are:
   field crypto : _
   open Crypto crypto public
   open Ledger.TokenAlgebra ScriptHash public
-  open Ledger.Address Network KeyHash ScriptHash public
+  open Ledger.Address Network KeyHash ScriptHash ⦃ it ⦄ ⦃ it ⦄ ⦃ it ⦄ public
 
   field epochStructure : _
   open EpochStructure epochStructure public

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -25,17 +25,17 @@ only if it is present.
 \begin{AgdaMultiCode}
 \begin{code}
 getVKeys : ℙ Credential → ℙ KeyHash
-getVKeys = mapPartial isInj₁
+getVKeys = mapPartial isKeyHashObj
 
 getScripts : ℙ Credential → ℙ ScriptHash
-getScripts = mapPartial isInj₂
+getScripts = mapPartial isScriptObj
 
 credsNeeded : UTxO → TxBody → ℙ (ScriptPurpose × Credential)
 credsNeeded utxo txb
   =  mapˢ (λ (i , o)  → (Spend  i , payCred (proj₁ o))) ((utxo ∣ txins) ˢ)
   ∪  mapˢ (λ a        → (Rwrd   a , RwdAddr.stake a)) (dom (txwdrls .proj₁))
   ∪  mapˢ (λ c        → (Cert   c , cwitness c)) (fromList txcerts)
-  ∪  mapˢ (λ x        → (Mint   x , inj₂ x)) (policies mint)
+  ∪  mapˢ (λ x        → (Mint   x , ScriptObj x)) (policies mint)
   ∪  mapˢ (λ v        → (Vote   v , proj₂ v)) (fromList $ map GovVote.voter txvote)
   ∪  mapPartial (λ p  → case  p .GovProposal.policy of
 \end{code}
@@ -43,7 +43,7 @@ credsNeeded utxo txb
     λ where
 \end{code}
 \begin{code}
-                              (just sh)  → just (Propose  p , inj₂ sh)
+                              (just sh)  → just (Propose  p , ScriptObj sh)
                               nothing    → nothing) (fromList txprop)
 \end{code}
 \begin{code}[hide]

--- a/src/ScriptVerification/HelloWorld.agda
+++ b/src/ScriptVerification/HelloWorld.agda
@@ -34,8 +34,8 @@ initEnv = createEnv 0
 
 initTxOut : TxOut
 initTxOut = inj₁ (record { net = tt ;
-                           pay = inj₂ 777 ;
-                           stake = inj₂ 777 })
+                           pay = ScriptObj 777 ;
+                           stake = ScriptObj 777 })
                            , 10 , nothing , nothing
 
 script : TxIn × TxOut
@@ -51,8 +51,8 @@ succeedTx = record { body = record
                          ; txouts = fromListIx ((6 , initTxOut)
                                                ∷ (5
                                                  , ((inj₁ (record { net = tt ;
-                                                                    pay = inj₁ 5 ;
-                                                                    stake = inj₁ 5 }))
+                                                                    pay = KeyHashObj 5 ;
+                                                                    stake = KeyHashObj 5 }))
                                                  , (1000000000000 - 10000000000) , nothing , nothing))
                                                ∷ [])
                          ; txfee = 10000000000

--- a/src/ScriptVerification/Lib.agda
+++ b/src/ScriptVerification/Lib.agda
@@ -74,7 +74,7 @@ createUTxO : (index : ℕ)
            → Maybe (D ⊎ DataHash)
            → TxIn × TxOut
 createUTxO index wallet value d = (index , index)
-                                , (inj₁ (record { net = tt ; pay = inj₁ wallet ; stake = inj₁ wallet })
+                                , (inj₁ (record { net = tt ; pay = KeyHashObj wallet ; stake = KeyHashObj wallet })
                                   , value , d , nothing)
 
 createInitUtxoState : (wallets : ℕ)

--- a/src/ScriptVerification/SucceedIfNumber.agda
+++ b/src/ScriptVerification/SucceedIfNumber.agda
@@ -43,15 +43,15 @@ initEnv = createEnv 0
 -- initTxOut for script with datum reference
 initTxOut : TxOut
 initTxOut = inj₁ (record { net = tt ;
-                           pay = inj₂ 777 ;
-                           stake = inj₂ 777 })
+                           pay = ScriptObj 777 ;
+                           stake = ScriptObj 777 })
                            , 10 , just (inj₂ 99) , nothing
 
 -- initTxOut for script without datum reference
 initTxOut' : TxOut
 initTxOut' = inj₁ (record { net = tt ;
-                           pay = inj₂ 888 ;
-                           stake = inj₂ 888 })
+                           pay = ScriptObj 888 ;
+                           stake = ScriptObj 888 })
                            , 10 , nothing , nothing
 
 scriptDatum : TxIn × TxOut
@@ -73,8 +73,8 @@ succeedTx = record { body = record
                          ; txouts = fromListIx ((6 , initTxOut)
                                                 ∷ (5
                                                   , ((inj₁ (record { net = tt ;
-                                                                     pay = inj₁ 5 ;
-                                                                     stake = inj₁ 5 }))
+                                                                     pay = KeyHashObj 5 ;
+                                                                     stake = KeyHashObj 5 }))
                                                   , (1000000000000 - 10000000000) , nothing , nothing))
                                                 ∷ [])
                          ; txfee = 10000000000


### PR DESCRIPTION
This simplifies the marshalling to Haskell since we want a data type on the Haskell side and not an `Either`. Also it makes the spec easier to follow.