### PR TITLE
Add support for Plutus versions

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -307,8 +307,22 @@ record Theoryᵈ : Type₁ where
   field
     ∈-sp : ⦃ DecEq A ⦄ → spec-∈ A
     _∈?_ : ⦃ DecEq A ⦄ → Decidable² (_∈_ {A = A})
-    all? : ⦃ DecEq A ⦄ → {P : A → Type} (P? : Decidable¹ P) {X : Set A} → Dec (All P X)
-    any? : ⦃ DecEq A ⦄ → {P : A → Type} (P? : Decidable¹ P) (X : Set A) → Dec (Any P X)
+    all? : {P : A → Type} (P? : Decidable¹ P) {X : Set A} → Dec (All P X)
+    any? : {P : A → Type} (P? : Decidable¹ P) (X : Set A) → Dec (Any P X)
+
+
+  module _ {A : Type} {P : A → Type} where
+    module _ ⦃ _ : P ⁇¹ ⦄ where instance
+      Dec-Allˢ : All P ⁇¹
+      Dec-Allˢ = ⁇¹ λ x → all? dec¹ {x}
+
+      Dec-Anyˢ : Any P ⁇¹
+      Dec-Anyˢ = ⁇¹ any? dec¹
+
+    module _ (P? : Decidable¹ P) where
+      allᵇ anyᵇ : (X : Set A) → Bool
+      allᵇ X = ⌊ all? P? {X} ⌋
+      anyᵇ X = ⌊ any? P? X   ⌋
 
   module _ {A : Type} ⦃ _ : DecEq A ⦄ where
 
@@ -318,18 +332,6 @@ record Theoryᵈ : Type₁ where
     instance
       Dec-∈ : _∈_ {A = A} ⁇²
       Dec-∈ = ⁇² _∈?_
-
-    module _ {P : A → Type} ⦃ _ : P ⁇¹ ⦄ where instance
-      Dec-Allˢ : All P ⁇¹
-      Dec-Allˢ = ⁇¹ λ x → all? dec¹ {x}
-
-      Dec-Anyˢ : Any P ⁇¹
-      Dec-Anyˢ = ⁇¹ any? dec¹
-
-    module _ {P : A → Type} (P? : Decidable¹ P) where
-      allᵇ anyᵇ : (X : Set A) → Bool
-      allᵇ X = ⌊ all? P? {X} ⌋
-      anyᵇ X = ⌊ any? P? X   ⌋
 
     _ = _∈_  {A = A} ⁇² ∋ it
     _ = _⊆_  {A = A} ⁇² ∋ it

--- a/src/Interface/IsSet.agda
+++ b/src/Interface/IsSet.agda
@@ -31,6 +31,11 @@ All-syntax : ∀ {A X} ⦃ _ : IsSet X A ⦄ → (A → Type) → X → Type
 All-syntax P X = All P (toSet X)
 syntax All-syntax (λ x → P) l = ∀[ x ∈ l ] P
 
+infix 2 Ex-syntax
+Ex-syntax : ∀ {A X} ⦃ _ : IsSet X A ⦄ → (A → Type) → X → Type
+Ex-syntax P X = Any P (toSet X)
+syntax Ex-syntax (λ x → P) l = ∃[ x ∈ l ] P
+
 module _ ⦃ _ : IsSet X (A × B) ⦄ where
   dom : X → Set A
   dom = Rel.dom ∘ toSet

--- a/src/Ledger/Address.lagda
+++ b/src/Ledger/Address.lagda
@@ -104,6 +104,14 @@ stakeCred (inj₂ _) = nothing
 netId (inj₁ record {net = net}) = net
 netId (inj₂ record {net = net}) = net
 
+data isBootstrapAddr : Addr → Set where
+ IsBootstrapAddr : ∀ a → isBootstrapAddr (inj₂ a)
+
+instance
+  isBootstrapAddr? : ∀ {a} → isBootstrapAddr a ⁇
+  isBootstrapAddr? {inj₁ _} = ⁇ no λ ()
+  isBootstrapAddr? {inj₂ a} = ⁇ yes (IsBootstrapAddr a)
+
 instance
   unquoteDecl DecEq-Credential = derive-DecEq ((quote Credential , DecEq-Credential) ∷ [])
 

