### PR TITLE
Improve `MAlonzo` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,24 @@ on:
 permissions:
   contents: write
 
+env:
+  MAlonzo_branch: ${{ github.event.pull_request.head.ref }}-MAlonzo
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: MAlonzo-code
+
+      - name: Create branch ${{ env.MAlonzo_branch }} for generated code
+        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        run: |
+          git checkout -b ${{ env.MAlonzo_branch }} origin/MAlonzo-code
+          git push origin ${{ env.MAlonzo_branch }}
+
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v20
@@ -65,11 +78,14 @@ jobs:
           echo "** Generated Haskell files:"; find -L docs/ -name '*.hs'
           OUT_DIR=../docs/ make staticWebsite
 
+      - name: Configure git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
       - name: Add files
         if: github.ref == 'refs/heads/master'
         run: |
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
             git add -f docs/
             git commit -m "Updated for ${{ github.sha }}"
 
@@ -82,20 +98,21 @@ jobs:
             force: true
             directory: .
 
-      - name: Commit haskell package
-        if: github.ref == 'refs/heads/master'
+      - name: Commit generated code at ${{ env.MAlonzo_branch }}
+        if: github.ref != 'refs/heads/master'
         run: |
-            nix-build -A ledger.hsSrc -j1 -o outputs/ledgerSrc
+            nix-build -A ledger.hsSrc -j1 -o outputs/MAlonzo
             git stash push
-            rsync -r --exclude={'**/nix-support','**/lib'} outputs/ledgerSrc/* ledgerSrc/
-            git add -f ledgerSrc
-            git commit -m "Updated for ${{ github.sha }}"
+            git fetch origin ${{ env.MAlonzo_branch }} --depth 1
+            git checkout ${{ env.MAlonzo_branch }}
+            rsync -r --exclude={'**/nix-support','**/lib'} outputs/MAlonzo/haskell/Ledger/* generated/
+            git add -f generated && git commit -m "Generate code for ${{ github.sha }}" || echo "Everything is up-to-date."
 
-      - name: Push haskell package
-        if: github.ref == 'refs/heads/master'
+      - name: Push ${{ env.MAlonzo_branch }}
+        if: github.ref != 'refs/heads/master'
         uses: ad-m/github-push-action@v0.6.0
         with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
-            branch: haskell-package
-            force: true
+            branch: ${{ env.MAlonzo_branch }}
+            force: false
             directory: .

--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -1,0 +1,53 @@
+name: Formal Ledger Specs - PR Merged
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+env:
+  MAlonzo_branch: ${{ github.event.pull_request.head.ref }}-MAlonzo
+
+jobs:
+  pr-merged:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: MAlonzo-code
+      - name: Merge ${{ env.MAlonzo_branch }} into MAlonzo-code
+        if: github.event.pull_request.merged
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          # GitHub Actions fetches shallow copies of remote branches
+          # which might not be ideal when rebasing, hence use `--unshallow`.
+          git fetch --unshallow origin ${{ env.MAlonzo_branch }}
+          git checkout ${{ env.MAlonzo_branch }}
+          # During `git rebase` 'ours' and 'theirs' are flipped
+          # so what we do here is that we keep the changes from ${{ env.MAlonzo_branch }}.
+          git rebase -X theirs origin/MAlonzo-code
+          git checkout MAlonzo-code
+          git merge --squash ${{ env.MAlonzo_branch }}
+          git commit -m "Generate code for GH-${{ github.event.pull_request.number }}" || echo "Everything is up-to-date."
+
+      - name: Push MAlonzo-code
+        if: github.event.pull_request.merged
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            branch: MAlonzo-code
+            force: false
+            directory: .
+
+      - name: Delete ${{ env.MAlonzo_branch }} branch
+        if: github.event.pull_request.merged
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches: ${{ env.MAlonzo_branch }}


### PR DESCRIPTION
# Description
- Create an orphan branch (`MAlonzo-code`) for the generated code
- When opening a PR for a feature branch, create a separate branch
  based on the `MAlonzo-code` branch which will contain newly
  generated code from the feature branch
- Once the PR is successfully merged, the branch based on
  `MAlonzo-code` gets squash merged into `MAlonzo-code` and deleted

Esentially, the above setup attempts to replicate
the git feature branch workflow for the generated code,
where the `MAlonzo-code` branch corresponds to the `main` / `master`
branch.

There will probably be some conflicts from time to time but these will be taken care of automatically by rebasing.
I opted to always keep the most recent changes, so the changes from the `*-MAlonzo` "feature" branches, rather than the ones from `MAlonzo-code`. This should mostly be okay, since the feature branches that we create are based on `master`, the `*-MAlonzo` branches contain the generated code of these feature branches (and we keep this up-to-date with `master` as required) and these are merged into `MAlonzo-code` when the PR is merged so the `MAlonzo-code` branch will contain generated code that is based on `master` by proxy and kept up-to-date via the feature branches of the PRs. However, since we can directly push to `master`, that can interfere with this slightly and might cause some problems.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
