### PR TITLE
Add monetary and treasury expansion to `PParams` (old)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### WIP
 
+- Add `treasuryCut` and `monetaryExpansion` to `PParams`
 - Change the `DELEG-dereg` transition so that the deposit field can be empty
 - Require witnessing of `reg` credential if the deposit is non-zero
 - Add witnessing of collaterals

--- a/src/Class/DecEq/Instances/Extra.agda
+++ b/src/Class/DecEq/Instances/Extra.agda
@@ -1,0 +1,26 @@
+{-# OPTIONS --safe #-}
+
+-- Extra instances for decidable equality.
+module Class.DecEq.Instances.Extra where
+
+open import Data.Refinement
+  using (Refinement; value; _,_)
+open import Function
+  using (_∘_)
+open import Relation.Binary.PropositionalEquality
+  using (cong; refl)
+open import Relation.Nullary.Decidable
+  using (no; yes)
+
+open import Class.DecEq
+  using (DecEq; _≟_)
+
+-- Equality for a Refinement type is decide if the equality
+-- for the type to be refined is decidable.
+DecEq-Refinement
+    : ∀ {a p} (A : Set a) (P : A → Set p)
+    → ⦃ DecEq A ⦄ → DecEq (Refinement A P)
+DecEq-Refinement A P ._≟_ (x , px) (y , py)
+  with x ≟ y
+... | no neq = no (neq ∘ cong value)
+... | yes refl = yes refl

--- a/src/Ledger/BaseTypes.lagda
+++ b/src/Ledger/BaseTypes.lagda
@@ -7,7 +7,9 @@
 
 module Ledger.BaseTypes where
 
-open import Prelude using (ℕ)
+open import Prelude using (ℕ; _×_)
+open import Data.Rational using (ℚ; 0ℚ; 1ℚ; _≤_)
+open import Data.Refinement using (Refinement-syntax)
 \end{code}
 
 \begin{code}[hide]
@@ -20,4 +22,11 @@ private
   Epoch  = ℕ
 \end{code}
 \caption{Some basic types used in many places in the ledger}
+\end{figure*}
+
+\begin{figure*}[h]
+\begin{code}
+  UnitInterval = [ x ∈ ℚ ∣ (0ℚ ≤ x) × (x ≤ 1ℚ) ]
+\end{code}
+\caption{Refinement types used in some places in the ledger}
 \end{figure*}

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -23,6 +23,7 @@ open import Ledger.Prelude
 open import Ledger.Crypto
 open import Ledger.Script
 open import Ledger.Types.Epoch
+open import Ledger.Types.Numeric using (UnitInterval)
 
 module Ledger.PParams
   (crypto : Crypto )
@@ -125,6 +126,8 @@ record PParams : Type where
         b                             : ℕ
         keyDeposit                    : Coin
         poolDeposit                   : Coin
+        monetaryExpansion             : UnitInterval -- formerly: rho
+        treasuryCut                   : UnitInterval -- formerly: tau
         coinsPerUTxOByte              : Coin
         prices                        : Prices
         minFeeRefScriptCoinsPerByte   : ℚ
@@ -229,6 +232,8 @@ module PParamsUpdate where
           a b                           : Maybe ℕ
           keyDeposit                    : Maybe Coin
           poolDeposit                   : Maybe Coin
+          monetaryExpansion             : Maybe UnitInterval
+          treasuryCut                   : Maybe UnitInterval
           coinsPerUTxOByte              : Maybe Coin
           prices                        : Maybe Prices
           minFeeRefScriptCoinsPerByte   : Maybe ℚ
@@ -279,6 +284,8 @@ module PParamsUpdate where
       ∷ is-just b
       ∷ is-just keyDeposit
       ∷ is-just poolDeposit
+      ∷ is-just monetaryExpansion
+      ∷ is-just treasuryCut
       ∷ is-just coinsPerUTxOByte
       ∷ is-just minFeeRefScriptCoinsPerByte
       ∷ is-just maxRefScriptSizePerTx
@@ -370,6 +377,8 @@ module PParamsUpdate where
       ; b                           = U.b ?↗ P.b
       ; keyDeposit                  = U.keyDeposit ?↗ P.keyDeposit
       ; poolDeposit                 = U.poolDeposit ?↗ P.poolDeposit
+      ; monetaryExpansion           = U.monetaryExpansion ?↗ P.monetaryExpansion
+      ; treasuryCut                 = U.treasuryCut ?↗ P.treasuryCut
       ; coinsPerUTxOByte            = U.coinsPerUTxOByte ?↗ P.coinsPerUTxOByte
       ; minFeeRefScriptCoinsPerByte = U.minFeeRefScriptCoinsPerByte ?↗ P.minFeeRefScriptCoinsPerByte
       ; maxRefScriptSizePerTx       = U.maxRefScriptSizePerTx ?↗ P.maxRefScriptSizePerTx

--- a/src/Ledger/Types/Numeric.agda
+++ b/src/Ledger/Types/Numeric.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --safe #-}
+
+-- Subsets of number types useful for the ledger specification.
+module Ledger.Types.Numeric where
+
+open import Ledger.Types.Numeric.UnitInterval public

--- a/src/Ledger/Types/Numeric/UnitInterval.agda
+++ b/src/Ledger/Types/Numeric/UnitInterval.agda
@@ -7,6 +7,7 @@ open import Prelude
   hiding ([_,_]; [_]; _*_)
 
 open import Agda.Builtin.FromNat
+open import Class.DecEq.Instances.Extra using (DecEq-Refinement)
 open import Data.Irrelevant using ([_])
 import Data.Rational as ℚ
 open import Data.Rational.Properties
@@ -59,6 +60,10 @@ inUnitInterval-* x y ux (0≤y , y≤1) =
 -- UnitInterval: rational number in the unit interval [0, 1].
 UnitInterval : Type
 UnitInterval = [ x ∈ ℚ ∣ inUnitInterval x ]
+
+instance
+  DecEq-UnitInterval : DecEq UnitInterval
+  DecEq-UnitInterval = DecEq-Refinement ℚ inUnitInterval
 
 -- In the cardano-ledger codebase:
 --  unboundRational

--- a/src/Ledger/Types/Numeric/UnitInterval.agda
+++ b/src/Ledger/Types/Numeric/UnitInterval.agda
@@ -1,0 +1,92 @@
+{-# OPTIONS --safe #-}
+
+-- Rational number in the unit interval.
+module Ledger.Types.Numeric.UnitInterval where
+
+open import Prelude
+  hiding ([_,_]; [_]; _*_)
+
+open import Agda.Builtin.FromNat
+open import Data.Irrelevant using ([_])
+import Data.Rational as ℚ
+open import Data.Rational.Properties
+open import Data.Rational using (ℚ; _≤_; _≤?_; _*_)
+open import Data.Refinement using (Refinement-syntax; value; _,_)
+
+open import Tactic.EquationalReasoning using (module ≡-Reasoning)
+open ≤-Reasoning
+
+-- inUnitInterval predicate
+inUnitInterval : (x : ℚ) → Type
+inUnitInterval x = (0 ≤ x) × (x ≤ 1)
+
+-- Decide whether a rational number is in the unit interval.
+isInUnitInterval : (x : ℚ) → Dec (inUnitInterval x)
+isInUnitInterval x = (0 ≤? x) ×-dec (x ≤? 1)
+
+-- Multiplying with a number from the unit interval only decreases.
+inUnitInterval-*-≤y : ∀ (x y : ℚ) → inUnitInterval x → 0 ≤ y → x * y ≤ y
+inUnitInterval-*-≤y x y (0≤x , x≤1) 0≤y =
+  begin
+    x * y  ≤⟨ *-monoʳ-≤-nonNeg y ⦃ ℚ.nonNegative 0≤y ⦄ x≤1 ⟩
+    1 * y  ≡⟨ *-identityˡ _ ⟩
+    y      ∎
+
+-- Left multiplication by unit interval element preserves non-negativity.
+inUnitInterval-*-0≤ : ∀ (x y : ℚ) → inUnitInterval x → 0 ≤ y → 0 ≤ x * y
+inUnitInterval-*-0≤ x y (0≤x , x≤1) 0≤y =
+  begin
+    0      ≡⟨ sym (*-zeroʳ x) ⟩
+    x * 0  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ ℚ.nonNegative 0≤x ⦄ 0≤y ⟩
+    x * y  ∎
+
+-- Left multiplication by unit interval element preserves being upper boundeded by 1.
+inUnitInterval-*-≤1 : ∀ (x y : ℚ) → inUnitInterval x → y ≤ 1 → x * y ≤ 1
+inUnitInterval-*-≤1 x y (0≤x , x≤1) y≤1 =
+  begin
+    x * y  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ ℚ.nonNegative 0≤x ⦄ y≤1 ⟩
+    x * 1  ≡⟨ *-identityʳ _ ⟩
+    x      ≤⟨ x≤1 ⟩
+    1      ∎
+
+-- The product of two numbers from the unit interval is also in the unit interval.
+inUnitInterval-* : ∀ (x y : ℚ)
+  → inUnitInterval x → inUnitInterval y → inUnitInterval (x * y)
+inUnitInterval-* x y ux (0≤y , y≤1) =
+  inUnitInterval-*-0≤ x y ux 0≤y
+  , inUnitInterval-*-≤1 x y ux y≤1
+
+-- UnitInterval: rational number in the unit interval [0, 1].
+UnitInterval : Type
+UnitInterval = [ x ∈ ℚ ∣ inUnitInterval x ]
+
+-- In the cardano-ledger codebase:
+--  unboundRational
+fromUnitInterval : UnitInterval → ℚ
+fromUnitInterval = value
+
+-- In the cardano-ledger codebase:
+--  unboundRational
+toUnitInterval : ℚ → Maybe UnitInterval
+toUnitInterval x with isInUnitInterval x
+... | no ¬p = nothing
+... | yes p = just (x , [ p ])
+
+-- Helper function to make an element of the Refinement type
+-- while having the Adga compiler compute the evidence from Dec.
+-- Usage example:  mkUnitInterval (+ 2 / 10) refl
+mkUnitInterval : ∀ (x : ℚ) → does (isInUnitInterval x) ≡ true → UnitInterval
+mkUnitInterval x evidence with isInUnitInterval x in eq
+... | no  _ rewrite cong does eq = case evidence of λ ()
+... | yes p = x , [ p ]
+
+
+-- UnitInterval Properties
+
+-- to/from is the identity
+prop-toUnitInterval-fromUnitInterval : ∀ (x : UnitInterval)
+  → toUnitInterval (fromUnitInterval x) ≡ just x
+
+prop-toUnitInterval-fromUnitInterval (x , [ p0 ]) with isInUnitInterval x
+... | no ¬p = ⊥-elim-irr (¬p p0)
+... | yes p = refl

--- a/src/Ledger/Types/Numeric/UnitInterval.agda
+++ b/src/Ledger/Types/Numeric/UnitInterval.agda
@@ -7,10 +7,12 @@ open import Prelude
   hiding ([_,_]; [_]; _*_)
 
 open import Agda.Builtin.FromNat
+open import Class.Show using (Show; show)
 open import Class.DecEq.Instances.Extra using (DecEq-Refinement)
 open import Data.Irrelevant using ([_])
 import Data.Rational as ℚ
 open import Data.Rational.Properties
+import Data.Rational.Show as ℚshow
 open import Data.Rational using (ℚ; _≤_; _≤?_; _*_)
 open import Data.Refinement using (Refinement-syntax; value; _,_)
 
@@ -64,6 +66,10 @@ UnitInterval = [ x ∈ ℚ ∣ inUnitInterval x ]
 instance
   DecEq-UnitInterval : DecEq UnitInterval
   DecEq-UnitInterval = DecEq-Refinement ℚ inUnitInterval
+
+instance
+  Show-UnitInterval : Show UnitInterval
+  Show-UnitInterval .show = ℚshow.show ∘ value
 
 -- In the cardano-ledger codebase:
 --  unboundRational

--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -76,8 +76,10 @@ syntax ∃₂-syntax (λ x y → C) = ∃₂[ x , y ] C
 
 -- Instance for number literals, not enabled by default
 import Data.Nat.Literals as ℕ
+import Data.Rational.Literals as ℚ
 
 instance Number-ℕ = ℕ.number
+instance Number-ℚ = ℚ.number
 
 -- (pseudo)equality (for Maybe)
 _~_ : {A : Type} → Maybe A → Maybe A → Type

--- a/src/ScriptVerification/Lib.agda
+++ b/src/ScriptVerification/Lib.agda
@@ -12,7 +12,9 @@ open import Ledger.Conway.Conformance.Utxo SVTransactionStructure SVAbstractFunc
 open import Ledger.Transaction
 open TransactionStructure SVTransactionStructure
 open import Ledger.Types.Epoch
+open import Ledger.Types.Numeric using (mkUnitInterval)
 open EpochStructure SVEpochStructure
+open import Data.Integer using (ℤ; +_)
 open import Data.Rational using (½; 1ℚ ; mkℚ+ ; _/_)
 open import Data.Nat.Coprimality using (Coprime; gcd≡1⇒coprime)
 open Implementation
@@ -33,6 +35,8 @@ createEnv s = record { slot = s ; treasury = 0 ;
                                ; minUTxOValue = 0
                                ; poolDeposit = 500000000 -- lovelace
                                ; keyDeposit = 500000000 -- lovelace
+                               ; monetaryExpansion = mkUnitInterval (+ 3 / 1000) refl
+                               ; treasuryCut = mkUnitInterval (+ 2 / 10) refl
                                ; coinsPerUTxOByte = 0  --lovelace
                                -- ^^^ was 4310, but that value resulted in failed tests once
                                -- we replaced `minUTxOValue` with `coinsPerUTxOByte`; see `HelloWorld.agda`


### PR DESCRIPTION
# Description

This pull request adds the monetary expansion `rho` and treasury expansion `tau` protocol parameters to the `PParams` type.

In order to be able to prove that the treasury and reserves are not negative, it is necessary to constrain these parameters need to the unit interval `[0, 1]`. These conditions need to be stored somewhere — I have chosen to make them part of the `PParams` type by refining the parameters to a new type `UnitInterval`. (This is similar to how the previous specification of the Shelley ledger encodes these parameters.)

Context: #706 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
