### PR TITLE
Fix indentation of record fields in PDF

### DIFF
--- a/src/Ledger/Enact.lagda
+++ b/src/Ledger/Enact.lagda
@@ -31,7 +31,7 @@ Note that all other fields of \EnactState also contain a \GovActionID
 since they are \HashProtected.
 
 \begin{figure*}[h]
-\begin{AgdaSuppressSpace}
+\begin{AgdaMultiCode}
 \begin{code}
 record EnactEnv : Type where
 \end{code}
@@ -90,7 +90,7 @@ data
 \begin{code}
   _⊢_⇀⦇_,ENACT⦈_ : EnactEnv → EnactState → GovAction → EnactState → Type
 \end{code}
-\end{AgdaSuppressSpace}
+\end{AgdaMultiCode}
 \caption{Types and function used for the ENACT transition system}
 \label{fig:enact-defs}
 \end{figure*}

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -61,7 +61,6 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 
 \begin{figure*}[h]
 \emph{Abstract types}
-\begin{AgdaMultiCode}
 \begin{code}
         Ix TxId AuxiliaryData : Type
 \end{code}
@@ -110,7 +109,6 @@ Ingredients of the transaction body introduced in the Conway era are the followi
   open GovernanceActions hiding (Vote; yes; no; abstain) public
 
   open import Ledger.Certs govStructure using (DCert)
-
 \end{code}
 \begin{NoConway}
 \emph{Derived types}
@@ -126,6 +124,7 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 \end{code}
 \end{NoConway}
 \emph{Transaction types}
+\begin{AgdaMultiCode}
 \begin{code}
   record TxBody : Type where
 \end{code}


### PR DESCRIPTION
# Description

This fixes the indentation of records in Figures 17 and 44 in the PDF.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
