### PR TITLE
Improve the error message when a file hasn't been type checked

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -101,7 +101,7 @@ rec {
     '';
     postInstall = ''
       cp -r latex/ Makefile typecheck.time $out
-      sh checkTypeChecked.sh
+      sh checkTypeChecked.sh -m
     '';
     extraExtensions = [ "hs" "cabal" "py" ];
   };

--- a/src/checkTypeChecked.sh
+++ b/src/checkTypeChecked.sh
@@ -4,8 +4,10 @@ echo "Checking that all Agda files have been typechecked..."
 for agdaFn in $(find . -name '*.*agda'); do
   agdaiFn="_build/2.7.0/agda/${agdaFn%.*agda}.agdai"
   if [ "$(( $(stat -c "%Y" $agdaiFn) - $(stat -c "%Y" $agdaFn) ))" -lt "0" ]; then
-    echo "        FAIL: $agdaiFn is not up-to-date"
+    if [ "$1" = "-m" ]; then
+      echo "        FAIL: $agdaiFn does not exist. Please remove the corresponding agda file or import it somewhere, e.g. from the Everything module."
+    fi
     exit 1
   fi
 done
-echo "        PASS: all Agda files have been typechecked"
+echo "        PASS: all Agda files have been typechecked."


### PR DESCRIPTION
# Description

Just a minor wording improvement so that it becomes clear what to do when the script that checks if files have been checked fails.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
