### PR TITLE
Tweaked SlotsPerEpoch

### DIFF
--- a/src/Ledger/Conway/Foreign/HSLedger/Core.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Core.agda
@@ -62,7 +62,7 @@ unquoteDecl Show-HSVKey = derive-Show
 
 module Implementation where
   Network          = ℕ
-  SlotsPerEpochᶜ   = 100
+  SlotsPerEpochᶜ   = 4320 -- TODO pass this externally instead of hardcoding
   StabilityWindowᶜ = 10
   Quorum           = 1
   NetworkId        = 0 -- Testnet


### PR DESCRIPTION
# Description

This is necessary to be able to run Imp conformance tests which use a different value for `SlotsPerEpoch`.

The proper approach would be to implement https://github.com/IntersectMBO/formal-ledger-specifications/issues/624, but this will unblock me for the time being.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
