### PR TITLE
Make the usage of field keyword consistent

### DIFF
--- a/src/Ledger/Certs.lagda
+++ b/src/Ledger/Certs.lagda
@@ -38,11 +38,7 @@ instance
 \begin{NoConway}
 \begin{code}
 record PoolParams : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     rewardAddr : Credential
 \end{code}
 \end{NoConway}
@@ -92,12 +88,8 @@ cwitness (reg c (suc _))     = just c
 \begin{AgdaMultiCode}
 \begin{code}
 record CertEnv : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_,_,_⟧ᶜ
   field
-\end{code}
-\begin{code}
     epoch     : Epoch
     pp        : PParams
     votes     : List GovVote
@@ -105,12 +97,8 @@ record CertEnv : Type where
     coldCreds : ℙ Credential
 
 record DState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_⟧ᵈ
   field
-\end{code}
-\begin{code}
     voteDelegs   : Credential ⇀ VDeleg
     stakeDelegs  : Credential ⇀ KeyHash
     rewards      : Credential ⇀ Coin
@@ -119,12 +107,8 @@ record DState : Type where
 \begin{code}
 
 record PState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_⟧ᵖ
   field
-\end{code}
-\begin{code}
     pools     : KeyHash ⇀ PoolParams
     retiring  : KeyHash ⇀ Epoch
 \end{code}
@@ -132,33 +116,21 @@ record PState : Type where
 \begin{code}
 
 record GState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_⟧ᵛ
   field
-\end{code}
-\begin{code}
     dreps      : Credential ⇀ Epoch
     ccHotKeys  : Credential ⇀ Maybe Credential
 
 record CertState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_⟧ᶜˢ
   field
-\end{code}
-\begin{code}
     dState : DState
     pState : PState
     gState : GState
 
 record DelegEnv : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_⟧ᵈᵉ
   field
-\end{code}
-\begin{code}
     pparams       : PParams
     pools         : KeyHash ⇀ PoolParams
     delegatees    : ℙ Credential

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -26,19 +26,11 @@ open import Ledger.Certs govStructure
 \begin{AgdaMultiCode}
 \begin{code}
 record ChainState : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     newEpochState  : NewEpochState
 
 record Block : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     ts    : List Tx
     slot  : Slot
 \end{code}

--- a/src/Ledger/Crypto.lagda
+++ b/src/Ledger/Crypto.lagda
@@ -23,7 +23,7 @@ record HashableSet : Type₁ where
 We rely on a public key signing scheme for verification of spending.
 \begin{figure*}[h]
 \begin{AgdaMultiCode}
-\begin{code}
+\begin{code}[hide]
 record PKKScheme : Type₁ where
   field
 \end{code}
@@ -35,6 +35,7 @@ record PKKScheme : Type₁ where
     sign               : SKey → Ser → Sig
 
   KeyPair = Σ[ sk ∈ SKey ] Σ[ vk ∈ VKey ] isKeyPair sk vk
+
 \end{code}
 \begin{code}[hide]
   field

--- a/src/Ledger/Crypto.lagda
+++ b/src/Ledger/Crypto.lagda
@@ -19,34 +19,39 @@ record HashableSet : Type₁ where
   field T : Type; ⦃ T-isHashable ⦄ : isHashableSet T
   open isHashableSet T-isHashable public
 
-record PKKScheme : Type₁ where
-  field
 \end{code}
 We rely on a public key signing scheme for verification of spending.
 \begin{figure*}[h]
+\begin{AgdaMultiCode}
+\begin{code}
+record PKKScheme : Type₁ where
+  field
+\end{code}
 \emph{Types \& functions}
 \begin{code}
-        SKey VKey Sig Ser  : Type
-        isKeyPair          : SKey → VKey → Type
-        isSigned           : VKey → Ser → Sig → Type
-        sign               : SKey → Ser → Sig
+    SKey VKey Sig Ser  : Type
+    isKeyPair          : SKey → VKey → Type
+    isSigned           : VKey → Ser → Sig → Type
+    sign               : SKey → Ser → Sig
 
   KeyPair = Σ[ sk ∈ SKey ] Σ[ vk ∈ VKey ] isKeyPair sk vk
 \end{code}
-\emph{Property of signatures}
 \begin{code}[hide]
-  field ⦃ Dec-isSigned ⦄ : isSigned ⁇³
-        isSigned-correct :
+  field
+    ⦃ Dec-isSigned ⦄ : isSigned ⁇³
 \end{code}
+\emph{Property of signatures}
 \begin{code}
-          ((sk , vk , _) : KeyPair) (d : Ser) (σ : Sig) → sign sk d ≡ σ → isSigned vk d σ
+    isSigned-correct  : ((sk , vk , _) : KeyPair) (d : Ser) (σ : Sig)
+                      → sign sk d ≡ σ → isSigned vk d σ
 \end{code}
