### PR TITLE
Mark `Ledger.Conway.Conformance.Equivalence` safe

### DIFF
--- a/src/Ledger/Conway/Conformance/Equivalence.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 -- Proof that the rules under Ledger.Conway.Conformance are equivalent
 -- to the rules under Ledger.
 

--- a/src/Ledger/Conway/Conformance/Equivalence/Base.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Base.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 
 open import Ledger.Abstract
 open import Ledger.Transaction using (TransactionStructure)

--- a/src/Ledger/Conway/Conformance/Equivalence/Bisimilarity.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Bisimilarity.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 
 module Ledger.Conway.Conformance.Equivalence.Bisimilarity where
 

--- a/src/Ledger/Conway/Conformance/Equivalence/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Certs.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 
 open import Ledger.Prelude
 open import Ledger.Abstract

--- a/src/Ledger/Conway/Conformance/Equivalence/Convert.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Convert.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 
 module Ledger.Conway.Conformance.Equivalence.Convert where
 

--- a/src/Ledger/Conway/Conformance/Equivalence/Deposits.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Deposits.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 
 open import Ledger.Prelude
 open import Ledger.Abstract

--- a/src/Ledger/Conway/Conformance/Equivalence/Gov.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Gov.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --safe #-}
+
 open import Ledger.Prelude
 open import Ledger.Abstract
 open import Ledger.Transaction using (TransactionStructure)

--- a/src/Ledger/Conway/Conformance/Equivalence/Map.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Map.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --allow-unsolved-metas #-}
+{-# OPTIONS --safe #-}
 
 module Ledger.Conway.Conformance.Equivalence.Map where
 

--- a/src/Ledger/Conway/Conformance/Equivalence/Utxo.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Utxo.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 
 open import Ledger.Prelude
 open import Ledger.Abstract


### PR DESCRIPTION
# Description

I noticed that the equivalence proof was not marked as `--safe` and in fact one of the modules had a `--allow-unsolved-metas` still left in it. This PR fixes that.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