--- a/src/Ledger/Ledger/Properties.agda
+++ b/src/Ledger/Ledger/Properties.agda
@@ -116,8 +116,8 @@ module _ where
     where open Tx; open TxBody; open UTxOState; open LState
 
   LEDGER-pov : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
-  LEDGER-pov h (LEDGER-V⋯ _ (UTXOW-inductive⋯ _ _ _ _ _ _ _ st) _ _) = pov h st
-  LEDGER-pov h (LEDGER-I⋯ _ (UTXOW-inductive⋯ _ _ _ _ _ _ _ st))     = pov h st
+  LEDGER-pov h (LEDGER-V⋯ _ (UTXOW⇒UTXO st) _ _) = pov h st
+  LEDGER-pov h (LEDGER-I⋯ _ (UTXOW⇒UTXO st))     = pov h st
 
   data FreshTxs : LEnv → LState → List Tx → Type where
     []-Fresh : FreshTxs Γ s []
@@ -154,7 +154,7 @@ module _  -- ASSUMPTIONS (TODO: eliminate/prove these) --
                       → filterˢ isGADeposit (dom ( deps ∣ certRefund c ᶜ ˢ )) ≡ᵉ filterˢ isGADeposit (dom (deps ˢ))}
   where
   module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {DepositPurpose})
-  pattern UTXOW-UTXOS x = UTXOW-inductive⋯ _ _ _ _ _ _ _ (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ x)
+  pattern UTXOW-UTXOS x = UTXOW⇒UTXO (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ x)
 
   filterGA : ∀ txid n → filterˢ isGADeposit ❴ GovActionDeposit (txid , n) ❵ ≡ᵉ ❴ GovActionDeposit (txid , n) ❵
   proj₁ (filterGA txid n) {a} x = (proj₂ (from ∈-filter x)) where open Equivalence

--- a/src/Ledger/Properties.agda
+++ b/src/Ledger/Properties.agda
@@ -127,10 +127,8 @@ module _ (s : ChainState) where
     propose-minSpend : noRefundCert (txcerts txb)
       → coin (consumed pparams utxoSt txb) ≥ length (txprop txb) * govActionDeposit
     propose-minSpend noRef = case valid of λ where
-      (_ , LEDGER-V (_ , (UTXOW-inductive⋯ _ _ _ _ _ _ _ x) , _ , _)) →
-        gmsc {indexedSum-∪⁺-hom} {indexedSum-⊆} x noRef
-      (_ , LEDGER-I (_ , (UTXOW-inductive⋯ _ _ _ _ _ _ _ x))) →
-        gmsc {indexedSum-∪⁺-hom} {indexedSum-⊆} x noRef
+      (_ , LEDGER-V (_ , UTXOW⇒UTXO x , _ , _)) → gmsc {indexedSum-∪⁺-hom} {indexedSum-⊆} x noRef
+      (_ , LEDGER-I (_ , UTXOW⇒UTXO x))         → gmsc {indexedSum-∪⁺-hom} {indexedSum-⊆} x noRef
 
   --   propose-ChangePP-hasGroup : ∀ {up prop}
   --     → prop ∈ txb → prop .GovProposal.action ≡ ChangePParams up → updateGroups up ≢ ∅

--- a/src/Ledger/Script.lagda
+++ b/src/Ledger/Script.lagda
@@ -32,17 +32,16 @@ record P1ScriptStructure : Type₁ where
 record PlutusStructure : Type₁ where
   field Dataʰ : HashableSet
         Language PlutusScript CostModel Prices LangDepView ExUnits : Type
+        PlutusV1 PlutusV2 PlutusV3   : Language
         ⦃ ExUnit-CommutativeMonoid ⦄ : IsCommutativeMonoid' 0ℓ 0ℓ ExUnits
         ⦃ Hashable-PlutusScript    ⦄ : Hashable PlutusScript ScriptHash
