### PR TITLE
Check if `*-MAlonzo` branch exists on each run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,18 @@ jobs:
   MAlonzo:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if ${{ env.MAlonzo_branch }} exists
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.MAlonzo_branch }}
+        id: MAlonzo-exists
+        continue-on-error: true
+        if: github.ref != 'refs/heads/master'
       - uses: actions/checkout@v4
         with:
           ref: MAlonzo-code
       - name: Create branch ${{ env.MAlonzo_branch }} for generated code
-        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        if: github.ref != 'refs/heads/master' && steps.MAlonzo-exists.outcome == 'failure'
         run: |
           git checkout -b ${{ env.MAlonzo_branch }} origin/MAlonzo-code
           git push origin ${{ env.MAlonzo_branch }}


### PR DESCRIPTION
# Description
By checking the existence of the automatically created `*-MAlonzo` branch on each workflow run and creating the branch if the check fails, rather than only running the branch creation on PR open events, we are reducing the likelihood of missing the branch creation as happened in #607. The `*-MAlonzo` branch creation step was skipped there for some reason (probably an issue with one of the webhooks in the `if` check that should have triggered the step) which caused some problems down the line.
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
