### PR TITLE
Replace a call to `error` in our FFI with a safe alternative

### DIFF
--- a/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
@@ -22,7 +22,7 @@ instance
       { Implementation
       ; isSigned         = λ a b m → extIsSigned (HSVKey.hvkVKey a) b m ≡ true
       ; sign             = λ _ _ → zero
-        -- we can't prove these properties since the functions are provided by the Haskell implementation
+        -- we can't prove correctness since the function is provided by the Haskell implementation
       ; isSigned-correct = error "isSigned-correct evaluated"
       ; Dec-isSigned     = ⁇ (_ ≟ _)
       }

--- a/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
@@ -24,7 +24,7 @@ instance
       ; sign             = λ _ _ → zero
         -- we can't prove these properties since the functions are provided by the Haskell implementation
       ; isSigned-correct = error "isSigned-correct evaluated"
-      ; Dec-isSigned     = λ { {vk} {ser} {sig} → ⁇ (extIsSigned (HSVKey.hvkVKey vk) ser sig because error "Dec-isSigned evaluated") }
+      ; Dec-isSigned     = ⁇ (_ ≟ _)
       }
 
 -- No P2 scripts for now


### PR DESCRIPTION
# Description

There was no need to be unsafe here. Our code just happened to not match on that proof, but this could have broken at any time when doing refactoring. In the Consensus spec (which copies our code), this actually caused a crash.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
