### PR TITLE
Add a proper `EnterpriseAddr` type

### DIFF
--- a/src/Ledger/Conway/Conformance/Utxo.agda
+++ b/src/Ledger/Conway/Conformance/Utxo.agda
@@ -280,7 +280,7 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv → UTxOState → Tx → UTxOState → Type
     ∙ ∀[ (_ , txout) ∈ txoutsʰ .proj₁ ]
         serSize (getValueʰ txout) ≤ maxValSize pp
     ∙ ∀[ (a , _) ∈ range txoutsʰ ]
-        Sum.All (const ⊤) (λ a → a .BootstrapAddr.attrsSize ≤ 64) a
+        if a isBootstrapAddr (λ a → a .attrsSize ≤ 64)
     ∙ ∀[ (a , _) ∈ range txoutsʰ ]  netId a         ≡ NetworkId
     ∙ ∀[ a ∈ dom txwdrls ]          a .RwdAddr.net  ≡ NetworkId
     ∙ txNetworkId ≡? NetworkId

--- a/src/Ledger/Conway/Foreign/HSLedger/Address.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Address.agda
@@ -9,6 +9,9 @@ instance
   HsTy-BaseAddr = autoHsType BaseAddr ⊣ fieldPrefix "base"
   Conv-BaseAddr = autoConvert BaseAddr
 
+  HsTy-EnterpriseAddr = autoHsType EnterpriseAddr ⊣ fieldPrefix "enterprise"
+  Conv-EnterpriseAddr = autoConvert EnterpriseAddr
+
   HsTy-BootstrapAddr = autoHsType BootstrapAddr ⊣ fieldPrefix "boot"
   Conv-BootstrapAddr = autoConvert BootstrapAddr
 

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -531,7 +531,7 @@ data _⊢_⇀⦇_,UTXO⦈_ where
     ∙ ∀[ (_ , txout) ∈ txoutsʰ .proj₁ ]
         serSize (getValueʰ txout) ≤ maxValSize pp
     ∙ ∀[ (a , _) ∈ range txoutsʰ ]
-        Sum.All (const ⊤) (λ a → a .BootstrapAddr.attrsSize ≤ 64) a
+        if a isBootstrapAddr (λ a → a .attrsSize ≤ 64)
     ∙ ∀[ (a , _) ∈ range txoutsʰ ]  netId a         ≡ NetworkId
     ∙ ∀[ a ∈ dom txwdrls ]          a .RwdAddr.net  ≡ NetworkId
     ∙ txNetworkId ≡? NetworkId

--- a/src/ScriptVerification/HelloWorld.agda
+++ b/src/ScriptVerification/HelloWorld.agda
@@ -35,7 +35,7 @@ initEnv = createEnv 0
 initTxOut : TxOut
 initTxOut = inj₁ (record { net = 0 ;
                            pay = ScriptObj 777 ;
-                           stake = just (ScriptObj 777) })
+                           stake = ScriptObj 777 })
                            , 10 , nothing , nothing
 
 script : TxIn × TxOut
@@ -52,7 +52,7 @@ succeedTx = record { body = record
                                                ∷ (5
                                                  , ((inj₁ (record { net = 0 ;
                                                                     pay = KeyHashObj 5 ;
-                                                                    stake = just (KeyHashObj 5) }))
+                                                                    stake = KeyHashObj 5 }))
                                                  , (1000000000000 - 10000000000) , nothing , nothing))
                                                ∷ [])
                          ; txfee = 10000000000

--- a/src/ScriptVerification/Lib.agda
+++ b/src/ScriptVerification/Lib.agda
@@ -81,7 +81,7 @@ createUTxO : (index : ℕ)
            → Maybe (D ⊎ DataHash)
            → TxIn × TxOut
 createUTxO index wallet value d = (index , index)
-                                , (inj₁ (record { net = 0 ; pay = KeyHashObj wallet ; stake = just (KeyHashObj wallet) })
+                                , (inj₁ (record { net = 0 ; pay = KeyHashObj wallet ; stake = KeyHashObj wallet })
                                   , value , d , nothing)
 
 createInitUtxoState : (wallets : ℕ)

--- a/src/ScriptVerification/SucceedIfNumber.agda
+++ b/src/ScriptVerification/SucceedIfNumber.agda
@@ -44,14 +44,14 @@ initEnv = createEnv 0
 initTxOut : TxOut
 initTxOut = inj₁ (record { net = 0 ;
                            pay = ScriptObj 777 ;
-                           stake = just (ScriptObj 777) })
+                           stake = ScriptObj 777 })
                            , 10 , just (inj₂ 99) , nothing
 
 -- initTxOut for script without datum reference
 initTxOut' : TxOut
 initTxOut' = inj₁ (record { net = 0 ;
                            pay = ScriptObj 888 ;
-                           stake = just (ScriptObj 888) })
+                           stake = ScriptObj 888 })
                            , 10 , nothing , nothing
 
 scriptDatum : TxIn × TxOut
@@ -74,7 +74,7 @@ succeedTx = record { body = record
                                                 ∷ (5
                                                   , ((inj₁ (record { net = 0 ;
                                                                      pay = KeyHashObj 5 ;
-                                                                     stake = just (KeyHashObj 5) }))
+                                                                     stake = KeyHashObj 5 }))
                                                   , (1000000000000 - 10000000000) , nothing , nothing))
                                                 ∷ [])
                          ; txfee = 10000000000


### PR DESCRIPTION
# Description

Replace the `Maybe` in the `stake` field of `BaseAddr` with a proper `EnterpriseAddr` type.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
