### PR TITLE
Stop auto tagging `haskell-package` commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,6 @@ jobs:
             rsync -r --exclude={'**/nix-support','**/lib'} outputs/ledgerSrc/* ledgerSrc/
             git add -f ledgerSrc
             git commit -m "Updated for ${{ github.sha }}"
-            git tag haskell-package-$(git rev-parse --short ${{ github.sha }}) -m "Tag for ${{ github.sha }}"
 
       - name: Push haskell package
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
# Description
Since we don't want to tag each new commit on branch `haskell-package` and only wish to tag a commit manually if that is used as an SRP in `cardano-ledger`, this PR removes the auto tagging from the GHA job. The instructions should be updated on the `cardano-ledger` side as a follow-up to this. 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
