### PR TITLE
408 document changes to fee calculation wr ref scripts

### DIFF
--- a/src/Ledger/Fees.lagda
+++ b/src/Ledger/Fees.lagda
@@ -19,6 +19,8 @@ open import Data.Product using (swap)
 open import Induction.WellFounded using (Acc; acc)
 \end{code}
 
+\section{Fee Calculation}
+
 \begin{figure*}[h]
 \begin{AgdaMultiCode}
 \begin{code}[hide]
@@ -67,15 +69,21 @@ scriptsCost pp scSz with (PParams.refScriptCostStride pp)
 \caption{Calculation of fees for reference scripts}
 \label{fig:scriptsCost}
 \end{figure*}
-The function \AgdaFunction{scriptsCost} (Fig.~\ref{fig:scriptsCost}) calculates the fee for
-reference scripts in the transaction using a function that is piece-wise linear in the size,
-where the linear constant multiple grows with each \refScriptCostStride bytes.
-Thus, the \AgdaFunction{scriptsCost} function depends on the \AgdaFunction{scriptsTotalSize}
-function, which returns an integer that is the total size of the reference script in bytes,
-as well as the following protocol parameters:
+
+The function \scriptsCost{} (Fig.~\ref{fig:scriptsCost}) calculates
+the fee for reference scripts in the transaction using a function that
+is piece-wise linear in the size, where the linear constant multiple
+grows with each \refScriptCostStride{} bytes. Thus, the \scriptsCost{}
+function depends on the \AgdaFunction{scriptsTotalSize} function,
+which returns an integer that is the total size of the reference
+script in bytes, as well as the following protocol parameters:
+%
 \begin{itemize}
-\item \refScriptCostMultiplier, a rational number, the growth factor or step multiplier that
-determines how much the price per byte increases after each increment;
-\item \refScriptCostStride, an integer, the size in bytes at which the price per byte grows linearly;
-\item \minFeeRefScriptCoinsPerByte, a rational number, the base fee or initial price per byte.
+  \item \refScriptCostMultiplier{}, a rational number, the growth factor
+  or step multiplier that determines how much the price per byte
+  increases after each increment;
+  \item \refScriptCostStride{}, an integer, the size in bytes at which
+  the price per byte grows linearly;
+  \item \minFeeRefScriptCoinsPerByte{}, a rational number, the base
+  fee or initial price per byte.
 \end{itemize}

--- a/src/Ledger/PDF.lagda
+++ b/src/Ledger/PDF.lagda
@@ -27,6 +27,7 @@ open import Ledger.Address
 open import Ledger.Script
 open import Ledger.ScriptValidation
 open import Ledger.PParams
+open import Ledger.Fees
 
 open import Ledger.Types.GovStructure
 open import Ledger.GovernanceActions
@@ -68,6 +69,7 @@ open import Ledger.PDF.ConwayBootstrap
 \include{Ledger/Address}
 \include{Ledger/Script}
 \include{Ledger/PParams}
+\include{Ledger/Fees}
 \include{Ledger/GovernanceActions}
 \include{Ledger/Transaction}
 \include{Ledger/Utxo}

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -452,7 +452,7 @@ to \consumed or \produced depending on its sign. This is done via
 \negPart and \posPart, which satisfy the key property that their
 difference is the identity function.
 
-Figures~\ref{fig:functions:utxo} also shows the signature of \ValidCertDeposits.
+Figure~\ref{fig:functions:utxo} also shows the signature of \ValidCertDeposits.
 Inhabitants of this type are constructed in one of eight ways, corresponding to
 seven certificate types plus one for an empty list of certificates.  Suffice it to
 say that \ValidCertDeposits is used to check the validity of the deposits in a

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -452,6 +452,10 @@ to \consumed or \produced depending on its sign. This is done via
 \negPart and \posPart, which satisfy the key property that their
 difference is the identity function.
 
+Figure~\ref{fig:functions:utxo} defines the function \minfee{}. In
+Conway, \minfee{} includes the cost for reference scripts. This is
+calculated using \scriptsCost{} (see Figure~\ref{fig:scriptsCost}).
+
 Figure~\ref{fig:functions:utxo} also shows the signature of \ValidCertDeposits.
 Inhabitants of this type are constructed in one of eight ways, corresponding to
 seven certificate types plus one for an empty list of certificates.  Suffice it to

--- a/src/latex/agda-latex-macros.sty
+++ b/src/latex/agda-latex-macros.sty
@@ -354,6 +354,7 @@
 \newcommand{\maybeprime}{\AgdaFunction{maybe′}\xspace}
 \newcommand{\meetsMinAVS}{\AgdaFunction{meetsMinAVS}\xspace}
 \newcommand{\minimumAVS}{\AgdaField{minimumAVS}\xspace}
+\newcommand{\minFeeRefScriptCoinsPerByte}{\AgdaField{minFeeRefScriptCoinsPerByte}\xspace}
 \newcommand{\ccMinSize}{\AgdaField{ccMinSize}\xspace}
 \newcommand{\mleqmplusn}{\AgdaFunction{m≤m+n}\xspace}
 \newcommand{\module}{\AgdaKeyword{module}\xspace}
@@ -481,6 +482,7 @@
 \newcommand{\sym}{\AgdaFunction{sym}\xspace}
 \newcommand{\ScriptHash}{\AgdaFunction{ScriptHash}\xspace}
 \newcommand{\ScriptPurpose}{\AgdaDatatype{ScriptPurpose}\xspace}
+\newcommand{\scriptsCost}{\AgdaFunction{scriptsCost}\xspace}
 \newcommand{\scriptsNeeded}{\AgdaFunction{scriptsNeeded}\xspace}
 
 \newcommand{\TacticDeriveDecEq}{\AgdaModule{Tactic.Derive.DecEq}\xspace}

--- a/src/latex/agda-latex-macros.sty
+++ b/src/latex/agda-latex-macros.sty
@@ -355,6 +355,7 @@
 \newcommand{\meetsMinAVS}{\AgdaFunction{meetsMinAVS}\xspace}
 \newcommand{\minimumAVS}{\AgdaField{minimumAVS}\xspace}
 \newcommand{\minFeeRefScriptCoinsPerByte}{\AgdaField{minFeeRefScriptCoinsPerByte}\xspace}
+\newcommand{\minfee}{\AgdaFunction{minfee}\xspace}
 \newcommand{\ccMinSize}{\AgdaField{ccMinSize}\xspace}
 \newcommand{\mleqmplusn}{\AgdaFunction{m≤m+n}\xspace}
 \newcommand{\module}{\AgdaKeyword{module}\xspace}

--- a/src/latex/conway-ledger.tex
+++ b/src/latex/conway-ledger.tex
@@ -42,6 +42,7 @@ Alasdair Hill, Ulf Norell, Orestis Melkonian, Jared Corduan, Alexey Kuleshevich
 \include{Conway/Ledger/Introduction}
 \include{Conway/Ledger/Notation}
 \include{Conway/Ledger/PParams}
+\include{Conway/Ledger/Fees}
 \include{Conway/Ledger/GovernanceActions}
 \include{Conway/Ledger/Transaction}
 \include{Conway/Ledger/Utxo}


### PR DESCRIPTION
# Description

This PR addresses #408.
It also:
- Formats the tex code in `Ledger.Fees`
- Includes `Ledger.Fees` in the PDF (both Conway and Cardano)
- Fixes a typo

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
