### PR TITLE
Moved action specific predicates to actionWellFormed and fix a conformance failure

### DIFF
--- a/src/Ledger/Conway/Conformance/Equivalence.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence.agda
@@ -396,8 +396,8 @@ opaque
           → (record Γ { certState = certState' } , n)
             ⊢ s ⇀⦇ txgov ,GOVn⦈ s'
   castGOV deps (BS-base Id-nop) = BS-base Id-nop
-  castGOV {Γ} deps (BS-ind (C.GOV-Vote {voter = voter} (a , b , c)) rs) =
-    BS-ind (C.GOV-Vote (a , b , cast-isRegistered Γ deps voter c))
+  castGOV {Γ} deps (BS-ind (C.GOV-Vote {voter = voter} (a , b , c , d)) rs) =
+    BS-ind (C.GOV-Vote (a , b , cast-isRegistered Γ deps voter c , d))
            (castGOV deps rs)
   castGOV deps (BS-ind (C.GOV-Propose h) rs) =
     BS-ind (C.GOV-Propose h)

--- a/src/Ledger/Conway/Conformance/Equivalence/Gov.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Gov.agda
@@ -41,7 +41,7 @@ instance
             → L.Deposits × L.Deposits
               ⊢ (Γ , n) L.⊢ s ⇀⦇ votes ,GOV'⦈ s' ⭆ⁱ λ deposits _ →
                 (deposits ⊢conv Γ , n) C.⊢ s ⇀⦇ votes ,GOV'⦈ s'
-  GOV'ToConf .convⁱ deposits (L.GOV-Vote (a , b , c)) = C.GOV-Vote (a , b , deposits ⊢conv c)
+  GOV'ToConf .convⁱ deposits (L.GOV-Vote (a , b , c , d)) = C.GOV-Vote (a , b , deposits ⊢conv c , d)
   GOV'ToConf .convⁱ deposits (L.GOV-Propose h) = C.GOV-Propose h
 
   GOVToConf : ∀ {Γ s votes s' n}
@@ -53,7 +53,7 @@ instance
 
   GOV'FromConf : ∀ {Γ s votes s' n}
             → (Γ , n) C.⊢ s ⇀⦇ votes ,GOV'⦈ s' ⭆ (conv Γ , n) L.⊢ s ⇀⦇ votes ,GOV'⦈ s'
-  GOV'FromConf .convⁱ _ (C.GOV-Vote (a , b , c)) = L.GOV-Vote (a , b , conv c)
+  GOV'FromConf .convⁱ _ (C.GOV-Vote (a , b , c , d)) = L.GOV-Vote (a , b , conv c , d)
   GOV'FromConf .convⁱ _ (C.GOV-Propose h)        = L.GOV-Propose h
 
   GOVFromConf : ∀ {Γ s votes s' n}

--- a/src/Ledger/Conway/Conformance/Equivalence/Gov.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Gov.agda
@@ -16,12 +16,12 @@ open import Ledger.Conway.Conformance.Equivalence.Certs txs abs
 
 instance
   GovEnvToConf : L.Deposits × L.Deposits ⊢ L.GovEnv ⭆ C.GovEnv
-  GovEnvToConf .convⁱ deposits L.⟦ txid , epoch , pp , policy , enactState , certState ⟧ᵍ =
-    C.⟦ txid , epoch , pp , policy , enactState , deposits ⊢conv certState ⟧ᵍ
+  GovEnvToConf .convⁱ deposits L.⟦ txid , epoch , pp , policy , enactState , certState , stakeDelegs ⟧ᵍ =
+    C.⟦ txid , epoch , pp , policy , enactState , deposits ⊢conv certState , stakeDelegs ⟧ᵍ
 
   GovEnvFromConf : C.GovEnv ⭆ L.GovEnv
-  GovEnvFromConf .convⁱ _ C.⟦ txid , epoch , pp , policy , enactState , certState ⟧ᵍ =
-    L.⟦ txid , epoch , pp , policy , enactState , conv certState ⟧ᵍ
+  GovEnvFromConf .convⁱ _ C.⟦ txid , epoch , pp , policy , enactState , certState , stakeDelegs ⟧ᵍ =
+    L.⟦ txid , epoch , pp , policy , enactState , conv certState , stakeDelegs ⟧ᵍ
 
   opaque
     unfolding L.isRegistered C.isRegistered

--- a/src/Ledger/Conway/Conformance/Gov.agda
+++ b/src/Ledger/Conway/Conformance/Gov.agda
@@ -77,6 +77,7 @@ data _⊢_⇀⦇_,GOV'⦈_  : GovEnv × ℕ → GovState → GovVote ⊎ GovProp
     ∙ (aid , ast) ∈ fromList s
     ∙ canVote pparams (action ast) (proj₁ voter)
     ∙ isRegistered Γ voter
+    ∙ ¬ (expired epoch ast)
       ───────────────────────────────────────
       (Γ , k) ⊢ s ⇀⦇ inj₁ vote ,GOV'⦈ L.addVote s aid voter v
 
@@ -86,11 +87,13 @@ data _⊢_⇀⦇_,GOV'⦈_  : GovEnv × ℕ → GovState → GovVote ⊎ GovProp
                     ; policy = p ; deposit = d ; prevAction = prev }
       s' = L.addAction s (govActionLifetime +ᵉ epoch) (txid , k) addr a prev
     in
-    ∙ L.actionWellFormed rewardCreds p ppolicy epoch a
+    ∙ L.actionWellFormed a
+    ∙ L.actionValid rewardCreds p ppolicy epoch a
     ∙ d ≡ govActionDeposit
     ∙ L.validHFAction prop s enactState
     ∙ L.hasParent enactState s a prev
     ∙ addr .RwdAddr.net ≡ NetworkId
+    ∙ addr .RwdAddr.stake ∈ rewardCreds
       ───────────────────────────────────────
       (Γ , k) ⊢ s ⇀⦇ inj₂ prop ,GOV'⦈ s'
 

--- a/src/Ledger/Conway/Conformance/Gov.agda
+++ b/src/Ledger/Conway/Conformance/Gov.agda
@@ -42,7 +42,7 @@ record GovEnv : Type where
     ppolicy     : Maybe ScriptHash
     enactState  : EnactState
     certState   : CertState
-    stakeCreds  : Credential ⇀ KeyHash
+    rewardCreds : ℙ Credential
 
 private variable
   Γ : GovEnv
@@ -86,7 +86,7 @@ data _⊢_⇀⦇_,GOV'⦈_  : GovEnv × ℕ → GovState → GovVote ⊎ GovProp
                     ; policy = p ; deposit = d ; prevAction = prev }
       s' = L.addAction s (govActionLifetime +ᵉ epoch) (txid , k) addr a prev
     in
-    ∙ L.actionWellFormed stakeCreds p ppolicy epoch a
+    ∙ L.actionWellFormed rewardCreds p ppolicy epoch a
     ∙ d ≡ govActionDeposit
     ∙ L.validHFAction prop s enactState
     ∙ L.hasParent enactState s a prev

--- a/src/Ledger/Conway/Conformance/Gov/Properties.agda
+++ b/src/Ledger/Conway/Conformance/Gov/Properties.agda
@@ -36,10 +36,6 @@ open GovActionState
 open Inverse
 
 private
-  lookupActionId : (pparams : PParams) (role : GovRole) (aid : GovActionID) (s : GovState) →
-                   Dec (Any (λ (aid' , ast) → aid ≡ aid' × canVote pparams (action ast) role) s)
-  lookupActionId pparams role aid = any? λ _ → ¿ _ ¿
-
   isUpdateCommittee : (a : GovAction) → Dec (∃[ new ] ∃[ rem ] ∃[ q ] a ≡ UpdateCommittee new rem q)
   isUpdateCommittee NoConfidence                = no λ()
   isUpdateCommittee (UpdateCommittee new rem q) = yes (new , rem , q , refl)
@@ -97,16 +93,16 @@ instance
       module GoVote sig where
         open GovVote sig
 
-        computeProof = case lookupActionId pparams (proj₁ voter) gid s ,′ isRegistered? (proj₁ Γ) voter of λ where
+        computeProof = case L.lookupActionId pparams (proj₁ voter) gid epoch s ,′ isRegistered? (proj₁ Γ) voter of λ where
             (yes p , yes p') → case Any↔ .from p of λ where
-              (_ , mem , refl , cV) → success (_ , GOV-Vote (∈-fromList .to mem , cV , p'))
+              (_ , mem , refl , cV , ¬exp) → success (_ , GOV-Vote (∈-fromList .to mem , cV , p' , ¬exp))
             (yes _ , no ¬p) → failure (genErrors ¬p)
             (no ¬p , _)     → failure (genErrors ¬p)
 
         completeness : ∀ s' → Γ ⊢ s ⇀⦇ inj₁ sig ,GOV'⦈ s' → map proj₁ computeProof ≡ success s'
-        completeness s' (GOV-Vote (mem , cV , reg))
-          with lookupActionId pparams (proj₁ voter) gid s | isRegistered? (proj₁ Γ) voter
-        ... | no ¬p | _ = ⊥-elim (¬p (Any↔ .to (_ , ∈-fromList .from mem , refl , cV)))
+        completeness s' (GOV-Vote (mem , cV , reg , ¬exp))
+          with L.lookupActionId pparams (proj₁ voter) gid epoch s | isRegistered? (proj₁ Γ) voter
+        ... | no ¬p | _ = ⊥-elim (¬p (Any↔ .to (_ , ∈-fromList .from mem , refl , cV , ¬exp)))
         ... | yes _ | no ¬p = ⊥-elim $ ¬p reg
         ... | yes p | yes p' with Any↔ .from p
         ... | (_ , mem , refl , cV) = refl
@@ -118,41 +114,56 @@ instance
 
         instance 
           Dec-actionWellFormed = L.actionWellFormed?
+          Dec-actionValid = L.actionValid?
         {-# INCOHERENT Dec-actionWellFormed #-}
+        {-# INCOHERENT Dec-actionValid #-}
 
-        H = ¿ L.actionWellFormed rewardCreds p ppolicy epoch a
+        H = ¿ L.actionWellFormed a
+            × L.actionValid rewardCreds p ppolicy epoch a
             × d ≡ govActionDeposit
             × L.validHFAction prop s enactState
             × L.hasParent' enactState s a prev
-            × addr .RwdAddr.net ≡ NetworkId ¿
+            × addr .RwdAddr.net ≡ NetworkId
+            × addr .RwdAddr.stake ∈ rewardCreds ¿
             ,′ isUpdateCommittee a
 
-        genErrorsWellFormed : ∀ {a} → ¬ (L.actionWellFormed rewardCreds p ppolicy epoch a) → String
-        genErrorsWellFormed {NoConfidence} ¬p          = genErrors ¬p
-        genErrorsWellFormed {UpdateCommittee _ _ _} ¬p = genErrors ¬p
-        genErrorsWellFormed {NewConstitution _ _} ¬p   = genErrors ¬p
-        genErrorsWellFormed {TriggerHF _} ¬p           = genErrors ¬p
-        genErrorsWellFormed {ChangePParams _} ¬p       = genErrors ¬p
-        genErrorsWellFormed {TreasuryWdrl _} ¬p        = genErrors ¬p
-        genErrorsWellFormed {Info} ¬p                  = genErrors ¬p
+        genErrorsActionWellFormed : ∀ {a} → ¬ (L.actionWellFormed a) → String
+        genErrorsActionWellFormed {NoConfidence} ¬p          = genErrors ¬p
+        genErrorsActionWellFormed {UpdateCommittee _ _ _} ¬p = genErrors ¬p
+        genErrorsActionWellFormed {NewConstitution _ _} ¬p   = genErrors ¬p
+        genErrorsActionWellFormed {TriggerHF _} ¬p           = genErrors ¬p
+        genErrorsActionWellFormed {ChangePParams _} ¬p       = genErrors ¬p
+        genErrorsActionWellFormed {TreasuryWdrl _} ¬p        = genErrors ¬p
+        genErrorsActionWellFormed {Info} ¬p                  = genErrors ¬p
+
+        genErrorsActionValid : ∀ {a} → ¬ (L.actionValid rewardCreds p ppolicy epoch a) → String
+        genErrorsActionValid {NoConfidence} ¬p          = genErrors ¬p
+        genErrorsActionValid {UpdateCommittee _ _ _} ¬p = genErrors ¬p
+        genErrorsActionValid {NewConstitution _ _} ¬p   = genErrors ¬p
+        genErrorsActionValid {TriggerHF _} ¬p           = genErrors ¬p
+        genErrorsActionValid {ChangePParams _} ¬p       = genErrors ¬p
+        genErrorsActionValid {TreasuryWdrl _} ¬p        = genErrors ¬p
+        genErrorsActionValid {Info} ¬p                  = genErrors ¬p
 
         computeProof = case H of λ where
-          (yes (wf , dep , vHFA , L.HasParent' en , goodAddr) , yes (new , rem , q , refl)) →
+          (yes (wf , av , dep , vHFA , L.HasParent' en , goodAddr , regReward) , yes (new , rem , q , refl)) →
             case ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ of λ where
-              (yes newOk) → success (_ , GOV-Propose (wf , dep , vHFA , en , goodAddr))
+              (yes newOk) → success (_ , GOV-Propose (wf , av , dep , vHFA , en , goodAddr , regReward))
               (no ¬p)     → failure (genErrors ¬p)
-          (yes (wf , dep , vHFA , L.HasParent' en , goodAddr) , no notNewComm) → success
-            (-, GOV-Propose (wf , dep , vHFA , en , goodAddr))
+          (yes (wf , av , dep , vHFA , L.HasParent' en , goodAddr) , no notNewComm) → success
+            (-, GOV-Propose (wf , av , dep , vHFA , en , goodAddr))
           (no ¬p , _) → case dec-de-morgan ¬p of λ where
-            (inj₁ q) → failure (genErrorsWellFormed q)
-            (inj₂ q) → failure (genErrors q)
+            (inj₁ q) → failure (genErrorsActionWellFormed q)
+            (inj₂ q) → case dec-de-morgan q of λ where
+              (inj₁ r) → failure (genErrorsActionValid r)
+              (inj₂ r) → failure (genErrors r)
 
         completeness : ∀ s' → Γ ⊢ s ⇀⦇ inj₂ prop ,GOV'⦈ s' → map proj₁ computeProof ≡ success s'
-        completeness s' (GOV-Propose (wf , dep , vHFA , en , goodAddr)) with H
-        ... | (no ¬p , _) = ⊥-elim (¬p (wf , dep , vHFA , L.HasParent' en , goodAddr))
-        ... | (yes (_ , _ , _ , L.HasParent' _ , _) , no notNewComm) = refl
-        ... | (yes ((_ , allOk) , _ , _ , L.HasParent' _ , _) , yes (new , rem , q , refl))
-          rewrite dec-yes ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ allOk .proj₂ = refl
+        completeness s' (GOV-Propose (wf , av , dep , vHFA , en , goodAddr)) with H
+        ... | (no ¬p , _) = ⊥-elim (¬p (wf , av , dep , vHFA , L.HasParent' en , goodAddr))
+        ... | (yes (_ , _ , _ , _ , L.HasParent' _ , _) , no notNewComm) = refl
+        ... | (yes (_ , (_ , (av₁ , av₂)) , _ , _ , L.HasParent' _ , _) , yes (new , rem , q , refl))
+          rewrite dec-yes ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ (λ { x → av₁ x , av₂ }) .proj₂ = refl
 
       computeProof : (sig : GovVote ⊎ GovProposal) → _
       computeProof (inj₁ s) = GoVote.computeProof s

--- a/src/Ledger/Conway/Conformance/Ledger.agda
+++ b/src/Ledger/Conway/Conformance/Ledger.agda
@@ -58,8 +58,6 @@ private variable
   tx : Tx
 
 open RwdAddr
-open DState
-open CertState
 open UTxOState
 
 data
@@ -70,12 +68,13 @@ data
 
   LEDGER-V :
     let open LState s; txb = tx .body; open TxBody txb; open LEnv Γ
+        open CertState certState; open DState dState
         utxoSt'' = record utxoSt' { deposits = L.updateDeposits pparams txb (deposits utxoSt') }
      in
     ∙  isValid tx ≡ true
     ∙  record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     ∙  ⟦ epoch slot , pparams , txvote , txwdrls , allColdCreds govSt enactState ⟧ᶜ ⊢ certState ⇀⦇ txcerts ,CERTS⦈ certState'
-    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
+    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' , stakeDelegs ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
        ────────────────────────────────
        Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt'' , govSt' , certState' ⟧ˡ
 

--- a/src/Ledger/Conway/Conformance/Ledger.agda
+++ b/src/Ledger/Conway/Conformance/Ledger.agda
@@ -74,7 +74,7 @@ data
     ∙  isValid tx ≡ true
     ∙  record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     ∙  ⟦ epoch slot , pparams , txvote , txwdrls , allColdCreds govSt enactState ⟧ᶜ ⊢ certState ⇀⦇ txcerts ,CERTS⦈ certState'
-    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' , stakeDelegs ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
+    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' , dom rewards ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
        ────────────────────────────────
        Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt'' , govSt' , certState' ⟧ˡ
 

--- a/src/Ledger/Conway/Conformance/Ledger/Properties.agda
+++ b/src/Ledger/Conway/Conformance/Ledger/Properties.agda
@@ -65,7 +65,7 @@ instance
       utxoΓ = UTxOEnv ∋ record { LEnv Γ }
       certΓ = CertEnv ∋ ⟦ epoch slot , pparams , txvote , txwdrls , _ ⟧ᶜ
       govΓ : CertState → GovEnv
-      govΓ = ⟦ txid , epoch slot , pparams , ppolicy , enactState ,_⟧ᵍ
+      govΓ certState = ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState , _ ⟧ᵍ
 
       computeProof : ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s')
       computeProof = case isValid ≟ true of λ where

--- a/src/Ledger/Gov/Properties.agda
+++ b/src/Ledger/Gov/Properties.agda
@@ -134,30 +134,28 @@ instance
           Dec-actionWellFormed = actionWellFormed?
         {-# INCOHERENT Dec-actionWellFormed #-}
 
-        H = ¿ actionWellFormed a
+        H = ¿ actionWellFormed stakeCreds p ppolicy epoch a
             × d ≡ govActionDeposit
             × validHFAction prop s enactState
-            × (∃[ u ] a ≡ ChangePParams u ⊎ ∃[ w ] a ≡ TreasuryWdrl w → p ≡ ppolicy)
-            × (¬ (∃[ u ] a ≡ ChangePParams u ⊎ ∃[ w ] a ≡ TreasuryWdrl w) → p ≡ nothing)
             × hasParent' enactState s a prev
             × addr .RwdAddr.net ≡ NetworkId ¿
             ,′ isUpdateCommittee a
 
         computeProof = case H of λ where
-          (yes (wf , dep , vHFA , pol , ¬pol , HasParent' en , goodAddr) , yes (new , rem , q , refl)) →
+          (yes (wf , dep , vHFA , HasParent' en , goodAddr) , yes (new , rem , q , refl)) →
             case ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ of λ where
-              (yes newOk) → success (_ , GOV-Propose (wf , dep , pol , ¬pol , (λ where refl → newOk) , vHFA , en , goodAddr))
+              (yes newOk) → success (_ , GOV-Propose (wf , dep , vHFA , en , goodAddr))
               (no ¬p)     → failure (genErrors ¬p)
-          (yes (wf , dep , vHFA , pol , ¬pol , HasParent' en , goodAddr) , no notNewComm) → success
-            (-, GOV-Propose (wf , dep , pol , ¬pol , (λ isNewComm → ⊥-elim (notNewComm (-, -, -, isNewComm))) , vHFA , en , goodAddr))
+          (yes (wf , dep , vHFA , HasParent' en , goodAddr) , no notNewComm) → success
+            (-, GOV-Propose (wf , dep , vHFA , en , goodAddr))
           (no ¬p , _) → failure (genErrors ¬p)
 
         completeness : ∀ s' → Γ ⊢ s ⇀⦇ inj₂ prop ,GOV'⦈ s' → map proj₁ computeProof ≡ success s'
-        completeness s' (GOV-Propose (wf , dep , pol , ¬pol , newOk , vHFA , en , goodAddr)) with H
-        ... | (no ¬p , _) = ⊥-elim (¬p (wf , dep , vHFA , pol , ¬pol , HasParent' en , goodAddr))
-        ... | (yes (_ , _ , _ , _ , _ , HasParent' _ , _) , no notNewComm) = refl
-        ... | (yes (_ , _ , _ , _ , _ , HasParent' _ , _) , yes (new , rem , q , refl))
-          rewrite dec-yes ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ (newOk refl) .proj₂ = refl
+        completeness s' (GOV-Propose (wf , dep , vHFA , en , goodAddr)) with H
+        ... | (no ¬p , _) = ⊥-elim (¬p (wf , dep , vHFA , HasParent' en , goodAddr))
+        ... | (yes (_ , _ , _ , HasParent' _ , _) , no notNewComm) = refl
+        ... | (yes ((_ , allOk) , _ , _ , HasParent' _ , _) , yes (new , rem , q , refl))
+          rewrite dec-yes ¿ ∀[ e ∈ range new ] epoch < e × dom new ∩ rem ≡ᵉ ∅ ¿ allOk .proj₂ = refl
 
       computeProof : (sig : GovVote ⊎ GovProposal) → _
       computeProof (inj₁ s) = GoVote.computeProof s

--- a/src/Ledger/Gov/Properties.agda
+++ b/src/Ledger/Gov/Properties.agda
@@ -134,7 +134,7 @@ instance
           Dec-actionWellFormed = actionWellFormed?
         {-# INCOHERENT Dec-actionWellFormed #-}
 
-        H = ¿ actionWellFormed stakeCreds p ppolicy epoch a
+        H = ¿ actionWellFormed rewardCreds p ppolicy epoch a
             × d ≡ govActionDeposit
             × validHFAction prop s enactState
             × hasParent' enactState s a prev

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -60,23 +60,6 @@ data GovAction : Type where
   ChangePParams    : PParamsUpdate                            →  GovAction
   TreasuryWdrl     : (RwdAddr ⇀ Coin)                         →  GovAction
   Info             :                                             GovAction
-
-actionWellFormed : GovAction → Type
-actionWellFormed (ChangePParams x)  = ppdWellFormed x
-actionWellFormed (TreasuryWdrl x)   = 
-  (∀[ a ∈ dom x ] RwdAddr.net a ≡ NetworkId)
-  × (∃[ v ∈ range x ] ¬ (v ≡ 0))
-actionWellFormed _                  = ⊤
-\end{code}
-\begin{code}[hide]
-actionWellFormed? : ∀ {a} → actionWellFormed a ⁇
-actionWellFormed? {NoConfidence}          = it
-actionWellFormed? {UpdateCommittee _ _ _} = it
-actionWellFormed? {NewConstitution _ _}   = it
-actionWellFormed? {TriggerHF _}           = it
-actionWellFormed? {ChangePParams _}       = it
-actionWellFormed? {TreasuryWdrl _}        = it
-actionWellFormed? {Info}                  = it
 \end{code}
 \end{AgdaMultiCode}
 \caption{Governance actions}

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -73,10 +73,6 @@ Figure~\ref{defs:governance} defines several data types used to represent govern
   \item \VDeleg (\defn{voter delegation})---one of three ways to delegate votes: by credential, abstention, or no confidence (\credVoter, \abstainRep, or \noConfidenceRep);
   \item \Anchor---a url and a document hash;
   \item \GovAction (\defn{governance action})---one of seven possible actions (see Figure~\ref{fig:types-of-governance-actions} for definitions);
-  \item \actionWellFormed---in the case of protocol parameter changes,
-    an action is well-formed if it preserves the well-formedness of parameters.
-    \ppdWellFormed is effectively the same as \paramsWellFormed, except that it
-    only applies to the parameters that are being changed.
 \end{itemize}
 The governance actions carry the following information:
 \begin{itemize}

--- a/src/Ledger/Ledger.lagda
+++ b/src/Ledger/Ledger.lagda
@@ -110,7 +110,7 @@ data
     ∙  isValid tx ≡ true
     ∙  record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     ∙  ⟦ epoch slot , pparams , txvote , txwdrls , allColdCreds govSt enactState ⟧ᶜ ⊢ certState ⇀⦇ txcerts ,CERTS⦈ certState'
-    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' , stakeDelegs ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
+    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' , dom rewards ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
        ────────────────────────────────
        Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt' , govSt' , certState' ⟧ˡ
 \end{code}

--- a/src/Ledger/Ledger.lagda
+++ b/src/Ledger/Ledger.lagda
@@ -83,11 +83,6 @@ private variable
 \begin{NoConway}
 \begin{figure*}[h]
 \begin{code}[hide]
-open RwdAddr
-open DState
-open CertState
-open UTxOState
-
 data
 \end{code}
 \begin{code}
@@ -103,11 +98,19 @@ data
 \begin{figure*}[htb]
 \begin{AgdaSuppressSpace}
 \begin{code}
-  LEDGER-V : let open LState s; txb = tx .body; open TxBody txb; open LEnv Γ in
+  LEDGER-V : 
+    let 
+      open LState s
+      txb = tx .body
+      open TxBody txb
+      open LEnv Γ
+      open CertState certState
+      open DState dState
+    in
     ∙  isValid tx ≡ true
     ∙  record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     ∙  ⟦ epoch slot , pparams , txvote , txwdrls , allColdCreds govSt enactState ⟧ᶜ ⊢ certState ⇀⦇ txcerts ,CERTS⦈ certState'
-    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
+    ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState' , stakeDelegs ⟧ᵍ ⊢ govSt |ᵒ certState' ⇀⦇ txgov txb ,GOV⦈ govSt'
        ────────────────────────────────
        Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt' , govSt' , certState' ⟧ˡ
 \end{code}

--- a/src/Ledger/Ledger/Properties.agda
+++ b/src/Ledger/Ledger/Properties.agda
@@ -239,7 +239,7 @@ module LEDGER-PROPS (tx : Tx) (Γ : LEnv) (s : LState) where
   STS→GovSt≡ (LEDGER-V ( _ , _ , _ , x )) refl = STS→updateGovSt≡ (txgov txb) 0 x
     where
     STS→updateGovSt≡ : (vps : List (GovVote ⊎ GovProposal)) (k : ℕ) {certSt : CertState} {govSt govSt' : GovState}
-      → (_⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS}{_⊢_⇀⦇_,GOV'⦈_} (⟦ txid , epoch slot , pp , ppolicy , enactState , certSt , stakeDelegs ⟧ᵍ , k) govSt vps govSt')
+      → (_⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS}{_⊢_⇀⦇_,GOV'⦈_} (⟦ txid , epoch slot , pp , ppolicy , enactState , certSt , dom rewards ⟧ᵍ , k) govSt vps govSt')
       → govSt' ≡ updateGovStates vps k govSt
     STS→updateGovSt≡ [] _ (BS-base Id-nop) = refl
     STS→updateGovSt≡ (inj₁ v ∷ vps) k (BS-ind (GOV-Vote x) h)

--- a/src/Ledger/Ledger/Properties.agda
+++ b/src/Ledger/Ledger/Properties.agda
@@ -66,7 +66,7 @@ instance
       utxoΓ = UTxOEnv ∋ record { LEnv Γ }
       certΓ = CertEnv ∋ ⟦ epoch slot , pparams , txvote , txwdrls , _ ⟧ᶜ
       govΓ : CertState → GovEnv
-      govΓ = ⟦ txid , epoch slot , pparams , ppolicy , enactState ,_⟧ᵍ
+      govΓ certState = ⟦ txid , epoch slot , pparams , ppolicy , enactState , certState , _ ⟧ᵍ
 
       computeProof : ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s')
       computeProof = case isValid ≟ true of λ where
@@ -203,6 +203,9 @@ module LEDGER-PROPS (tx : Tx) (Γ : LEnv) (s : LState) where
   open Tx tx renaming (body to txb); open TxBody txb
   open LEnv Γ renaming (pparams to pp)
   open PParams pp using (govActionDeposit)
+  open LState s
+  open CertState certState
+  open DState dState
 
   -- initial utxo deposits
   utxoDeps : DepositPurpose ⇀ Coin
@@ -233,10 +236,10 @@ module LEDGER-PROPS (tx : Tx) (Γ : LEnv) (s : LState) where
   -- updateGovStates faithfully represents a step of the LEDGER sts
   STS→GovSt≡ : ∀ {s' : LState} → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s'
                → isValid ≡ true → LState.govSt s' ≡ updateGovStates (txgov txb) 0 (LState.govSt s |ᵒ LState.certState s')
-  STS→GovSt≡ (LEDGER-V x) refl = STS→updateGovSt≡ (txgov txb) 0 (proj₂ (proj₂ (proj₂ x)))
+  STS→GovSt≡ (LEDGER-V ( _ , _ , _ , x )) refl = STS→updateGovSt≡ (txgov txb) 0 x
     where
     STS→updateGovSt≡ : (vps : List (GovVote ⊎ GovProposal)) (k : ℕ) {certSt : CertState} {govSt govSt' : GovState}
-      → (_⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS}{_⊢_⇀⦇_,GOV'⦈_} (⟦ txid , epoch slot , pp , ppolicy , enactState , certSt ⟧ᵍ , k) govSt vps govSt')
+      → (_⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS}{_⊢_⇀⦇_,GOV'⦈_} (⟦ txid , epoch slot , pp , ppolicy , enactState , certSt , stakeDelegs ⟧ᵍ , k) govSt vps govSt')
       → govSt' ≡ updateGovStates vps k govSt
     STS→updateGovSt≡ [] _ (BS-base Id-nop) = refl
     STS→updateGovSt≡ (inj₁ v ∷ vps) k (BS-ind (GOV-Vote x) h)

--- a/src/latex/agda-latex-macros.sty
+++ b/src/latex/agda-latex-macros.sty
@@ -12,6 +12,7 @@
 \newcommand{\acceptedStakeRatio}{\AgdaFunction{acceptedStakeRatio}\xspace}
 \newcommand{\action}{\AgdaField{action}\xspace}
 \newcommand{\actionWellFormed}{\AgdaFunction{actionWellFormed}\xspace}
+\newcommand{\actionValid}{\AgdaFunction{actionValid}\xspace}
 \newcommand{\activeDReps}{\AgdaFunction{activeDReps}\xspace}
 \newcommand{\activeVotingStake}{\AgdaFunction{activeVotingStake}\xspace}
 \newcommand{\actualCCVote}{\AgdaFunction{actualCCVote}\xspace}
@@ -459,15 +460,16 @@
 \newcommand{\role}{\AgdaField{role}\xspace}
 \newcommand{\roleVotes}{\AgdaFunction{roleVotes}\xspace}
 
-\newcommand{\SPOs}{\AgdaInductiveConstructor{SPOs}\xspace}
-\newcommand{\SPO}{\AgdaInductiveConstructor{SPO}\xspace}
 \newcommand{\RTC}{\AgdaFunction{ReflexiveTransitiveClosure}\xspace}
 \newcommand{\RTCI}{\AgdaOperator{\AgdaBound{\AgdaUnderscore{}⊢\AgdaUnderscore{}⇀⟦\AgdaUnderscore{}⟧*\AgdaUnderscore{}}}}
 \newcommand{\RTCB}{\AgdaOperator{\AgdaBound{\AgdaUnderscore{}⊢\AgdaUnderscore{}⇀⟦\AgdaUnderscore{}⟧\AgdaUnderscore{}}}}
+\newcommand{\RwdAddrToCoinMap}{\AgdaRecord{RwdAddr}~\AgdaFunction{⇀}~\AgdaFunction{Coin}}
 \newcommand{\SecurityGroup}{\AgdaInductiveConstructor{SecurityGroup}\xspace}
 \newcommand{\StakeDistrs}{\AgdaRecord{StakeDistrs}\xspace}
 \newcommand{\snd}{\AgdaField{proj₂}\xspace}
 \newcommand{\specProperty}{\AgdaFunction{specProperty}\xspace}
+\newcommand{\SPO}{\AgdaInductiveConstructor{SPO}\xspace}
+\newcommand{\SPOs}{\AgdaInductiveConstructor{SPOs}\xspace}
 \newcommand{\sprime}{\AgdaGeneralizable{s'}\xspace}
 \newcommand{\spring}{\AgdaFunction{sp-∘}\xspace}
 \newcommand{\stake}{\AgdaField{stake}\xspace}


### PR DESCRIPTION
# Description

This PR moves the action-specific predicates in `GOV-Propose` to `actionWellFormed` and adds a check that makes sure all the receiving staking credentials of a `TreasuryWithdrawal` are registered when the proposal is made.

This probably requires some changes to the prose. It seemed like the prose about `actionWellFormed` was already outdated before these changes, because it only mentioned we check the parameter updates, but we also had some conditions about treasury withdrawals as well.

I also added two other predicate checks to the GOV rule which are present in the implementation:
- In `GOV-Propose`: the return address of a new proposal must be a registered staking credential
- In `GOV-Vote`: the proposal being voted for must not be expired

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
