### PR TITLE
Fixes alignment of submodule contents in Utxo figure

### DIFF
--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -211,6 +211,7 @@ data
 \begin{code}[hide]
 module _ (let open Tx; open TxBody; open TxWitnesses) where opaque
 \end{code}
+\AgdaNoSpaceAroundCode{}
 \begin{AgdaMultiCode}
 \begin{NoConway}
 \begin{code}
@@ -225,6 +226,7 @@ module _ (let open Tx; open TxBody; open TxWitnesses) where opaque
 \end{code}
 \end{NoConway}
 \begin{code}
+
   refScriptsSize : UTxO → Tx → ℕ
   refScriptsSize utxo tx = sum $ map scriptSize (refScripts tx utxo)
 
@@ -234,6 +236,8 @@ module _ (let open Tx; open TxBody; open TxWitnesses) where opaque
                      + scriptsCost pp (refScriptsSize utxo tx)
 
 \end{code}
+\end{AgdaMultiCode}
+\begin{AgdaMultiCode}
 \begin{code}[hide]
 instance
   HasCoin-UTxO : HasCoin UTxO
@@ -361,6 +365,7 @@ depositsChange pp txb deposits =
   getCoin (updateDeposits pp txb deposits) - getCoin deposits
 \end{code}
 \end{AgdaMultiCode}
+\AgdaSpaceAroundCode{}
 \caption{Functions used in UTxO rules}
 \label{fig:functions:utxo}
 \end{figure*}


### PR DESCRIPTION
# Description
Fixes alignment issue in Figure 16/Conway | 14/Ledger

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
