### PR TITLE
DO NOT MERGE: add withdrawals to consume (bug fix triage)

### DIFF
--- a/src/Ledger/Foreign/HSLedger/BaseTypes.agda
+++ b/src/Ledger/Foreign/HSLedger/BaseTypes.agda
@@ -324,6 +324,7 @@ instance
       ; txouts = to txouts
       ; txfee  = txfee
       ; txvldt = to txvldt
+      ; txwdrls = to txwdrls
       ; txsize = txsize
       ; txid   = to txid
       ; collateral = to collateral
@@ -339,7 +340,7 @@ instance
       ; mint          = ε -- tokenAlgebra only contains ada atm, so mint is surely empty
       ; txfee         = txfee
       ; txvldt        = from txvldt
-      ; txwdrls       = ∅
+      ; txwdrls       = from txwdrls
       ; txup          = nothing
       ; txADhash      = nothing
       ; txNetworkId   = nothing

--- a/src/Ledger/Foreign/LedgerTypes.agda
+++ b/src/Ledger/Foreign/LedgerTypes.agda
@@ -191,13 +191,18 @@ data TxCert : Type where
   CCRegHot    : Credential → Maybe Credential → TxCert
 {-# COMPILE GHC TxCert = data TxCert (Delegate | Dereg | RegPool | RetirePool | RegDRep | DeRegDRep | CCRegHot) #-}
 
+Wdrl = HSMap RwdAddr Coin
+{-# FOREIGN GHC
+  type Wdrl = HSMap RwdAddr Coin
+#-}
+
 record TxBody : Type where
   field txins    : List TxIn
         refInputs : List TxIn
         txouts   : HSMap Ix TxOut
         txfee    : Coin
         txvldt   : Pair (Maybe ℕ) (Maybe ℕ)
-        --txwdrls  : Wdrl
+        txwdrls  : Wdrl
         --txup     : Maybe Update
         --txADhash : Maybe ADHash
         txsize   : ℕ
@@ -213,6 +218,7 @@ record TxBody : Type where
     , txouts :: HSMap Ix TxOut
     , txfee  :: Coin
     , txvldt :: (Maybe Integer, Maybe Integer)
+    , txwdrls :: Wdrl
     , txsize :: Integer
     , txid   :: TxId
     , collateral    :: [TxIn]

--- a/src/Ledger/Ledger/Properties.agda
+++ b/src/Ledger/Ledger/Properties.agda
@@ -115,22 +115,24 @@ module _ where
   FreshTx tx ls = tx .body .txid ∉ mapˢ proj₁ (dom (ls .utxoSt .utxo))
     where open Tx; open TxBody; open UTxOState; open LState
 
-  LEDGER-pov : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
-  LEDGER-pov h (LEDGER-V⋯ _ (UTXOW⇒UTXO st) _ _) = pov h st
-  LEDGER-pov h (LEDGER-I⋯ _ (UTXOW⇒UTXO st))     = pov h st
+  -- TODO: fix this to accommodate adding withdrawals to consumed
+  -- LEDGER-pov : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
+  -- LEDGER-pov h (LEDGER-V⋯ _ (UTXOW⇒UTXO st) _ _) = pov h st
+  -- LEDGER-pov h (LEDGER-I⋯ _ (UTXOW⇒UTXO st))     = pov h st
 
   data FreshTxs : LEnv → LState → List Tx → Type where
     []-Fresh : FreshTxs Γ s []
     ∷-Fresh  : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → FreshTxs Γ s' l
               → FreshTxs Γ s (tx ∷ l)
 
-  LEDGERS-pov : FreshTxs Γ s l → Γ ⊢ s ⇀⦇ l ,LEDGERS⦈ s' → getCoin s ≡ getCoin s'
-  LEDGERS-pov _ (BS-base Id-nop) = refl
-  LEDGERS-pov {Γ} {_} {_ ∷ l} (∷-Fresh h h₁ h₂) (BS-ind x st) =
-    trans (LEDGER-pov h x) $
-      LEDGERS-pov (subst (λ s → FreshTxs Γ s l)
-                          (sym $ computational⇒rightUnique Computational-LEDGER x h₁)
-                          h₂) st
+  -- TODO: fix this to accommodate adding withdrawals to consumed
+  -- LEDGERS-pov : FreshTxs Γ s l → Γ ⊢ s ⇀⦇ l ,LEDGERS⦈ s' → getCoin s ≡ getCoin s'
+  -- LEDGERS-pov _ (BS-base Id-nop) = refl
+  -- LEDGERS-pov {Γ} {_} {_ ∷ l} (∷-Fresh h h₁ h₂) (BS-ind x st) =
+  --   trans (LEDGER-pov h x) $
+  --     LEDGERS-pov (subst (λ s → FreshTxs Γ s l)
+  --                         (sym $ computational⇒rightUnique Computational-LEDGER x h₁)
+  --                         h₂) st
 
 -- ** Proof that the set equality `govDepsMatch` (below) is a LEDGER invariant.
 

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -350,11 +350,15 @@ module _ (let open UTxOState; open TxBody) where
   newDeposits : PParams → UTxOState → TxBody → Coin
   newDeposits pp st txb = posPart (depositsChange pp txb (st .deposits))
 
+  sumWithdrawals : TxBody → Coin
+  sumWithdrawals txb = ∑[ x ← txb .txwdrls ] x
+
   consumed : PParams → UTxOState → TxBody → Value
   consumed pp st txb
     =  balance (st .utxo ∣ txb .txins)
     +  txb .mint
     +  inject (depositRefunds pp st txb)
+    +  inject (sumWithdrawals txb)
 
   produced : PParams → UTxOState → TxBody → Value
   produced pp st txb

--- a/src/Ledger/Utxo/Haskell/Properties.agda
+++ b/src/Ledger/Utxo/Haskell/Properties.agda
@@ -84,6 +84,7 @@ instance
                             +ˢ "\n    ins  =\t\t" +ˢ showValue (balance (s .UTxOState.utxo ∣ txb .TxBody.txins))
                             +ˢ "\n    mint =\t\t" +ˢ showValue (TxBody.mint txb)
                             +ˢ "\n    depositRefunds =\t" +ˢ showValue (inject (depositRefunds pp s txb))
+                            +ˢ "\n    withdrawals =\t" +ˢ showValue (inject (sumWithdrawals txb))
                             +ˢ "\n  produced =\t\t" +ˢ showValue prod
                             +ˢ "\n    outs =\t\t" +ˢ showValue (balance $ outs txb)
                             +ˢ "\n    fee  =\t\t" +ˢ show (txb .TxBody.txfee)

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -105,6 +105,7 @@ instance
                             +ˢ "\n    ins  =\t\t" +ˢ showValue (balance (s .UTxOState.utxo ∣ txb .TxBody.txins))
                             +ˢ "\n    mint =\t\t" +ˢ showValue (TxBody.mint txb)
                             +ˢ "\n    depositRefunds =\t" +ˢ showValue (inject (depositRefunds pp s txb))
+                            +ˢ "\n    withdrawals =\t" +ˢ showValue (inject (sumWithdrawals txb))
                             +ˢ "\n  produced =\t\t" +ˢ showValue prod
                             +ˢ "\n    outs =\t\t" +ˢ showValue (balance $ outs txb)
                             +ˢ "\n    fee  =\t\t" +ˢ show (txb .TxBody.txfee)

--- a/src/Ledger/hs-src/test/UtxowSpec.hs
+++ b/src/Ledger/hs-src/test/UtxowSpec.hs
@@ -62,6 +62,7 @@ bodyFromSimple pp stxb = let s = 5 in MkTxBody
   , txouts    = stxouts stxb
   , txfee     = (ppA pp) * s + (ppB pp)
   , txvldt    = stxvldt stxb
+  , txwdrls   = MkHSMap mempty
   , txsize    = s
   , txid      = stxid stxb
   , txcerts   = stxcerts stxb}


### PR DESCRIPTION
# Description

This is a temporary PR to unblock conformance tests that detect the "withdrawals not included in `consumed`" bug in the formal spec.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
