### PR TITLE
Removed deposit updating from Haskell version of UTXO

### DIFF
--- a/src/Ledger/Conway/Conformance/Foreign/HSLedger/Core.agda
+++ b/src/Ledger/Conway/Conformance/Foreign/HSLedger/Core.agda
@@ -117,9 +117,9 @@ instance
     HSPKKScheme : PKKScheme
     HSPKKScheme = record
       { Implementation
-      ; isSigned         = λ a b m → a + b ≡ m
-      ; sign             = _+_
-      ; isSigned-correct = λ where (sk , sk , refl) _ _ h → h
+      ; isSigned         = λ a b m → ⊤
+      ; sign             = λ _ _ → zero
+      ; isSigned-correct = λ where (sk , sk , refl) _ _ h → tt
       }
 
 -- No P2 scripts for now

--- a/src/Ledger/Conway/Conformance/Ledger.lagda
+++ b/src/Ledger/Conway/Conformance/Ledger.lagda
@@ -93,13 +93,16 @@ data
 \begin{figure*}[htb]
 \begin{AgdaSuppressSpace}
 \begin{code}
-  LEDGER-V : let open LState s; txb = tx .body; open TxBody txb; open LEnv Γ in
+  LEDGER-V :
+    let open LState s; txb = tx .body; open TxBody txb; open LEnv Γ
+        utxoSt'' = record utxoSt' { deposits = updateDeposits pparams txb (deposits utxoSt') }
+     in
     ∙  isValid tx ≡ true
     ∙  record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     ∙  ⟦ epoch slot , pparams , txvote , txwdrls ⟧ᶜ ⊢ certState ⇀⦇ txcerts ,CERTS⦈ certState'
     ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState ⟧ᵍ ⊢ govSt ⇀⦇ txgov txb ,GOV⦈ govSt'
        ────────────────────────────────
-       Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt' , govSt' , certState' ⟧ˡ
+       Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt'' , govSt' , certState' ⟧ˡ
 \end{code}
 \begin{NoConway}
 \begin{code}

--- a/src/Ledger/Conway/Conformance/Utxo.agda
+++ b/src/Ledger/Conway/Conformance/Utxo.agda
@@ -30,16 +30,9 @@ instance
 
 certDepositUtxo : DCert → PParams → DepositPurpose ⇀ Coin
 certDepositUtxo (regpool kh _)     pp  = ❴ PoolDeposit kh , pp .poolDeposit ❵
--- This is how RegDeleg certificates are translated in conformance testing
-certDepositUtxo (delegate c nothing nothing v) pp = ❴ CredentialDeposit c , pp .keyDeposit ❵
+certDepositUtxo (delegate c _ _ v) _   = ❴ CredentialDeposit c , v ❵
+certDepositUtxo (regdrep c v _)    _   = ❴ DRepDeposit c , v ❵
 certDepositUtxo _                  _   = ∅
--- -- Handle the following two cases in Certs.Haskell module:
--- certDeposit (delegate c _ _ v) _   = ❴ CredentialDeposit c , v ❵
--- certDeposit (regdrep c v _)    _   = ❴ DRepDeposit c , v ❵
-
--- -- Handle refunds in Certs.Haskell module.
--- certRefund : DCert → ℙ DepositPurpose
-
 
 updateCertDeposits  : PParams → List DCert → (DepositPurpose ⇀ Coin)
                     → DepositPurpose ⇀ Coin
@@ -143,7 +136,7 @@ data _⊢_⇀⦇_,UTXOS⦈_ : UTxOEnv → UTxOState → Tx → UTxOState → Typ
           ────────────────────────────────
           Γ ⊢ s ⇀⦇ tx ,UTXOS⦈  ⟦ (utxo ∣ txins ᶜ) ∪ˡ (outs txb)
                               , fees + txfee
-                              , updateDeposits pp txb deposits
+                              , deposits
                               , donations + txdonation
                               ⟧ᵘ
 

--- a/src/ScriptVerification/LedgerImplementation.agda
+++ b/src/ScriptVerification/LedgerImplementation.agda
@@ -113,9 +113,9 @@ SVCrypto = record
   SVPKKScheme : PKKScheme
   SVPKKScheme = record
     { Implementation
-    ; isSigned         = λ a b m → a + b ≡ m
-    ; sign             = _+_
-    ; isSigned-correct = λ where (sk , sk , refl) _ _ h → h
+    ; isSigned         = λ a b m → ⊤
+    ; sign             = λ _ _ → zero
+    ; isSigned-correct = λ where (sk , sk , refl) _ _ h → tt
     }
 
 instance _ = SVCrypto


### PR DESCRIPTION
# Description

This PR modifies the alternative spec so that the deposit update happens in the LEDGER rule instead of the UTXO rule like in the implementation. It also makes the `isSigned` check always succeed in conformance testing.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
