### PR TITLE
Added `reg` cert, fixed hashing of `VKey`s

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -22,10 +22,6 @@ in {
     nativeBuildInputs = [
       specs.agda
       cabal-install
-      (haskellPackages.ghcWithPackages (pkgs: with pkgs; [
-        specs.ledger.hsExe
-        specs.midnight.hsExe
-      ]))
     ];
   };
 }

--- a/src/Ledger/Certs.lagda
+++ b/src/Ledger/Certs.lagda
@@ -56,16 +56,22 @@ data DCert : Type where
   deregdrep   : Credential → Coin → DCert
   ccreghot    : Credential → Maybe Credential → DCert
 \end{code}
+\begin{code}[hide]
+  reg         : Credential → Coin → DCert
+\end{code}
 \begin{NoConway}
 \begin{code}
-cwitness : DCert → Credential
-cwitness (delegate c _ _ _)  = c
-cwitness (dereg c _)         = c
-cwitness (regpool kh _)      = KeyHashObj kh
-cwitness (retirepool kh _)   = KeyHashObj kh
-cwitness (regdrep c _ _)     = c
-cwitness (deregdrep c _)     = c
-cwitness (ccreghot c _)      = c
+cwitness : DCert → Maybe Credential
+cwitness (delegate c _ _ _)  = just c
+cwitness (dereg c _)         = just c
+cwitness (regpool kh _)      = just $ KeyHashObj kh
+cwitness (retirepool kh _)   = just $ KeyHashObj kh
+cwitness (regdrep c _ _)     = just c
+cwitness (deregdrep c _)     = just c
+cwitness (ccreghot c _)      = just c
+\end{code}
+\begin{code}[hide]
+cwitness (reg _ _)           = nothing
 \end{code}
 \end{NoConway}
 \end{AgdaMultiCode}
@@ -326,6 +332,15 @@ data _⊢_⇀⦇_,DELEG⦈_ where
       ────────────────────────────────
       ⟦ pp , pools , delegatees ⟧ᵈᵉ ⊢ ⟦ vDelegs , sDelegs , rwds ⟧ᵈ ⇀⦇ dereg c d ,DELEG⦈
         ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ ⟧ᵈ
+\end{code}
+\begin{code}[hide]
+  DELEG-reg : let open PParams pp in
+    ∙ c ∉ dom rwds
+    ∙ d ≡ keyDeposit
+      ────────────────────────────────
+      ⟦ pp , pools , delegatees ⟧ᵈᵉ ⊢
+        ⟦ vDelegs , sDelegs , rwds ⟧ᵈ ⇀⦇ reg c d ,DELEG⦈
+        ⟦ vDelegs , sDelegs , rwds ∪ˡ ❴ c , 0 ❵ ⟧ᵈ
 \end{code}
 \end{AgdaSuppressSpace}
 \caption{Auxiliary DELEG transition system}

--- a/src/Ledger/Certs.lagda
+++ b/src/Ledger/Certs.lagda
@@ -336,7 +336,7 @@ data _⊢_⇀⦇_,DELEG⦈_ where
 \begin{code}[hide]
   DELEG-reg : let open PParams pp in
     ∙ c ∉ dom rwds
-    ∙ d ≡ keyDeposit
+    ∙ d ≡ keyDeposit ⊎ d ≡ 0
       ────────────────────────────────
       ⟦ pp , pools , delegatees ⟧ᵈᵉ ⊢
         ⟦ vDelegs , sDelegs , rwds ⟧ᵈ ⇀⦇ reg c d ,DELEG⦈

--- a/src/Ledger/Certs/Properties.agda
+++ b/src/Ledger/Certs/Properties.agda
@@ -36,7 +36,7 @@ instance
       (yes p) → success (-, DELEG-dereg p)
       (no ¬p) → failure (genErrors ¬p)
     (reg c d) → case ¿ c ∉ dom rwds
-                     × d ≡ pp .PParams.keyDeposit
+                     × (d ≡ pp .PParams.keyDeposit ⊎ d ≡ 0)
                      ¿ of λ where
       (yes p) → success (-, DELEG-reg p)
       (no ¬p) → failure (genErrors ¬p)
@@ -51,7 +51,7 @@ instance
   Computational-DELEG .completeness ⟦ _ , _ , _ ⟧ᵈᵉ ⟦ _ , _ , rwds ⟧ᵈ (dereg c d) _ (DELEG-dereg p)
     rewrite dec-yes (¿ (c , 0) ∈ rwds ¿) p .proj₂ = refl
   Computational-DELEG .completeness ⟦ pp , _ , _ ⟧ᵈᵉ ⟦ _ , _ , rwds ⟧ᵈ (reg c d) _ (DELEG-reg p)