+\end{AgdaMultiCode}
 \caption{Definitions for the public key signature scheme}
 \label{fig:defs:crypto}
 \end{figure*}
 \begin{code}[hide]
-        ⦃ DecEq-Sig  ⦄ : DecEq Sig
-        ⦃ DecEq-Ser  ⦄ : DecEq Ser
+    ⦃ DecEq-Sig  ⦄ : DecEq Sig
+    ⦃ DecEq-Ser  ⦄ : DecEq Ser
 
 record Crypto : Type₁ where
   field pkk : PKKScheme

--- a/src/Ledger/Enact.lagda
+++ b/src/Ledger/Enact.lagda
@@ -34,22 +34,14 @@ since they are \HashProtected.
 \begin{AgdaMultiCode}
 \begin{code}
 record EnactEnv : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_⟧ᵉ
   field
-\end{code}
-\begin{code}
     gid       : GovActionID
     treasury  : Coin
     epoch     : Epoch
 
 record EnactState : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     cc            : HashProtected (Maybe ((Credential ⇀ Epoch) × ℚ))
     constitution  : HashProtected (DocHash × Maybe ScriptHash)
     pv            : HashProtected ProtVer

--- a/src/Ledger/Epoch.lagda
+++ b/src/Ledger/Epoch.lagda
@@ -64,12 +64,8 @@ record Snapshots : Set where
 \end{NoConway}
 \begin{code}
 record EpochState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_,_,_⟧ᵉ'
   field
-\end{code}
-\begin{code}
     acnt       : Acnt
     ss         : Snapshots
     ls         : LState
@@ -79,12 +75,8 @@ record EpochState : Type where
 \begin{NoConway}
 \begin{code}
 record NewEpochState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_⟧ⁿᵉ
   field
-\end{code}
-\begin{code}
     lastEpoch   : Epoch
     epochState  : EpochState
     ru          : Maybe RewardUpdate

--- a/src/Ledger/Gov.lagda
+++ b/src/Ledger/Gov.lagda
@@ -41,12 +41,8 @@ GovState : Type
 GovState = List (GovActionID × GovActionState)
 
 record GovEnv : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_,_,_,_⟧ᵍ
   field
-\end{code}
-\begin{code}
     txid        : TxId
     epoch       : Epoch
     pparams     : PParams

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -48,11 +48,7 @@ data VDeleg : Type where
   noConfidenceRep  :                         VDeleg
 
 record Anchor : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     url   : String
     hash  : DocHash
 
@@ -182,22 +178,14 @@ data Vote : Type where
   yes no abstain  : Vote
 
 record GovVote : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     gid         : GovActionID
     voter       : Voter
     vote        : Vote
     anchor      : Maybe Anchor
 
 record GovProposal : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     action      : GovAction
     prevAction  : NeedsHash action
     policy      : Maybe ScriptHash
@@ -206,11 +194,7 @@ record GovProposal : Type where
     anchor      : Anchor
 
 record GovActionState : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     votes       : Voter ⇀ Vote
     returnAddr  : RwdAddr
     expiresIn   : Epoch

--- a/src/Ledger/Introduction.lagda
+++ b/src/Ledger/Introduction.lagda
@@ -144,11 +144,7 @@ over the state transition relation.
 \begin{AgdaMultiCode}
 \begin{code}
 record Computational (_⊢_⇀⦇_,X⦈_ : C → S → Sig → S → Type) : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     compute     : C → S → Sig → Maybe S
     ≡-just⇔STS  : compute Γ s b ≡ just s' ⇔ Γ ⊢ s ⇀⦇ b ,X⦈ s'
 

--- a/src/Ledger/Ledger.lagda
+++ b/src/Ledger/Ledger.lagda
@@ -34,12 +34,8 @@ defined transition systems.
 \begin{AgdaMultiCode}
 \begin{code}
 record LEnv : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_,_,_⟧ˡᵉ
   field
-\end{code}
-\begin{code}
     slot        : Slot
     ppolicy     : Maybe ScriptHash
     pparams     : PParams
@@ -47,12 +43,8 @@ record LEnv : Type where
     treasury    : Coin
 
 record LState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_⟧ˡ
   field
-\end{code}
-\begin{code}
     utxoSt     : UTxOState
     govSt      : GovState
     certState  : CertState

--- a/src/Ledger/NewPP.lagda
+++ b/src/Ledger/NewPP.lagda
@@ -20,11 +20,7 @@ record NewPParamEnv : Type where
 \begin{code}
 record NewPParamState : Type where
   constructor ⟦_,_⟧ⁿᵖ
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     pparams  : PParams
     ppup     : PPUpdateState
 

