### PR TITLE
Eliminate Boolean properties

### DIFF
--- a/src/Ledger/Conway/Conformance/Utxo.agda
+++ b/src/Ledger/Conway/Conformance/Utxo.agda
@@ -88,7 +88,7 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv → UTxOState → Tx → UTxOState → Type
     in
     ∙ txins ≢ ∅                              ∙ txins ∪ refInputs ⊆ dom utxo
     ∙ txins ∩ refInputs ≡ ∅                  ∙ L.inInterval slot txvldt
-    ∙ L.feesOK pp tx utxo ≡ true             ∙ L.consumed pp s txb ≡ L.produced pp s txb
+    ∙ L.feesOK pp tx utxo                    ∙ L.consumed pp s txb ≡ L.produced pp s txb
     ∙ coin mint ≡ 0                          ∙ txsize ≤ maxTxSize pp
     ∙ L.refScriptsSize utxo tx ≤ pp .maxRefScriptSizePerTx
 

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -238,9 +238,9 @@ Ingredients of the transaction body introduced in the Conway era are the followi
   isP2Script : Script → Type
   isP2Script = From-inj₂
 
-  isP2Script? : ∀ {s} → Dec (isP2Script s)
-  isP2Script? {inj₁ x} = true because ofʸ (lift tt)
-  isP2Script? {inj₂ y} = true because ofʸ y
+  isP2Script? : ∀ {s} → isP2Script s ⁇
+  isP2Script? {inj₁ x} .dec = true because ofʸ (lift tt)
+  isP2Script? {inj₂ y} .dec = true because ofʸ y
 
   instance
     HasCoin-TxOut : HasCoin TxOut

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -236,11 +236,11 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 
 \begin{code}[hide]
   isP2Script : Script → Type
-  isP2Script = From-inj₂
+  isP2Script = T ∘ is-just ∘ isInj₂
 
   isP2Script? : ∀ {s} → isP2Script s ⁇
-  isP2Script? {inj₁ x} .dec = true because ofʸ (lift tt)
-  isP2Script? {inj₂ y} .dec = true because ofʸ y
+  isP2Script? {inj₁ x} .dec = false because ofⁿ (λ ())
+  isP2Script? {inj₂ y} .dec = true because ofʸ tt
 
   instance
     HasCoin-TxOut : HasCoin TxOut

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -239,8 +239,8 @@ Ingredients of the transaction body introduced in the Conway era are the followi
   isP2Script = T ∘ is-just ∘ isInj₂
 
   isP2Script? : ∀ {s} → isP2Script s ⁇
-  isP2Script? {inj₁ x} .dec = false because ofⁿ (λ ())
-  isP2Script? {inj₂ y} .dec = true because ofʸ tt
+  isP2Script? {inj₁ x} .dec = no λ ()
+  isP2Script? {inj₂ y} .dec = yes tt
 
   instance
     HasCoin-TxOut : HasCoin TxOut

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -235,8 +235,12 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 \end{NoConway}
 
 \begin{code}[hide]
-  isP2Script : Script → Bool
-  isP2Script = is-just ∘ isInj₂
+  isP2Script : Script → Type
+  isP2Script = From-inj₂
+
+  isP2Script? : ∀ {s} → Dec (isP2Script s)
+  isP2Script? {inj₁ x} = true because ofʸ (lift tt)
+  isP2Script? {inj₂ y} = true because ofʸ y
 
   instance
     HasCoin-TxOut : HasCoin TxOut

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -47,7 +47,7 @@ isTwoPhaseScriptAddress : Tx → UTxO → Addr → Bool
 isTwoPhaseScriptAddress tx utxo a =
   if isScriptAddr a then
     (λ {p} → if lookupScriptHash (getScriptHash a p) tx utxo
-                 then (λ {s} → isP2Script s)
+                 then (λ {s} → isYes (isP2Script? {s}))
                  else false)
   else
     false

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -392,18 +392,15 @@ _≥ᵇ_ = flip _≤ᵇ_
 coinPolicies : ℙ ScriptHash
 coinPolicies = policies (inject 1)
 