-    rewrite dec-yes (¿ c ∉ dom rwds × d ≡ pp .PParams.keyDeposit ¿) p .proj₂ = refl
+    rewrite dec-yes (¿ c ∉ dom rwds × (d ≡ pp .PParams.keyDeposit ⊎ d ≡ 0) ¿) p .proj₂ = refl
 
   Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
   Computational-POOL .computeProof _ ⟦ pools , _ ⟧ᵖ (regpool c _) =

--- a/src/Ledger/Conway/Conformance/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Certs.agda
@@ -43,6 +43,7 @@ record CertState : Type where
 certDeposit : DCert → PParams → Deposits
 certDeposit (delegate c _ _ v) _   = ❴ CredentialDeposit c , v ❵
 certDeposit (regdrep c v _)    _   = ❴ DRepDeposit c , v ❵
+certDeposit (reg c v)          pp  = ❴ CredentialDeposit c , pp .PParams.keyDeposit ❵
 certDeposit _                  _   = ∅
 -- handled in the Utxo module:
 -- certDeposit (regpool kh _)     pp  = ❴ PoolDeposit kh , pp .poolDeposit ❵
@@ -137,6 +138,14 @@ data _⊢_⇀⦇_,DELEG⦈_ where
       ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ
       , updateCertDeposit pp (dereg c d) dep ⟧ᵈ
 
+  DELEG-reg : let open PParams pp in
+    ∙ c ∉ dom rwds
+    ∙ d ≡ keyDeposit ⊎ d ≡ 0
+      ────────────────────────────────
+      ⟦ pp , pools , delegatees ⟧ᵈᵉ ⊢
+        ⟦ vDelegs , sDelegs , rwds , dep ⟧ᵈ ⇀⦇ reg c d ,DELEG⦈
+        ⟦ vDelegs , sDelegs , rwds ∪ˡ ❴ c , 0 ❵ 
+        , updateCertDeposit pp (reg c d) dep ⟧ᵈ
 
 data _⊢_⇀⦇_,GOVCERT⦈_ : GovCertEnv → GState → DCert → GState → Type where
   GOVCERT-regdrep : ∀ {pp} → let open PParams pp in

--- a/src/Ledger/Conway/Conformance/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Certs.agda
@@ -54,6 +54,7 @@ certRefund _                = ∅
 
 updateCertDeposit  : PParams → DCert → Deposits → Deposits
 updateCertDeposit pp (delegate c _ _ v) deposits = deposits ∪⁺ ❴ CredentialDeposit c , v ❵
+updateCertDeposit pp (reg c _)          deposits = deposits ∪⁺ ❴ CredentialDeposit c , pp .PParams.keyDeposit ❵
 updateCertDeposit pp (regdrep c v _)    deposits = deposits ∪⁺ ❴ DRepDeposit c , v ❵
 updateCertDeposit pp (dereg c _)        deposits = deposits ∣ ❴ CredentialDeposit c ❵ ᶜ
 updateCertDeposit pp (deregdrep c _)    deposits = deposits ∣ ❴ DRepDeposit c ❵ ᶜ

--- a/src/Ledger/Conway/Conformance/Certs/Properties.agda
+++ b/src/Ledger/Conway/Conformance/Certs/Properties.agda
@@ -30,6 +30,9 @@ instance
     (dereg c d) → case ¿ (c , 0) ∈ rwds × (CredentialDeposit c , d) ∈ dep ¿ of λ where
       (yes p) → success (-, DELEG-dereg p)
       (no ¬p) → failure (genErrors ¬p)
+    (reg c d) → case ¿ c ∉ dom rwds × (d ≡ pp .PParams.keyDeposit ⊎ d ≡ 0) ¿ of λ where
+      (yes p) → success (-, DELEG-reg p)
+      (no ¬p) → failure (genErrors ¬p)
     _ → failure "Unexpected certificate in DELEG"
 
   Computational-DELEG .completeness ⟦ pp , pools , delegatees ⟧ᵈᵉ ⟦ _ , _ , rwds , dep ⟧ᵈ (delegate c mv mc d)
@@ -40,6 +43,8 @@ instance
                                            × mc ∈ mapˢ just (dom pools) ∪ ❴ nothing ❵ ¿) p .proj₂ = refl
   Computational-DELEG .completeness ⟦ _ , _ , _ ⟧ᵈᵉ ⟦ _ , _ , rwds , dep ⟧ᵈ (dereg c d) _ (DELEG-dereg p)
     rewrite dec-yes (¿ (c , 0) ∈ rwds × (CredentialDeposit c , d) ∈ dep ¿) p .proj₂ = refl
+  Computational-DELEG .completeness ⟦ pp , _ , _ ⟧ᵈᵉ ⟦ _ , _ , rwds , dep ⟧ᵈ (reg c d) _ (DELEG-reg p)
+    rewrite dec-yes (¿ c ∉ dom rwds × (d ≡ pp .PParams.keyDeposit ⊎ d ≡ 0) ¿) p .proj₂ = refl
 
   Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
   Computational-POOL .computeProof _ ps (regpool c _) =