--- a/src/Ledger/PPUp.lagda
+++ b/src/Ledger/PPUp.lagda
@@ -24,20 +24,12 @@ private variable m n : ℕ
 GenesisDelegation = KeyHash ⇀ (KeyHash × KeyHash)
 
 record PPUpdateState : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     pup   : ProposedPPUpdates
     fpup  : ProposedPPUpdates
 
 record PPUpdateEnv : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     slot       : Slot
     pparams    : PParams
     genDelegs  : GenesisDelegation

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -39,12 +39,8 @@ remain in treasury and reserves.
 \begin{AgdaMultiCode}
 \begin{code}
 record Acnt : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_⟧ᵃ
   field
-\end{code}
-\begin{code}
     treasury reserves : Coin
 
 ProtVer : Type
@@ -75,24 +71,14 @@ data PParamGroup : Type where
   SecurityGroup    : PParamGroup
 
 record DrepThresholds : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     P1 P2a P2b P3 P4 P5a P5b P5c P5d P6 : ℚ
 
 record PoolThresholds : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     Q1 Q2a Q2b Q4 Q5e : ℚ
 
 record PParams : Type where
-\end{code}
-\begin{code}[hide]
   field
 \end{code}
 \emph{Network group}
@@ -433,7 +419,7 @@ something) and if it preserves well-formedness.
 
 \begin{figure*}[ht]
 \begin{AgdaMultiCode}
-\begin{code}[hide]
+\begin{code}
 record PParamsDiff : Type₁ where
   field
 \end{code}

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -436,7 +436,7 @@ something) and if it preserves well-formedness.
 
 \begin{figure*}[ht]
 \begin{AgdaMultiCode}
-\begin{code}
+\begin{code}[hide]
 record PParamsDiff : Type₁ where
   field
 \end{code}

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -185,19 +185,11 @@ by at least half of the SPO stake.
 \begin{AgdaMultiCode}
 \begin{code}
 record StakeDistrs : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     stakeDistr  : VDeleg ⇀ Coin
 
 record RatifyEnv : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     stakeDistrs   : StakeDistrs
     currentEpoch  : Epoch
     dreps         : Credential ⇀ Epoch
@@ -207,12 +199,8 @@ record RatifyEnv : Type where
     delegatees    : Credential ⇀ VDeleg
 
 record RatifyState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_⟧ʳ
   field
-\end{code}
-\begin{code}
     es              : EnactState
     removed         : ℙ (GovActionID × GovActionState)
     delay           : Bool

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -10,6 +10,7 @@ module Ledger.TokenAlgebra (
 \emph{Abstract types}
 \begin{code}
   PolicyId
+
 \end{code}
 \begin{code}[hide]
   : Type) where
@@ -40,6 +41,8 @@ record TokenAlgebra : Type₁ where
 
   open MonoidMorphisms (rawMonoid) (Monoid.rawMonoid +-0-monoid) public
   field
+\end{code}
+\begin{code}
     coin                      : Value → Coin
     inject                    : Coin → Value
     policies                  : Value → ℙ PolicyId

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -28,11 +28,7 @@ MemoryEstimate = ℕ
 \AgdaTarget{TokenAlgebra}
 \begin{code}
 record TokenAlgebra : Type₁ where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     Value : Set
     ⦃ Value-CommutativeMonoid ⦄ : CommutativeMonoid 0ℓ 0ℓ Value
 
@@ -44,8 +40,6 @@ record TokenAlgebra : Type₁ where
 
   open MonoidMorphisms (rawMonoid) (Monoid.rawMonoid +-0-monoid) public
   field
-\end{code}
-\begin{code}
     coin                      : Value → Coin
     inject                    : Coin → Value
     policies                  : Value → ℙ PolicyId

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -30,8 +30,6 @@ data Tag : Type where
   Spend Mint Cert Rewrd Vote Propose : Tag
 unquoteDecl DecEq-Tag = derive-DecEq ((quote Tag , DecEq-Tag) ∷ [])
 
-record TransactionStructure : Type₁ where
-  field
 \end{code}
 
 Transactions are defined in Figure~\ref{fig:defs:transactions}. A
@@ -60,9 +58,11 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 \end{Conway}
 
 \begin{figure*}[h]
-\emph{Abstract types}
 \begin{code}
-        Ix TxId AuxiliaryData : Type
+record TransactionStructure : Type₁ where
+  field
+    -- Abstract types
+    Ix TxId AuxiliaryData : Type
 \end{code}
 \begin{code}[hide]
         ⦃ DecEq-Ix   ⦄ : DecEq Ix
@@ -127,11 +127,7 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 \begin{AgdaMultiCode}
 \begin{code}
   record TxBody : Type where
-\end{code}
-\begin{code}[hide]
     field
