### PR TITLE
Capitalization of Sec heads to conform with previous eras

### DIFF
--- a/src/Ledger/BaseTypes.lagda
+++ b/src/Ledger/BaseTypes.lagda
@@ -1,4 +1,4 @@
-\section{Base types}
+\section{Base Types}
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
 

--- a/src/Ledger/Certs.lagda
+++ b/src/Ledger/Certs.lagda
@@ -159,7 +159,7 @@ private variable
   wdrls  : RwdAddr ⇀ Coin
 \end{code}
 
-\subsection{Removal of pointer addresses, genesis delegations and MIR certificates}
+\subsection{Removal of Pointer Addresses, Genesis Delegations and MIR Certificates}
 
 In the Conway era, support for pointer addresses, genesis delegations
 and MIR certificates is removed. In \DState, this means that the four
@@ -183,7 +183,7 @@ are two separate features. In fact, preventing this could weaken the
 security of the chain, since security relies on high participation of
 honest stake holders.
 
-\subsection{Governance certificate rules}
+\subsection{Governance Certificate Rules}
 
 The rules for transition systems dealing with individual certificates
 are defined in Figures~\ref{fig:sts:aux-cert-deleg},

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -1,4 +1,4 @@
-\section{Blockchain layer}
+\section{Blockchain Layer}
 
 \begin{code}[hide]
 {-# OPTIONS --safe #-}

--- a/src/Ledger/Crypto.lagda
+++ b/src/Ledger/Crypto.lagda
@@ -1,4 +1,4 @@
-\section{Cryptographic primitives}
+\section{Cryptographic Primitives}
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
 module Ledger.Crypto where

--- a/src/Ledger/Epoch.lagda
+++ b/src/Ledger/Epoch.lagda
@@ -1,4 +1,4 @@
-\section{Epoch boundary}
+\section{Epoch Boundary}
 
 \begin{code}[hide]
 {-# OPTIONS --safe #-}

--- a/src/Ledger/EssentialAgda.lagda
+++ b/src/Ledger/EssentialAgda.lagda
@@ -1,4 +1,4 @@
-\section{Appendix: Agda essentials}
+\section{Agda Essentials}
 \label{sec:appendix-agda-essentials}
 Here we describe some of the essential concepts and syntax of the Agda programming language and proof assistant.
 The goal is to provide some background for readers who are not already familiar with Agda, to help them
@@ -13,7 +13,7 @@ open import Prelude using (Type)
 open import Data.Nat
 \end{code}
 
-\subsection{Record types}
+\subsection{Record Types}
 
 A \defn{record} is a product with named accessors for the individual fields.  It provides a way to
 define a type that groups together inhabitants of other types.\\[6pt]

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -1,4 +1,4 @@
-\section{Governance actions}
+\section{Governance Actions}
 \label{sec:governance-actions}
 We introduce three distinct bodies that have specific functions in the new governance framework:
 \begin{enumerate}
@@ -120,13 +120,13 @@ Figure~\ref{defs:governance} defines several data types used to represent govern
   obsoleting nodes that are unable to handle the upgrade.}
 
 
-% \subsection{Voting and ratification}
+% \subsection{Voting and Ratification}
 % \label{sec:voting-and-ratification}
 % Every governance action must be ratified by at least two of these three bodies using their on-chain \defn{votes}.
 % The type of action and the state of the governance system determines which bodies must ratify it.
 % Ratified actions are then \defn{enacted} on-chain, following a set of rules (see Section~\ref{sec:enactment} and Figure~\ref{fig:enactment-types}).
 
-\subsection{Hash protection}
+\subsection{Hash Protection}
 \label{sec:hash-protection}
 
 For some types of governance actions, enactment requires a second
@@ -220,7 +220,7 @@ instance
 \caption{Vote and proposal types}
 \label{defs:governance-votes}
 \end{figure*}
-\subsection{Votes and proposals}
+\subsection{Votes and Proposals}
 
 \begin{figure*}[h]
 \begin{code}

--- a/src/Ledger/Introduction.lagda
+++ b/src/Ledger/Introduction.lagda
@@ -54,7 +54,7 @@ Conway \cite{cip1694} & Complete & Partial & Partial \\
 \end{longtable}
 \end{NoConway}
 
-\subsection{A note on Agda}
+\subsection{A Note on Agda}
 
 This specification is written using the Agda programming language and
 proof assistant \cite{agda2023}. We have spent a lot of time on making
@@ -69,7 +69,7 @@ expression, please feel free to open an issue in our
 \href{https://github.com/input-output-hk/formal-ledger-specifications/issues}{repository}
 with the `notation' label.
 
-\subsection{Separation of concerns}
+\subsection{Separation of Concerns}
 
 The \emph{Cardano Node} consists of three pieces:
 
@@ -90,7 +90,7 @@ initial state \(s\), a signal \(b\) and a final state \(s'\). The ledger consist
 25-ish (depending on the version) such relations that depend on each
 other, forming a directed graph that is almost a tree.
 
-\subsection{Reflexive-transitive closure}
+\subsection{Reflexive-transitive Closure}
 
 Some STS (state transition system) relations need to be applied as
 many times as they can to arrive at a final state. Since we use this
@@ -188,7 +188,7 @@ correct. This is indeed something we have done, and the same source
 code that generates this document also generates a Haskell library
 that lets anyone run this code.
 
-\subsection{Sets \& maps}
+\subsection{Sets \& Maps}
 \label{sec:sets-maps}
 
 The ledger heavily uses set theory. For various reasons it was
@@ -232,7 +232,7 @@ module _ (ℙ_ : Type → Type) (_∈_ : ∀ {A : Type} → A → ℙ A → Type
 \end{code}
 \end{figure*}
 
-\subsection{Propositions as types, properties and relations}
+\subsection{Propositions as Types, Properties and Relations}
 
 In type theory we represent propositions as types and proofs of a proposition as
 elements of the corresponding type.
@@ -245,7 +245,7 @@ asserting that the relation \AgdaFunction{R} holds between \AgdaBound{x} and \Ag
 Thus, such a relation is a function of type \AgdaBound{A}~\AgdaFunction{×}~\AgdaBound{B}~\AgdaSymbol{→}~\Type
 or \AgdaBound{A}~\AgdaSymbol{→}~\AgdaBound{B}~\AgdaSymbol{→}~\Type.
 
-\subsection{Superscripts and other special notations}
+\subsection{Superscripts and Other Special Notations}
 
 In the current version of this specification, superscript letters are
 heavily used for things such as disambiguations or type

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -1,4 +1,4 @@
-\section{Protocol parameters}
+\section{Protocol Parameters}
 \label{sec:protocol-parameters}
 This section defines the adjustable protocol parameters of the Cardano ledger.
 These parameters are used in block validation and can affect various features of the system,

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -36,7 +36,7 @@ new constitution, and ensures that the in principle arbitrary semantic
 changes caused by enacting a hard-fork do not have unintended
 consequences in combination with other actions.
 
-\subsection{Ratification requirements}
+\subsection{Ratification Requirements}
 \label{sec:ratification-requirements}
 Figure~\ref{fig:ratification-requirements} details the ratification
 requirements for each governance action scenario. For a governance
@@ -165,7 +165,7 @@ canVote pp a r = Is-just (threshold pp nothing a r)
 \label{fig:ratification-requirements}
 \end{figure*}
 
-\subsection{Protocol parameters and governance actions}
+\subsection{Protocol Parameters and Governance Actions}
 \label{sec:protocol-parameters-and-governance-actions}
 Voting thresholds for protocol parameters can be set by group, and we do not require that each protocol
 parameter governance action be confined to a single group. In case a governance action carries updates
@@ -177,7 +177,7 @@ security-relevant protocol parameters. Any proposal that includes a
 change to a security-relevant protocol parameter must also be accepted
 by at least half of the SPO stake.
 
-\subsection{Ratification restrictions}
+\subsection{Ratification Restrictions}
 \label{sec:ratification-restrictions}
 \begin{figure*}[h!]
 \begin{AgdaMultiCode}

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -1,4 +1,4 @@
-\section{Token algebras}
+\section{Token Algebras}
 \label{sec:token-algebra}
 \begin{figure*}[h]
 \begin{AgdaMultiCode}


### PR DESCRIPTION
# Description

This closes issue #479.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