@@ -92,6 +97,10 @@ instance
     "DELEG: " <> e₁ <> "\nPOOL: " <> e₂ <> "\nVDEL: " <> e₃
   Computational-CERT .completeness ⟦ _ , pp , _ , wdrls ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
     dCert@(delegate c mv mc d) ⟦ stᵈ' , stᵖ , stᵍ ⟧ᶜˢ (CERT-deleg h)
+    with computeProof ⟦ pp , PState.pools stᵖ , dom (GState.dreps stᵍ) ⟧ᵈᵉ stᵈ dCert | completeness _ _ _ _ h
+  ... | success _ | refl = refl
+  Computational-CERT .completeness ⟦ _ , pp , _ , wdrls ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ
+    dCert@(reg c d) ⟦ stᵈ' , stᵖ , stᵍ ⟧ᶜˢ (CERT-deleg h)
     with computeProof ⟦ pp , PState.pools stᵖ , dom (GState.dreps stᵍ) ⟧ᵈᵉ stᵈ dCert | completeness _ _ _ _ h
   ... | success _ | refl = refl
   Computational-CERT .completeness ⟦ _ , pp , _ , wdrls ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜˢ

--- a/src/Ledger/Conway/Foreign/HSLedger/Address.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Address.agda
@@ -3,6 +3,9 @@ module Ledger.Conway.Foreign.HSLedger.Address where
 open import Ledger.Conway.Foreign.HSLedger.BaseTypes
 
 instance
+  HsTy-HSVKey = autoHsType HSVKey
+  Conv-HSVKey = autoConvert HSVKey
+
   HsTy-Credential = autoHsType Credential
   Conv-Credential = autoConvert Credential
 

--- a/src/Ledger/Conway/Foreign/HSLedger/BaseTypes.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/BaseTypes.agda
@@ -64,7 +64,7 @@ instance
   Conv-ComputationResult : ConvertibleType ComputationResult F.ComputationResult
   Conv-ComputationResult = autoConvertible
 