-\end{code}
-\begin{code}
       txins          : ℙ TxIn
       refInputs      : ℙ TxIn
       txouts         : Ix ⇀ TxOut
@@ -156,11 +152,7 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 \begin{NoConway}
 \begin{code}
   record TxWitnesses : Type where
-\end{code}
-\begin{code}[hide]
     field
-\end{code}
-\begin{code}
       vkSigs   : VKey ⇀ Sig
       scripts  : ℙ Script
       txdats   : DataHash ⇀ Datum
@@ -170,11 +162,7 @@ Ingredients of the transaction body introduced in the Conway era are the followi
     scriptsP1 = mapPartial isInj₁ scripts
 
   record Tx : Type where
-\end{code}
-\begin{code}[hide]
     field
-\end{code}
-\begin{code}
       body     : TxBody
       wits     : TxWitnesses
       isValid  : Bool

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -61,8 +61,11 @@ Ingredients of the transaction body introduced in the Conway era are the followi
 \begin{code}
 record TransactionStructure : Type₁ where
   field
-    -- Abstract types
+\end{code}
+\emph{Abstract types}
+\begin{code}
     Ix TxId AuxiliaryData : Type
+
 \end{code}
 \begin{code}[hide]
     ⦃ DecEq-Ix   ⦄ : DecEq Ix

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -65,9 +65,9 @@ record TransactionStructure : Type₁ where
     Ix TxId AuxiliaryData : Type
 \end{code}
 \begin{code}[hide]
-        ⦃ DecEq-Ix   ⦄ : DecEq Ix
-        ⦃ DecEq-TxId ⦄ : DecEq TxId
-        adHashingScheme : isHashableSet AuxiliaryData
+    ⦃ DecEq-Ix   ⦄ : DecEq Ix
+    ⦃ DecEq-TxId ⦄ : DecEq TxId
+    adHashingScheme : isHashableSet AuxiliaryData
   open isHashableSet adHashingScheme renaming (THash to ADHash) public
 
   field globalConstants : _

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -148,11 +148,7 @@ the new deposits logic in older eras and then replaying the chain.
 \emph{UTxO environment}
 \begin{code}
 record UTxOEnv : Type where
-\end{code}
-\begin{code}[hide]
   field
-\end{code}
-\begin{code}
     slot      : Slot
     pparams   : PParams
     treasury  : Coin
@@ -161,12 +157,8 @@ record UTxOEnv : Type where
 \emph{UTxO states}
 \begin{code}
 record UTxOState : Type where
-\end{code}
-\begin{code}[hide]
   constructor ⟦_,_,_,_⟧ᵘ
   field
-\end{code}
-\begin{code}
     utxo       : UTxO
     fees       : Coin
     deposits   : Deposits

--- a/src/MidnightExample/Ledger.lagda
+++ b/src/MidnightExample/Ledger.lagda
@@ -46,8 +46,9 @@ points in the chain.
 \AgdaTarget{Point, slot, blockHash, slotsInEpoch, epochOf}
 \begin{code}
 record Point : Type where
-  field  slot       : Maybe ℕ
-         blockHash  : Hash
+  field
+    slot       : Maybe ℕ
+    blockHash  : Hash
 
 slotsInEpoch : ℕ
 slotsInEpoch = 50
@@ -95,15 +96,17 @@ instance
 \AgdaTarget{Header, slotNo, blockNo, blockHash, prev, nodeId, Block, header, body, blockPoint, computeBlockHash, addBlockHash}
 \begin{code}
 record Header : Type where
-  field  slotNo     : ℕ
-         blockNo    : ℕ
-         blockHash  : Hash
-         prev       : ℕ
-         nodeId     : ℕ
+  field
+    slotNo     : ℕ
+    blockNo    : ℕ
+    blockHash  : Hash
+    prev       : ℕ
+    nodeId     : ℕ
 
 record Block : Type where
-  field  header  : Header
-         body    : List Tx
+  field
+    header  : Header
+    body    : List Tx
 
   open Header header public
 
@@ -133,9 +136,10 @@ The ledger state consists of a pointer to the previous block as well as a counte
 \begin{AgdaSuppressSpace}
 \begin{code}
 record LedgerState : Type where
-  field  tip                  : Point
-         count                : ℤ
-         snapshot1 snapshot2  : ℤ
+  field
+    tip                  : Point
+    count                : ℤ
+    snapshot1 snapshot2  : ℤ
 
 \end{code}
 \begin{code}[hide]


### PR DESCRIPTION
# Description

This closes issue #656

+ Remove all `\begin{code}[hide]` blocks surrounding occurrences of `field` keyword

+ Unhide record constructor bracket syntax definitions, since this was inconsistent (some constructor syntax definitions were hidden and some were not).

+ Make indentation convention for field names in `lagda` files consistent.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
