### PR TITLE
Prevent proposals from being accepted in no-confidence

### DIFF
--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -132,7 +132,7 @@ threshold pp ccThreshold =
         open DrepThresholds drepThresholds
         open PoolThresholds poolThresholds
 
-        ✓ = ccThreshold
+        ✓ = maybe just ✓† ccThreshold
 \end{code}
 \begin{code}
         P/Q2a/b : Maybe ℚ × Maybe ℚ


### PR DESCRIPTION
# Description

There was a mistake in the logic that allowed proposals that require CC votes to be passed in no-confidence state.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