-open ExternalStructures dummyExternalFunctions
+open import Ledger.Conway.Foreign.HSLedger.ExternalStructures dummyExternalFunctions
   renaming
     ( HSTransactionStructure to DummyTransactionStructure
     ; HSAbstractFunctions to DummyAbstractFunctions

--- a/src/Ledger/Conway/Foreign/HSLedger/Core.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Core.agda
@@ -22,16 +22,43 @@ open import Ledger.Transaction renaming (Vote to VoteTag) public
 
 open import Ledger.Conway.Foreign.Util public
 
-module _ {A : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : Show A ⦄ where instance
-  ∀Hashable : Hashable A A
-  ∀Hashable = λ where .hash → id
-
-  ∀isHashableSet : isHashableSet A
-  ∀isHashableSet = mkIsHashableSet A
+open import Tactic.Derive.DecEq
+open import Tactic.Derive.Show
 
 instance
   Hashable-⊤ : Hashable ⊤ ℕ
   Hashable-⊤ = λ where .hash tt → 0
+
+record HSVKey : Type where
+  constructor MkHSVKey
+  field hvkVKey       : ℕ
+        hvkStoredHash : ℕ
+
+{-# FOREIGN GHC
+  data HSVKey = MkHSVKey
+    { hvkVKey :: Integer
+    , hvkStoredHash :: Integer
+    }
+#-}
+{-# COMPILE GHC HSVKey = data HSVKey (MkHSVKey) #-}
+
+unquoteDecl DecEq-HSVKey = derive-DecEq ((quote HSVKey , DecEq-HSVKey) ∷ [])
+
+instance
+  Hashable-HSVKey : Hashable HSVKey ℕ
+  Hashable-HSVKey = λ where .hash → HSVKey.hvkStoredHash
+
+  isHashableSet-HSVKey : isHashableSet HSVKey
+  isHashableSet-HSVKey = mkIsHashableSet ℕ
+
+  Hashable-ℕ : Hashable ℕ ℕ
+  Hashable-ℕ = λ where .hash → id
+
+  isHashableSet-ℕ : isHashableSet ℕ
+  isHashableSet-ℕ = mkIsHashableSet ℕ
+
+unquoteDecl Show-HSVKey = derive-Show
+  ((quote HSVKey , Show-HSVKey) ∷ [])
 
 module Implementation where
   Network          = ℕ
@@ -41,16 +68,16 @@ module Implementation where
   NetworkId        = 0 -- Testnet
 
   SKey = ℕ
-  VKey = ℕ
+  VKey = HSVKey
   Sig  = ℕ
   Ser  = ℕ
 
-  isKeyPair  = _≡_
+  isKeyPair  = λ sk vk → sk ≡ HSVKey.hvkVKey vk
   sign       = _+_
   ScriptHash = ℕ
 
   Data         = ℕ
-  Dataʰ        = mkHashableSet Data
+  Dataʰ        = mkHashableSet ℕ
   toData : ∀ {A : Type} → A → Data
   toData _ = 0
 
@@ -99,124 +126,3 @@ module Implementation where
   AuxiliaryData   = ℕ
   DocHash         = ℕ
   tokenAlgebra    = coinTokenAlgebra
-
-module ExternalStructures (externalFunctions : ExternalFunctions) where
-  HSGlobalConstants = GlobalConstants ∋ record {Implementation}
-  instance
-    HSEpochStructure = EpochStructure  ∋ ℕEpochStructure HSGlobalConstants
-  
-    HSCrypto : Crypto
-    HSCrypto = record
-      { Implementation
-      ; pkk = HSPKKScheme
-      }
-      where
-      open ExternalFunctions externalFunctions
-      HSPKKScheme : PKKScheme
-      HSPKKScheme = record
-        { Implementation
-        ; isSigned         = λ a b m → extIsSigned a b m ≡ true
-        ; sign             = λ _ _ → zero
-          -- we can't prove these properties since the functions are provided by the Haskell implementation
-        ; isSigned-correct = error "isSigned-correct evaluated"
-        ; Dec-isSigned     = λ { {vk} {ser} {sig} → ⁇ (extIsSigned vk ser sig because error "Dec-isSigned evaluated") }
-        }
-  
-  -- No P2 scripts for now
-  
-  open import Ledger.Script it it
-  open import Ledger.Conway.Conformance.Script it it public
-  
-  instance
-    HSScriptStructure : ScriptStructure
-    HSScriptStructure = record
-      { p1s = P1ScriptStructure-HTL
-      ; hashRespectsUnion = hashRespectsUnion
-      ; ps = HSP2ScriptStructure
-      }
-      where
-        hashRespectsUnion : ∀ {A B ℍ}
-          → Hashable A ℍ → Hashable B ℍ
-          → Hashable (A ⊎ B) ℍ
-        hashRespectsUnion a _ .hash (inj₁ x) = hash ⦃ a ⦄ x
-        hashRespectsUnion _ b .hash (inj₂ y) = hash ⦃ b ⦄ y
-  
-        HSP2ScriptStructure : PlutusStructure
-        HSP2ScriptStructure = record
-          { Implementation
-          ; validPlutusScript = λ _ _ _ _ → ⊤
-          }
-  
-  open import Ledger.PParams it it it hiding (Acnt; DrepThresholds; PoolThresholds)
-  
-  HsGovParams : GovParams
-  HsGovParams = record
-    { Implementation
-    ; ppUpd = let open PParamsDiff in λ where
-        .UpdateT      → PParamsUpdate
-        .updateGroups → modifiedUpdateGroups
-        .applyUpdate  → applyPParamsUpdate
-        .ppWF? {u}    → ppWF u
-    ; ppHashingScheme = it
-    }
-    where
-      open PParamsUpdate
-      -- FIXME Replace `trustMe` with an actual proof
-      ppWF : (u : PParamsUpdate) →
-        ((pp : PParams) →
-        paramsWellFormed pp →
-        paramsWellFormed (applyPParamsUpdate pp u))
-        ⁇
-      ppWF u with paramsUpdateWellFormed? u
-      ... | yes _ = ⁇ (yes trustMe)
-        where
-          postulate
-            trustMe :
-              ((pp : PParams) →
-              paramsWellFormed pp →
-              paramsWellFormed (applyPParamsUpdate pp u))
-      ... | no _  = ⁇ (no trustMe)
-        where
-          postulate
-            trustMe :
-              ¬((pp : PParams) →
-              paramsWellFormed pp →
-              paramsWellFormed (applyPParamsUpdate pp u))
-  
-  instance
-    HSTransactionStructure : TransactionStructure
-    HSTransactionStructure = record
-      { Implementation
-      ; epochStructure  = HSEpochStructure
-      ; globalConstants = HSGlobalConstants
-      ; adHashingScheme = it
-      ; crypto          = HSCrypto
-      ; govParams       = HsGovParams
-      ; txidBytes       = id
-      ; scriptStructure = HSScriptStructure
-      }
-  
-  open TransactionStructure HSTransactionStructure public
-  open import Ledger.Certs govStructure public
-  
-  open import Ledger.Abstract it
-  
-  instance
-    HSAbstractFunctions : AbstractFunctions
-    HSAbstractFunctions = record
-      { Implementation
-      ; txscriptfee = λ tt y → 0
-      ; serSize     = λ v → v
-      ; indexOfImp  = record
-        { indexOfDCert    = λ _ _ → nothing
-        ; indexOfRwdAddr  = λ _ _ → nothing
-        ; indexOfTxIn     = λ _ _ → nothing
-        ; indexOfPolicyId = λ _ _ → nothing
-        ; indexOfVote     = λ _ _ → nothing
-        ; indexOfProposal = λ _ _ → nothing
-        }
-      ; runPLCScript = λ _ _ _ _ → false
-      ; scriptSize = λ _ → 0
-      }
-  
-  open import Ledger.Address Network KeyHash ScriptHash using () public

--- a/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
@@ -1,0 +1,126 @@
+open import Ledger.Conway.Foreign.ExternalFunctions
+
+module Ledger.Conway.Foreign.HSLedger.ExternalStructures (externalFunctions : ExternalFunctions) where
+
+open import Ledger.Crypto
+open import Ledger.Types.Epoch
+open import Ledger.Conway.Foreign.HSLedger.Core
+
+HSGlobalConstants = GlobalConstants ∋ record {Implementation}
+instance
+  HSEpochStructure = EpochStructure  ∋ ℕEpochStructure HSGlobalConstants
+
+  HSCrypto : Crypto
+  HSCrypto = record
+    { Implementation
+    ; pkk = HSPKKScheme
+    }
+    where
+    open ExternalFunctions externalFunctions
+    HSPKKScheme : PKKScheme
+    HSPKKScheme = record
+      { Implementation
+      ; isSigned         = λ a b m → extIsSigned (HSVKey.hvkVKey a) b m ≡ true
+      ; sign             = λ _ _ → zero
+        -- we can't prove these properties since the functions are provided by the Haskell implementation
+      ; isSigned-correct = error "isSigned-correct evaluated"
+      ; Dec-isSigned     = λ { {vk} {ser} {sig} → ⁇ (extIsSigned (HSVKey.hvkVKey vk) ser sig because error "Dec-isSigned evaluated") }
+      }
+
+-- No P2 scripts for now
+
+open import Ledger.Script it it
+open import Ledger.Conway.Conformance.Script it it public
+
+instance
+  HSScriptStructure : ScriptStructure
+  HSScriptStructure = record
+    { p1s = P1ScriptStructure-HTL
+    ; hashRespectsUnion = hashRespectsUnion
+    ; ps = HSP2ScriptStructure
+    }
+    where
+      hashRespectsUnion : ∀ {A B ℍ}
+        → Hashable A ℍ → Hashable B ℍ
+        → Hashable (A ⊎ B) ℍ
+      hashRespectsUnion a _ .hash (inj₁ x) = hash ⦃ a ⦄ x
+      hashRespectsUnion _ b .hash (inj₂ y) = hash ⦃ b ⦄ y
+
+      HSP2ScriptStructure : PlutusStructure
+      HSP2ScriptStructure = record
+        { Implementation
+        ; validPlutusScript = λ _ _ _ _ → ⊤
+        }
+
+open import Ledger.PParams it it it hiding (Acnt; DrepThresholds; PoolThresholds)
+
+HsGovParams : GovParams
+HsGovParams = record
+  { Implementation
+  ; ppUpd = let open PParamsDiff in λ where
+      .UpdateT      → PParamsUpdate
+      .updateGroups → modifiedUpdateGroups
+      .applyUpdate  → applyPParamsUpdate
+      .ppWF? {u}    → ppWF u
+  }
+  where
+    open PParamsUpdate
+    -- FIXME Replace `trustMe` with an actual proof
+    ppWF : (u : PParamsUpdate) →
+      ((pp : PParams) →
+      paramsWellFormed pp →
+      paramsWellFormed (applyPParamsUpdate pp u))
+      ⁇
+    ppWF u with paramsUpdateWellFormed? u
+    ... | yes _ = ⁇ (yes trustMe)
+      where
+        postulate
+          trustMe :
+            ((pp : PParams) →
+            paramsWellFormed pp →
+            paramsWellFormed (applyPParamsUpdate pp u))
+    ... | no _  = ⁇ (no trustMe)
+      where
+        postulate
+          trustMe :
+            ¬((pp : PParams) →
+            paramsWellFormed pp →
+            paramsWellFormed (applyPParamsUpdate pp u))
+
+instance
+  HSTransactionStructure : TransactionStructure
+  HSTransactionStructure = record
+    { Implementation
+    ; epochStructure  = HSEpochStructure
+    ; globalConstants = HSGlobalConstants
+    ; crypto          = HSCrypto
+    ; govParams       = HsGovParams
+    ; txidBytes       = id
+    ; scriptStructure = HSScriptStructure
+    ; adHashingScheme = isHashableSet-ℕ
+    }
+
+open TransactionStructure HSTransactionStructure public
+open import Ledger.Certs govStructure public
+
+open import Ledger.Abstract it
+
+instance
+  HSAbstractFunctions : AbstractFunctions
+  HSAbstractFunctions = record
+    { Implementation
+    ; txscriptfee = λ tt y → 0
+    ; serSize     = λ v → 0
+    ; indexOfImp  = record
+      { indexOfDCert    = λ _ _ → nothing
+      ; indexOfRwdAddr  = λ _ _ → nothing
+      ; indexOfTxIn     = λ _ _ → nothing
+      ; indexOfPolicyId = λ _ _ → nothing
+      ; indexOfVote     = λ _ _ → nothing
+      ; indexOfProposal = λ _ _ → nothing
+      }
+    ; runPLCScript = λ _ _ _ _ → false
+    ; scriptSize = λ _ → 0
+    }
+
+open import Ledger.Address Network KeyHash ScriptHash using () public

--- a/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
@@ -17,6 +17,7 @@ open import Foreign.Haskell.Coerce
 open import Ledger.Conway.Foreign.HSLedger.BaseTypes hiding (TxWitnesses)
 open import Ledger.Conway.Conformance.Utxo DummyTransactionStructure DummyAbstractFunctions
 open import Ledger.Conway.Conformance.Utxow DummyTransactionStructure DummyAbstractFunctions
+  renaming (module L to LW)
 
 instance
   HsTy-UTxOEnv = autoHsType UTxOEnv ⊣ withConstructor "MkUTxOEnv"
@@ -31,7 +32,7 @@ unquoteDecl = do
   hsTypeAlias Redeemer
 
 module _ (ext : ExternalFunctions) where
-  open ExternalStructures ext hiding (Tx; TxBody; inject)
+  open import Ledger.Conway.Foreign.HSLedger.ExternalStructures ext hiding (Tx; TxBody; inject)
   open import Ledger.Conway.Conformance.Utxow.Properties HSTransactionStructure HSAbstractFunctions
   open import Ledger.Conway.Conformance.Utxo.Properties HSTransactionStructure HSAbstractFunctions
 
@@ -77,11 +78,9 @@ module _ (ext : ExternalFunctions) where
         open TxWitnesses (coerce ⦃ TrustMe ⦄ wits)
      in unlines
        $ "witsVKeyNeeded utxo txb = "
-       ∷ show (witsVKeyNeeded utxo body)
+       ∷ show (LW.witsVKeyNeeded utxo body)
        ∷ "\nwitsKeyHashes = "
        ∷ show (mapˢ hash (dom vkSigs))
-       --∷ "\ncredsNeeded = "
-       --∷ show (credsNeeded utxo body)
        ∷ []
 
   {-# COMPILE GHC utxow-debug as utxowDebug #-}

--- a/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
@@ -14,8 +14,9 @@ open import Ledger.Conway.Foreign.HSLedger.Transaction
 
 open import Foreign.Haskell.Coerce
 
-open import Ledger.Conway.Foreign.HSLedger.BaseTypes
+open import Ledger.Conway.Foreign.HSLedger.BaseTypes hiding (TxWitnesses)
 open import Ledger.Conway.Conformance.Utxo DummyTransactionStructure DummyAbstractFunctions
+open import Ledger.Conway.Conformance.Utxow DummyTransactionStructure DummyAbstractFunctions
 
 instance
   HsTy-UTxOEnv = autoHsType UTxOEnv ⊣ withConstructor "MkUTxOEnv"
@@ -66,3 +67,21 @@ module _ (ext : ExternalFunctions) where
           []
 
   {-# COMPILE GHC utxo-debug as utxoDebug #-}
+
+  utxow-debug : HsType (UTxOEnv → UTxOState → Tx → String)
+  utxow-debug env st tx =
+    let open Tx (from tx)
+        open TxBody body
+        open UTxOState (from st)
+        open UTxOEnv (from env)
+        open TxWitnesses (coerce ⦃ TrustMe ⦄ wits)
+     in unlines
+       $ "witsVKeyNeeded utxo txb = "
+       ∷ show (witsVKeyNeeded utxo body)
+       ∷ "\nwitsKeyHashes = "
+       ∷ show (mapˢ hash (dom vkSigs))
+       --∷ "\ncredsNeeded = "
+       --∷ show (credsNeeded utxo body)
+       ∷ []
+
+  {-# COMPILE GHC utxow-debug as utxowDebug #-}

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -462,8 +462,6 @@ record PParamsDiff : Type₁ where
 record GovParams : Type₁ where
   field ppUpd : PParamsDiff
   open PParamsDiff ppUpd renaming (UpdateT to PParamsUpdate) public
-  field ppHashingScheme : isHashableSet PParams
-  open isHashableSet ppHashingScheme renaming (THash to PPHash) public
   field ⦃ DecEq-UpdT ⦄ : DecEq PParamsUpdate
 --         ⦃ Show-UpdT ⦄ : Show PParamsUpdate
 \end{code}

--- a/src/Ledger/ScriptValidation.agda
+++ b/src/Ledger/ScriptValidation.agda
@@ -16,6 +16,7 @@ module Ledger.ScriptValidation
   where
 
 open import Ledger.Certs govStructure
+open import Tactic.Derive.Show
 
 instance
   _ = DecEq-Slot

--- a/src/Ledger/ScriptValidation.agda
+++ b/src/Ledger/ScriptValidation.agda
@@ -79,6 +79,7 @@ txInfo l pp utxo tx = record
   } where open Tx tx; open TxBody body
 
 data DelegateOrDeReg : DCert → Type where instance
+  reg       : ∀ {x y} →     DelegateOrDeReg (reg x y)
   delegate  : ∀ {x y z w} → DelegateOrDeReg (delegate x y z w)
   dereg     : ∀ {x y} →     DelegateOrDeReg (dereg x y)
   regdrep   : ∀ {x y z} →   DelegateOrDeReg (regdrep x y z)
@@ -88,6 +89,7 @@ instance
   Dec-DelegateOrDeReg : DelegateOrDeReg ⁇¹
   Dec-DelegateOrDeReg {dc} .dec with dc
   ... | delegate _ _ _ _ = yes it
+  ... | reg _ _          = yes it
   ... | dereg _ _        = yes it
   ... | regdrep _ _ _    = yes it
   ... | deregdrep _ _    = yes it
@@ -126,6 +128,8 @@ certScripts d with ¿ DelegateOrDeReg d ¿
 ... | no ¬p = nothing
 certScripts c@(delegate  (KeyHashObj x) _ _ _) | yes p = nothing
 certScripts c@(delegate  (ScriptObj  y) _ _ _) | yes p = just (Cert c , y)
+certScripts c@(reg       (KeyHashObj x) _)     | yes p = nothing
+certScripts c@(reg       (ScriptObj  y) _)     | yes p = just (Cert c , y)
 certScripts c@(dereg     (KeyHashObj x) _)     | yes p = nothing
 certScripts c@(dereg     (ScriptObj  y) _)     | yes p = just (Cert c , y)
 certScripts c@(regdrep   (KeyHashObj x) _ _)   | yes p = nothing

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -662,25 +662,27 @@ module _ -- ASSUMPTION --
           ∎
         where open Prelude.≡-Reasoning
 
-  ≤certDeps  :  (certs : List DCert)
-                {d : DepositPurpose ⇀ Coin} {(dp , c) : DepositPurpose × Coin}
+  ≤certDeps  :  {d : DepositPurpose ⇀ Coin} {(dp , c) : DepositPurpose × Coin}
              →  getCoin d ≤ getCoin (d ∪⁺ ❴ (dp , c) ❵)
 
-  ≤certDeps certs {d} = begin
+  ≤certDeps {d} = begin
     getCoin d                      ≤⟨ m≤m+n (getCoin d) _ ⟩
     getCoin d + _                  ≡⟨ sym ∪⁺singleton≡ ⟩
     getCoin (d ∪⁺ ❴ _ ❵)           ∎
     where open ≤-Reasoning
 
+
   ≤updateCertDeps : (cs : List DCert) {pp : PParams} {deposits :  DepositPurpose ⇀ Coin}
     → noRefundCert cs
     → getCoin deposits ≤ getCoin (updateCertDeposits pp cs deposits)
   ≤updateCertDeps [] nrf = ≤-reflexive refl
+  ≤updateCertDeps (reg c v ∷ cs) {pp} {deposits} (_ All.∷ nrf) =
+    ≤-trans ≤certDeps (≤updateCertDeps cs {pp} {deposits ∪⁺ ❴ CredentialDeposit c , pp .PParams.keyDeposit ❵} nrf)
   ≤updateCertDeps (delegate c _ _ v ∷ cs) {pp} {deposits} (_ All.∷ nrf) =
-    ≤-trans (≤certDeps cs) (≤updateCertDeps cs {pp} {deposits ∪⁺ ❴ CredentialDeposit c , v ❵} nrf)
-  ≤updateCertDeps (regpool _ _ ∷ cs)       (_ All.∷ nrf) = ≤-trans (≤certDeps cs) (≤updateCertDeps cs nrf)
+    ≤-trans ≤certDeps (≤updateCertDeps cs {pp} {deposits ∪⁺ ❴ CredentialDeposit c , v ❵} nrf)
+  ≤updateCertDeps (regpool _ _ ∷ cs)       (_ All.∷ nrf) = ≤-trans ≤certDeps (≤updateCertDeps cs nrf)
   ≤updateCertDeps (retirepool _ _ ∷ cs)    (_ All.∷ nrf) = ≤updateCertDeps cs nrf
-  ≤updateCertDeps (regdrep _ _ _ ∷ cs)     (_ All.∷ nrf) = ≤-trans (≤certDeps cs) (≤updateCertDeps cs nrf)
+  ≤updateCertDeps (regdrep _ _ _ ∷ cs)     (_ All.∷ nrf) = ≤-trans ≤certDeps (≤updateCertDeps cs nrf)
   ≤updateCertDeps (ccreghot _ _ ∷ cs)      (_ All.∷ nrf) = ≤updateCertDeps cs nrf
 
   -- Main Theorem: General Minimum Spending Condition --

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -101,7 +101,7 @@ credsNeeded : UTxO → TxBody → ℙ (ScriptPurpose × Credential)
 credsNeeded utxo txb
   =  mapˢ (λ (i , o)  → (Spend  i , payCred (proj₁ o))) ((utxo ∣ txins) ˢ)
   ∪  mapˢ (λ a        → (Rwrd   a , stake a)) (dom (txwdrls .proj₁))
-  ∪  mapˢ (λ c        → (Cert   c , cwitness c)) (fromList txcerts)
+  ∪  mapPartial (λ c  → (Cert   c ,_) <$> cwitness c) (fromList txcerts)
   ∪  mapˢ (λ x        → (Mint   x , ScriptObj x)) (policies mint)
   ∪  mapˢ (λ v        → (Vote   v , proj₂ v)) (fromList (map voter txvote))
   ∪  mapPartial (λ p  → case  p .policy of

--- a/src/Ledger/hs-src/Lib.hs
+++ b/src/Ledger/hs-src/Lib.hs
@@ -35,7 +35,8 @@ import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.NewEpoch    as X
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.Ratify      as X
   (StakeDistrs(..), RatifyEnv(..), RatifyState(..), ratifyStep, ratifyDebug)
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.Utxo        as X
-  (UTxOEnv(..), UTxOState(..), UTxO, utxoStep, utxowStep, Redeemer, utxoDebug)
+  ( UTxOEnv(..), UTxOState(..), UTxO, utxoStep, utxowStep, Redeemer
+  , utxoDebug, utxowDebug)
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.BaseTypes   as X
   (Coin, ExUnits, Epoch)
 import MAlonzo.Code.Ledger.Conway.Foreign.ExternalFunctions    as X

--- a/src/Ledger/hs-src/Lib.hs
+++ b/src/Ledger/hs-src/Lib.hs
@@ -6,7 +6,7 @@ module Lib
 import MAlonzo.Code.Ledger.Conway.Foreign.HSTypes              as X
   (HSSet(..), HSMap(..), ComputationResult(..), Rational(..))
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.Address     as X
-  (Credential(..), BaseAddr(..), BootstrapAddr(..), RwdAddr(..), Addr)
+  (Credential(..), BaseAddr(..), BootstrapAddr(..), RwdAddr(..), Addr, HSVKey (..))
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.PParams     as X
   (DrepThresholds(..), PoolThresholds(..), Acnt(..), PParams(..), PParamsUpdate(..))
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.Transaction as X

--- a/src/Ledger/hs-src/test/UtxowSpec.hs
+++ b/src/Ledger/hs-src/test/UtxowSpec.hs
@@ -127,7 +127,7 @@ testTxBody1 = bodyFromSimple initParams $ MkSimpleTxBody
 testTx1 :: Tx
 testTx1 = MkTx
   { body = testTxBody1
-  , wits = MkTxWitnesses { vkSigs = MkHSMap [(0, 1)], scripts = MkHSSet [], txdats = MkHSMap [], txrdmrs = MkHSMap [] }
+  , wits = MkTxWitnesses { vkSigs = MkHSMap [(MkHSVKey 0 0, 1)], scripts = MkHSSet [], txdats = MkHSMap [], txrdmrs = MkHSMap [] }
   , txAD = Nothing
   , isValid = True
   }
@@ -146,7 +146,7 @@ testTxBody2 = bodyFromSimple initParams $ MkSimpleTxBody
 testTx2 :: Tx
 testTx2 = MkTx
   { body = testTxBody2
-  , wits = MkTxWitnesses { vkSigs = MkHSMap [(1, 3)], scripts = MkHSSet [], txdats = MkHSMap [], txrdmrs = MkHSMap [] }
+  , wits = MkTxWitnesses { vkSigs = MkHSMap [(MkHSVKey 1 1, 3)], scripts = MkHSSet [], txdats = MkHSMap [], txrdmrs = MkHSMap [] }
   , txAD = Nothing
   , isValid = True
   }

--- a/src/ScriptVerification/LedgerImplementation.agda
+++ b/src/ScriptVerification/LedgerImplementation.agda
@@ -154,7 +154,6 @@ SVGovParams = record
       .updateGroups           → λ _ → ∅
       .applyUpdate            → λ p _ → p
       .ppWF?                  → ⁇ yes λ _ → id
-  ; ppHashingScheme = it
   }
 
 SVGovStructure : GovStructure


### PR DESCRIPTION
# Description

Adds `reg` cert, which behaves similarly to `delegate c nothing nothing d`, except that it doesn't require witnessing. This is the legacy staking address registration certificate that we still want to support in Conway and hopefully we can get rid of in the future.

Adds `HSVKey`, which stores the verification key together with the hash that's provided during translation in conformance testing. This fixes the issue where the value of the VKey itself is used as the hash, which caused conformance tests to fail.

related: https://github.com/IntersectMBO/cardano-ledger/pull/4780
closes https://github.com/IntersectMBO/formal-ledger-specifications/issues/615

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