+        ⦃ DecEq-Language           ⦄ : DecEq Language
         ⦃ DecEq-CostModel          ⦄ : DecEq CostModel
         ⦃ DecEq-LangDepView        ⦄ : DecEq LangDepView
 
   field  _≥ᵉ_              : ExUnits → ExUnits → Type
          ⦃ DecEq-ExUnits ⦄ : DecEq ExUnits
          ⦃ DecEQ-Prices  ⦄ : DecEq Prices
-         -- GetPair              : ExUnits → Type × Type
-         -- coinIsMonoidMorphism : GetPair Is ExUnit-CommutativeMonoid
-         --                          -CommutativeMonoid⟶ +-0-commutativeMonoid
 
   open HashableSet Dataʰ renaming (T to Data; THash to DataHash) public
 

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -25,7 +25,7 @@ only if it is present.
 Conway. If a transaction contains any votes, proposals, a treasury
 donation or asserts the treasury amount, it is only allowed to contain
 Plutus V3 scripts. Additionally, the presence of reference scripts or
-inline scripts does not prevent Plutus V1 scripts to be used in a
+inline scripts does not prevent Plutus V1 scripts from being used in a
 transaction anymore. Only inline datums are now disallowed from
 appearing together with a Plutus V1 script.
 

--- a/src/Ledger/Utxow/Properties.agda
+++ b/src/Ledger/Utxow/Properties.agda
@@ -37,18 +37,20 @@ instance
               (inj₁ a₄) → "inputHashes ⊆ txdatsHashes"
               (inj₂ b₄) → case dec-de-morgan b₄ of λ where
                 (inj₁ a₅) → "txdatsHashes ⊆ (inputHashes ∪ allOutHashes ∪ getDataHashes (range (utxo ∣ refInputs)))"
-                (inj₂ b₅) → "txADhash ≡ map hash txAD"
+                (inj₂ b₅) → case dec-de-morgan b₅ of λ where
+                  (inj₁ a₆) → "languages ⊆ allowedLanguages"
+                  (inj₂ b₆) → "txADhash ≡ map hash txAD"
 
     computeProof : ComputationResult String (∃ (Γ ⊢ s ⇀⦇ tx ,UTXOW⦈_))
     computeProof =
       case H? of λ where
-        (yes (p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ )) →
-          map (map₂′ (UTXOW-inductive⋯ p₁ p₂ p₃ p₄ p₅ p₆ p₇ )) (computeProof' Γ s tx)
+        (yes (p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈)) →
+          map (map₂′ (UTXOW-inductive⋯ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈)) (computeProof' Γ s tx)
         (no ¬p) → failure $ genErr ¬p
 
     completeness : ∀ s' → Γ ⊢ s ⇀⦇ tx ,UTXOW⦈ s'
                         → map proj₁ computeProof ≡ success s'
-    completeness s' (UTXOW-inductive⋯ p₁ p₂ p₃ p₄ p₅ p₆ p₇ h) with H?
-    ... | no ¬p = ⊥-elim $ ¬p ((p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇))
+    completeness s' (UTXOW-inductive⋯ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ h) with H?
+    ... | no ¬p = ⊥-elim $ ¬p ((p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈))
     ... | yes _ with computeProof' Γ s tx | completeness' _ _ _ _ h
     ... | success _ | refl = refl

--- a/src/latex/agda-latex-macros.sty
+++ b/src/latex/agda-latex-macros.sty
@@ -23,6 +23,7 @@
 \newcommand{\addVote}{\AgdaFunction{addVote}\xspace}
 \newcommand{\addAction}{\AgdaFunction{addAction}\xspace}
 \newcommand{\validHFAction}{\AgdaFunction{validHFAction}\xspace}
+\newcommand{\allowedLanguages}{\AgdaFunction{allowedLanguages}\xspace}
 
 \newcommand{\agdaboundA}{\AgdaBound{A}\xspace}
 \newcommand{\agdabounda}{\AgdaBound{a}\xspace}


### PR DESCRIPTION
# Description

Closes #416 and #407. Because of issues with instance resolution, I had to add `HasInlineDatum` and `UsesV3Features` as explicit data types.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
