### PR TITLE
Add a way to pull in functions from the Haskell implementation

### DIFF
--- a/src/Ledger/Conway/Foreign/ExternalFunctions.agda
+++ b/src/Ledger/Conway/Foreign/ExternalFunctions.agda
@@ -1,0 +1,17 @@
+module Ledger.Conway.Foreign.ExternalFunctions where
+
+open import Ledger.Prelude
+open import Foreign.HaskellTypes.Deriving
+
+record ExternalFunctions : Set where
+  field extIsSigned : ℕ → ℕ → ℕ → Bool
+{-# FOREIGN GHC
+  data ExternalFunctions = MkExternalFunctions
+    { extIsSigned :: Integer -> Integer -> Integer -> Bool
+    }
+#-}
+{-# COMPILE GHC ExternalFunctions = data ExternalFunctions (MkExternalFunctions) #-}
+
+dummyExternalFunctions : ExternalFunctions
+dummyExternalFunctions = record { extIsSigned = λ x x₁ x₂ → true }
+{-# COMPILE GHC dummyExternalFunctions as dummyExternalFunctions #-}

--- a/src/Ledger/Conway/Foreign/HSLedger/BaseTypes.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/BaseTypes.agda
@@ -2,8 +2,7 @@ module Ledger.Conway.Foreign.HSLedger.BaseTypes where
 
 open import Data.Rational
 
-open import Ledger.Prelude
-
+open import Ledger.Conway.Foreign.ExternalFunctions
 open import Ledger.Conway.Foreign.HSLedger.Core public
 import Ledger.Conway.Foreign.HSTypes as F
 
@@ -65,7 +64,12 @@ instance
   Conv-ComputationResult : ConvertibleType ComputationResult F.ComputationResult
   Conv-ComputationResult = autoConvertible
 
-
+open ExternalStructures dummyExternalFunctions
+  renaming
+    ( HSTransactionStructure to DummyTransactionStructure
+    ; HSAbstractFunctions to DummyAbstractFunctions
+    )
+  public
 open import Ledger.Conway.Conformance.Certs.Properties govStructure
 
 unquoteDecl = do

--- a/src/Ledger/Conway/Foreign/HSLedger/Core.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Core.agda
@@ -1,3 +1,5 @@
+open import Ledger.Conway.Foreign.ExternalFunctions
+
 module Ledger.Conway.Foreign.HSLedger.Core where
 
 open import Ledger.Prelude hiding (ε) renaming (fromList to fromListˢ) public
@@ -18,10 +20,7 @@ open import Ledger.Types.Epoch
 
 open import Ledger.Transaction renaming (Vote to VoteTag) public
 
-postulate
-  error : {A : Set} → String → A
-{-# FOREIGN GHC import Data.Text #-}
-{-# COMPILE GHC error = \ _ s -> error (unpack s) #-}
+open import Ledger.Conway.Foreign.Util public
 
 module _ {A : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : Show A ⦄ where instance
   ∀Hashable : Hashable A A
@@ -101,120 +100,123 @@ module Implementation where
   DocHash         = ℕ
   tokenAlgebra    = coinTokenAlgebra
 
-HSGlobalConstants = GlobalConstants ∋ record {Implementation}
-instance
-  HSEpochStructure = EpochStructure  ∋ ℕEpochStructure HSGlobalConstants
-
-  HSCrypto : Crypto
-  HSCrypto = record
-    { Implementation
-    ; pkk = HSPKKScheme
-    }
-    where
-    -- Dummy private key crypto scheme
-    HSPKKScheme : PKKScheme
-    HSPKKScheme = record
+module ExternalStructures (externalFunctions : ExternalFunctions) where
+  HSGlobalConstants = GlobalConstants ∋ record {Implementation}
+  instance
+    HSEpochStructure = EpochStructure  ∋ ℕEpochStructure HSGlobalConstants
+  
+    HSCrypto : Crypto
+    HSCrypto = record
       { Implementation
-      ; isSigned         = λ a b m → ⊤
-      ; sign             = λ _ _ → zero
-      ; isSigned-correct = λ where (sk , sk , refl) _ _ h → tt
+      ; pkk = HSPKKScheme
       }
-
--- No P2 scripts for now
-
-open import Ledger.Script it it
-open import Ledger.Conway.Conformance.Script it it public
-
-instance
-  HSScriptStructure : ScriptStructure
-  HSScriptStructure = record
-    { p1s = P1ScriptStructure-HTL
-    ; hashRespectsUnion = hashRespectsUnion
-    ; ps = HSP2ScriptStructure
+      where
+      open ExternalFunctions externalFunctions
+      HSPKKScheme : PKKScheme
+      HSPKKScheme = record
+        { Implementation
+        ; isSigned         = λ a b m → extIsSigned a b m ≡ true
+        ; sign             = λ _ _ → zero
+          -- we can't prove these properties since the functions are provided by the Haskell implementation
+        ; isSigned-correct = error "isSigned-correct evaluated"
+        ; Dec-isSigned     = λ { {vk} {ser} {sig} → ⁇ (extIsSigned vk ser sig because error "Dec-isSigned evaluated") }
+        }
+  
+  -- No P2 scripts for now
+  
+  open import Ledger.Script it it
+  open import Ledger.Conway.Conformance.Script it it public
+  
+  instance
+    HSScriptStructure : ScriptStructure
+    HSScriptStructure = record
+      { p1s = P1ScriptStructure-HTL
+      ; hashRespectsUnion = hashRespectsUnion
+      ; ps = HSP2ScriptStructure
+      }
+      where
+        hashRespectsUnion : ∀ {A B ℍ}
+          → Hashable A ℍ → Hashable B ℍ
+          → Hashable (A ⊎ B) ℍ
+        hashRespectsUnion a _ .hash (inj₁ x) = hash ⦃ a ⦄ x
+        hashRespectsUnion _ b .hash (inj₂ y) = hash ⦃ b ⦄ y
+  
+        HSP2ScriptStructure : PlutusStructure
+        HSP2ScriptStructure = record
+          { Implementation
+          ; validPlutusScript = λ _ _ _ _ → ⊤
+          }
+  
+  open import Ledger.PParams it it it hiding (Acnt; DrepThresholds; PoolThresholds)
+  
+  HsGovParams : GovParams
+  HsGovParams = record
+    { Implementation
+    ; ppUpd = let open PParamsDiff in λ where
+        .UpdateT      → PParamsUpdate
+        .updateGroups → modifiedUpdateGroups
+        .applyUpdate  → applyPParamsUpdate
+        .ppWF? {u}    → ppWF u
+    ; ppHashingScheme = it
     }
     where
-      hashRespectsUnion : ∀ {A B ℍ}
-        → Hashable A ℍ → Hashable B ℍ
-        → Hashable (A ⊎ B) ℍ
-      hashRespectsUnion a _ .hash (inj₁ x) = hash ⦃ a ⦄ x
-      hashRespectsUnion _ b .hash (inj₂ y) = hash ⦃ b ⦄ y
-
-      HSP2ScriptStructure : PlutusStructure
-      HSP2ScriptStructure = record
-        { Implementation
-        ; validPlutusScript = λ _ _ _ _ → ⊤
-        }
-
-open import Ledger.PParams it it it hiding (Acnt; DrepThresholds; PoolThresholds)
-
-HsGovParams : GovParams
-HsGovParams = record
-  { Implementation
-  ; ppUpd = let open PParamsDiff in λ where
-      .UpdateT      → PParamsUpdate
-      .updateGroups → modifiedUpdateGroups
-      .applyUpdate  → applyPParamsUpdate
-      .ppWF? {u}    → ppWF u
-  ; ppHashingScheme = it
-  }
-  where
-    open PParamsUpdate
-    -- FIXME Replace `trustMe` with an actual proof
-    ppWF : (u : PParamsUpdate) →
-      ((pp : PParams) →
-      paramsWellFormed pp →
-      paramsWellFormed (applyPParamsUpdate pp u))
-      ⁇
-    ppWF u with paramsUpdateWellFormed? u
-    ... | yes _ = ⁇ (yes trustMe)
-      where
-        postulate
-          trustMe :
-            ((pp : PParams) →
-            paramsWellFormed pp →
-            paramsWellFormed (applyPParamsUpdate pp u))
-    ... | no _  = ⁇ (no trustMe)
-      where
-        postulate
-          trustMe :
-            ¬((pp : PParams) →
-            paramsWellFormed pp →
-            paramsWellFormed (applyPParamsUpdate pp u))
-
-instance
-  HSTransactionStructure : TransactionStructure
-  HSTransactionStructure = record
-    { Implementation
-    ; epochStructure  = HSEpochStructure
-    ; globalConstants = HSGlobalConstants
-    ; adHashingScheme = it
-    ; crypto          = HSCrypto
-    ; govParams       = HsGovParams
-    ; txidBytes       = id
-    ; scriptStructure = HSScriptStructure
-    }
-
-open TransactionStructure HSTransactionStructure public
-open import Ledger.Certs govStructure public
-
-open import Ledger.Abstract it
-
-instance
-  HSAbstractFunctions : AbstractFunctions
-  HSAbstractFunctions = record
-    { Implementation
-    ; txscriptfee = λ tt y → 0
-    ; serSize     = λ v → v
-    ; indexOfImp  = record
-      { indexOfDCert    = λ _ _ → nothing
-      ; indexOfRwdAddr  = λ _ _ → nothing
-      ; indexOfTxIn     = λ _ _ → nothing
-      ; indexOfPolicyId = λ _ _ → nothing
-      ; indexOfVote     = λ _ _ → nothing
-      ; indexOfProposal = λ _ _ → nothing
+      open PParamsUpdate
+      -- FIXME Replace `trustMe` with an actual proof
+      ppWF : (u : PParamsUpdate) →
+        ((pp : PParams) →
+        paramsWellFormed pp →
+        paramsWellFormed (applyPParamsUpdate pp u))
+        ⁇
+      ppWF u with paramsUpdateWellFormed? u
+      ... | yes _ = ⁇ (yes trustMe)
+        where
+          postulate
+            trustMe :
+              ((pp : PParams) →
+              paramsWellFormed pp →
+              paramsWellFormed (applyPParamsUpdate pp u))
+      ... | no _  = ⁇ (no trustMe)
+        where
+          postulate
+            trustMe :
+              ¬((pp : PParams) →
+              paramsWellFormed pp →
+              paramsWellFormed (applyPParamsUpdate pp u))
+  
+  instance
+    HSTransactionStructure : TransactionStructure
+    HSTransactionStructure = record
+      { Implementation
+      ; epochStructure  = HSEpochStructure
+      ; globalConstants = HSGlobalConstants
+      ; adHashingScheme = it
+      ; crypto          = HSCrypto
+      ; govParams       = HsGovParams
+      ; txidBytes       = id
+      ; scriptStructure = HSScriptStructure
       }
-    ; runPLCScript = λ _ _ _ _ → false
-    ; scriptSize = λ _ → 0
-    }
-
-open import Ledger.Address Network KeyHash ScriptHash using () public
+  
+  open TransactionStructure HSTransactionStructure public
+  open import Ledger.Certs govStructure public
+  
+  open import Ledger.Abstract it
+  
+  instance
+    HSAbstractFunctions : AbstractFunctions
+    HSAbstractFunctions = record
+      { Implementation
+      ; txscriptfee = λ tt y → 0
+      ; serSize     = λ v → v
+      ; indexOfImp  = record
+        { indexOfDCert    = λ _ _ → nothing
+        ; indexOfRwdAddr  = λ _ _ → nothing
+        ; indexOfTxIn     = λ _ _ → nothing
+        ; indexOfPolicyId = λ _ _ → nothing
+        ; indexOfVote     = λ _ _ → nothing
+        ; indexOfProposal = λ _ _ → nothing
+        }
+      ; runPLCScript = λ _ _ _ _ → false
+      ; scriptSize = λ _ → 0
+      }
+  
+  open import Ledger.Address Network KeyHash ScriptHash using () public

--- a/src/Ledger/Conway/Foreign/HSLedger/Gov.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Gov.agda
@@ -1,5 +1,7 @@
 module Ledger.Conway.Foreign.HSLedger.Gov where
 
+open import Ledger.Prelude using (Type)
+
 open import Ledger.Conway.Foreign.HSLedger.Address
 open import Ledger.Conway.Foreign.HSLedger.BaseTypes
 open import Ledger.Conway.Foreign.HSLedger.Enact

--- a/src/Ledger/Conway/Foreign/HSLedger/NewEpoch.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/NewEpoch.agda
@@ -11,6 +11,8 @@ open import Ledger.Conway.Conformance.Epoch.Properties it it
 
 open import Ledger.Conway.Foreign.HSTypes hiding (ComputationResult)
 
+open import Ledger.Conway.Foreign.Util
+
 record HsRewardUpdate : Type where
   field Δt Δr Δf : ℤ
         rs : HsType (Credential ⇀ Coin)

--- a/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
@@ -1,16 +1,21 @@
+{-# OPTIONS --no-qualified-instances #-}
+
 module Ledger.Conway.Foreign.HSLedger.Utxo where
+
+open import Ledger.Conway.Foreign.ExternalFunctions
 
 open import Data.String.Base renaming (_++_ to _+ˢ_) hiding (show; length)
 
+open import Ledger.Conway.Foreign.HSLedger.Core
 open import Ledger.Conway.Foreign.HSLedger.Address
-open import Ledger.Conway.Foreign.HSLedger.BaseTypes
 open import Ledger.Conway.Foreign.HSLedger.Certs
 open import Ledger.Conway.Foreign.HSLedger.PParams
 open import Ledger.Conway.Foreign.HSLedger.Transaction
 
-open import Ledger.Conway.Conformance.Utxo it it
-open import Ledger.Conway.Conformance.Utxo.Properties it it
-open import Ledger.Conway.Conformance.Utxow.Properties it it
+open import Foreign.Haskell.Coerce
+
+open import Ledger.Conway.Foreign.HSLedger.BaseTypes
+open import Ledger.Conway.Conformance.Utxo DummyTransactionStructure DummyAbstractFunctions
 
 instance
   HsTy-UTxOEnv = autoHsType UTxOEnv ⊣ withConstructor "MkUTxOEnv"
@@ -24,35 +29,40 @@ unquoteDecl = do
   hsTypeAlias UTxO
   hsTypeAlias Redeemer
 
-utxo-step : HsType (UTxOEnv → UTxOState → Tx → ComputationResult String UTxOState)
-utxo-step = to (compute Computational-UTXO)
+module _ (ext : ExternalFunctions) where
+  open ExternalStructures ext hiding (Tx; TxBody; inject)
+  open import Ledger.Conway.Conformance.Utxow.Properties HSTransactionStructure HSAbstractFunctions
+  open import Ledger.Conway.Conformance.Utxo.Properties HSTransactionStructure HSAbstractFunctions
 
-{-# COMPILE GHC utxo-step as utxoStep #-}
+  utxo-step : HsType (UTxOEnv → UTxOState → Tx → ComputationResult String UTxOState)
+  utxo-step = to (coerce ⦃ TrustMe ⦄ $ compute Computational-UTXO)
+  
+  {-# COMPILE GHC utxo-step as utxoStep #-}
 
-utxow-step : HsType (UTxOEnv → UTxOState → Tx → ComputationResult String UTxOState)
-utxow-step = to (compute Computational-UTXOW)
-
-{-# COMPILE GHC utxow-step as utxowStep #-}
-
-utxo-debug : HsType (UTxOEnv → UTxOState → Tx → String)
-utxo-debug env st tx =
-  let open Tx (from tx)
-      open TxBody body
-      open UTxOState (from st)
-      open UTxOEnv (from env)
-   in unlines $
-        "Consumed:" ∷
-        ("\tInputs:      \t" +ˢ show (balance (utxo ∣ txins))) ∷
-        ("\tMint:        \t" +ˢ show mint) ∷
-        ("\tRefunds:     \t" +ˢ show (inject (depositRefunds pparams (from st) body))) ∷
-        ("\tWithdrawals: \t" +ˢ show (inject (getCoin txwdrls))) ∷
-        ("\tTotal:       \t" +ˢ show (consumed pparams (from st) body)) ∷
-        "Produced:" ∷
-        ("\tOutputs:     \t" +ˢ show (balance (outs body))) ∷
-        ("\tDonations:   \t" +ˢ show (inject txdonation)) ∷
-        ("\tDeposits:    \t" +ˢ show (inject (newDeposits pparams (from st) body))) ∷
-        ("\tFees:        \t" +ˢ show (inject txfee)) ∷
-        ("\tTotal:       \t" +ˢ show (produced pparams (from st) body)) ∷
-        []
-
-{-# COMPILE GHC utxo-debug as utxoDebug #-}
+  utxow-step : HsType (UTxOEnv → UTxOState → Tx → ComputationResult String UTxOState)
+  utxow-step = to (coerce ⦃ TrustMe ⦄ $ compute Computational-UTXOW)
+  
+  {-# COMPILE GHC utxow-step as utxowStep #-}
+  
+  utxo-debug : HsType (UTxOEnv → UTxOState → Tx → String)
+  utxo-debug env st tx =
+    let open Tx (from tx)
+        open TxBody body
+        open UTxOState (from st)
+        open UTxOEnv (from env)
+     in unlines $
+          "Consumed:" ∷
+          ("\tInputs:      \t" +ˢ show (balance (utxo ∣ txins))) ∷
+          ("\tMint:        \t" +ˢ show mint) ∷
+          ("\tRefunds:     \t" +ˢ show (inject (depositRefunds pparams (from st) body))) ∷
+          ("\tWithdrawals: \t" +ˢ show (inject (getCoin txwdrls))) ∷
+          ("\tTotal:       \t" +ˢ show (consumed pparams (from st) body)) ∷
+          "Produced:" ∷
+          ("\tOutputs:     \t" +ˢ show (balance (outs body))) ∷
+          ("\tDonations:   \t" +ˢ show (inject txdonation)) ∷
+          ("\tDeposits:    \t" +ˢ show (inject (newDeposits pparams (from st) body))) ∷
+          ("\tFees:        \t" +ˢ show (inject txfee)) ∷
+          ("\tTotal:       \t" +ˢ show (produced pparams (from st) body)) ∷
+          []
+  
+  {-# COMPILE GHC utxo-debug as utxoDebug #-}

--- a/src/Ledger/Conway/Foreign/Util.agda
+++ b/src/Ledger/Conway/Foreign/Util.agda
@@ -1,0 +1,8 @@
+module Ledger.Conway.Foreign.Util where
+
+open import Ledger.Prelude
+
+postulate
+  error : {A : Set} → String → A
+{-# FOREIGN GHC import Data.Text #-}
+{-# COMPILE GHC error = \ _ s -> error (unpack s) #-}

--- a/src/Ledger/hs-src/Lib.hs
+++ b/src/Ledger/hs-src/Lib.hs
@@ -37,4 +37,6 @@ import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.Utxo        as X
   (UTxOEnv(..), UTxOState(..), UTxO, utxoStep, utxowStep, Redeemer, utxoDebug)
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.BaseTypes   as X
   (Coin, ExUnits, Epoch)
+import MAlonzo.Code.Ledger.Conway.Foreign.ExternalFunctions    as X
+  (ExternalFunctions(..), dummyExternalFunctions)
 

--- a/src/Ledger/hs-src/test/UtxowSpec.hs
+++ b/src/Ledger/hs-src/test/UtxowSpec.hs
@@ -152,7 +152,7 @@ testTx2 = MkTx
   }
 
 utxowSteps :: UTxOEnv -> UTxOState -> [Tx] -> ComputationResult Text UTxOState
-utxowSteps = foldM . utxowStep
+utxowSteps = foldM . utxowStep dummyExternalFunctions
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
# Description

This PR makes it possible to pass the `isSigned` function from Haskell to Agda via the `ExternalFunctions` record. 

closes https://github.com/IntersectMBO/formal-ledger-specifications/issues/593

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