-isAdaOnlyᵇ : Value → Bool
-isAdaOnlyᵇ v = toBool (policies v ≡ᵉ coinPolicies)
-
--- TODO: this could be a regular property
--- TODO: using this in UTxO rule below
+isAdaOnlyᵇ : Value → Type
+isAdaOnlyᵇ v = policies v ≡ᵉ coinPolicies
 \end{code}
 \begin{code}
 
 feesOK : PParams → Tx → UTxO → Bool
 feesOK pp tx utxo =  (  minfee pp utxo tx ≤ᵇ txfee ∧ not (≟-∅ᵇ (txrdmrs ˢ))
                         =>ᵇ  ( allᵇ (λ (addr , _) → ¿ isVKeyAddr addr ¿) collateralRange
-                             ∧ isAdaOnlyᵇ bal
+                             ∧ toBool (isAdaOnlyᵇ bal)
                              ∧ (coin bal * 100) ≥ᵇ (txfee * pp .collateralPercentage)
                              ∧ not (≟-∅ᵇ collateral)
                              )

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -399,14 +399,14 @@ instance
 coinPolicies : ℙ ScriptHash
 coinPolicies = policies (inject 1)
 
-isAdaOnlyᵇ : Value → Type
-isAdaOnlyᵇ v = policies v ≡ᵉ coinPolicies
+isAdaOnly : Value → Type
+isAdaOnly v = policies v ≡ᵉ coinPolicies
 \end{code}
 \begin{code}
 feesOK : PParams → Tx → UTxO → Type
-feesOK pp tx utxo = ( minfee pp utxo tx ≤ txfee × (txrdmrs ˢ ≢ ∅
+feesOK pp tx utxo = ( minfee pp utxo tx ≤ txfee × (txrdmrs ≢ ∅
                       → ( All (λ (addr , _) → isVKeyAddr addr) collateralRange
-                        × isAdaOnlyᵇ bal
+                        × isAdaOnly bal
                         × coin bal * 100 ≥ txfee * pp .collateralPercentage
                         × collateral ≢ ∅
                         )

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -404,7 +404,7 @@ isAdaOnly v = policies v ≡ᵉ coinPolicies
 \end{code}
 \begin{code}
 feesOK : PParams → Tx → UTxO → Type
-feesOK pp tx utxo = ( minfee pp utxo tx ≤ txfee × (txrdmrs ≢ ∅
+feesOK pp tx utxo = ( minfee pp utxo tx ≤ txfee × (txrdmrs ˢ ≢ ∅
                       → ( All (λ (addr , _) → isVKeyAddr addr) collateralRange
                         × isAdaOnly bal
                         × coin bal * 100 ≥ txfee * pp .collateralPercentage

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -56,10 +56,10 @@ isTwoPhaseScriptAddress tx utxo a =
 isTwoPhaseScriptAddress? : ∀ {tx utxo a} → isTwoPhaseScriptAddress tx utxo a ⁇
 isTwoPhaseScriptAddress? {tx} {utxo} {a} .dec
   with decide (isScriptAddr a)
-... | inj₂ _ = false because ofⁿ λ ()
+... | inj₂ _ = no λ ()
 ... | inj₁ p
   with decide (lookupScriptHash (getScriptHash a p) tx utxo)
-... | inj₂ _ = false because ofⁿ λ ()
+... | inj₂ _ = no λ ()
 ... | inj₁ s = isP2Script? {s} .dec
 
 record isTwoPhaseScriptAddress′ (tx : Tx) (utxo : UTxO) (a : Addr) : Type where

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -61,6 +61,15 @@ isTwoPhaseScriptAddress? {tx} {utxo} {a} .dec
   with decide (lookupScriptHash (getScriptHash a p) tx utxo)
 ... | inj₂ _ = false because ofⁿ λ ()
 ... | inj₁ s = isP2Script? {s} .dec
+
+record isTwoPhaseScriptAddress′ (tx : Tx) (utxo : UTxO) (a : Addr) : Type where
+  constructor wrap
+  field unwrap : isTwoPhaseScriptAddress tx utxo a
+
+instance
+  isTwoPhaseScriptAddress′? : ∀ {tx utxo a} → isTwoPhaseScriptAddress′ tx utxo a ⁇
+  isTwoPhaseScriptAddress′? {tx} {utxo} {a} = ⁇ (map′ wrap unwrap (isTwoPhaseScriptAddress? {tx} {utxo} {a} .dec))
+    where open isTwoPhaseScriptAddress′
 \end{code}
 \begin{code}[hide]
 opaque
@@ -71,8 +80,7 @@ opaque
 
   getInputHashes : Tx → UTxO → ℙ DataHash
   getInputHashes tx utxo = getDataHashes
-    (filterˢ (λ (a , _ ) → isTwoPhaseScriptAddress tx utxo a)
-             ⦃ λ {(a , _)} → isTwoPhaseScriptAddress? {tx} {utxo} {a} ⦄
+    (filterˢ (λ (a , _ ) → isTwoPhaseScriptAddress′ tx utxo a)
              (range (utxo ∣ txins)))
     where open Tx; open TxBody (tx .body)
 

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -385,12 +385,13 @@ isAdaOnlyᵇ v = policies v ≡ᵉ coinPolicies
 \end{code}
 \begin{code}
 feesOK : PParams → Tx → UTxO → Type
-feesOK pp tx utxo = ( minfee pp utxo tx ≤ txfee × txrdmrs ˢ ≢ ∅
+feesOK pp tx utxo = ( minfee pp utxo tx ≤ txfee × (txrdmrs ˢ ≢ ∅
                       → ( All (λ (addr , _) → isVKeyAddr addr) collateralRange
                         × isAdaOnlyᵇ bal
                         × coin bal * 100 ≥ txfee * pp .collateralPercentage
                         × collateral ≢ ∅
                         )
+                      )
                     )
   where
     open Tx tx; open TxBody body; open TxWitnesses wits; open PParams pp

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -92,7 +92,7 @@ instance
                 (inj₂ b₂') → case dec-de-morgan b₂' of λ where
                   (inj₁ a₂) → "¬ inInterval (UTxOEnv.slot Γ) (txvldt (Tx.body tx))"
                   (inj₂ b₂) → case dec-de-morgan b₂ of λ where
-                    (inj₁ a₃) → "¬ feesOK pp tx utxo ≡ true"
+                    (inj₁ a₃) → "¬ feesOK pp tx utxo"
                     (inj₂ b₃) → case dec-de-morgan b₃ of λ where
                         (inj₁ a₄) →
                           let


### PR DESCRIPTION
# Description

Addresses #342.

Original:
- [x] `actionWellFormed`
- [x] `isP2Script`
- [x] `isAdaOnlyᵇ`
- [x] `feesOK`

Other:
- [x] `isTwoPhaseScriptAddress`

Left:
- [ ] `isValid`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
