### PR TITLE
Made `CERTBASE` get applied at the end of `CERTS`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -74,7 +74,6 @@ let
 
 in rec
 {
-
   agdaWithDeps = agdaWithPkgs deps;
 
   latex = texlive.combine {

--- a/src/Ledger/Certs.lagda
+++ b/src/Ledger/Certs.lagda
@@ -466,14 +466,12 @@ data _⊢_⇀⦇_,CERTBASE⦈_ where
         validVoteDelegs  = voteDelegs ∣^ (  mapˢ (credVoter DRep) (dom dReps)
                                         ∪ fromList (noConfidenceRep ∷ abstainRep ∷ []) )
     in
-    ∙ mapˢ (map₁ stake) (wdrls ˢ) ⊆ rewards ˢ
-      ────────────────────────────────
       ⟦ e , pp , vs , wdrls , cc ⟧ ⊢
         ⟦ ⟦ voteDelegs , stakeDelegs , rewards ⟧
         , stᵖ
         , ⟦ dReps , ccHotKeys ⟧
         ⟧ ⇀⦇ _ ,CERTBASE⦈
-        ⟦ ⟦ validVoteDelegs , stakeDelegs , constMap wdrlCreds 0 ∪ˡ rewards ⟧
+        ⟦ ⟦ validVoteDelegs , stakeDelegs , rewards ⟧
         , stᵖ
         , ⟦ refreshedDReps , ccHotKeys ⟧
         ⟧

--- a/src/Ledger/Certs.lagda
+++ b/src/Ledger/Certs.lagda
@@ -320,7 +320,7 @@ module _ where  -- achieves uniform (but perhaps misleading) alignment of type s
   _⊢_⇀⦇_,CERTS⦈_     : CertEnv     → CertState  → List DCert  → CertState  → Type
 \end{code}
 \begin{code}[hide]
-  _⊢_⇀⦇_,CERTS⦈_ = ReflexiveTransitiveClosureᵇ' {_⊢_⇀⟦_⟧ᵇ_ = _⊢_⇀⦇_,CERTBASE⦈_} {_⊢_⇀⦇_,CERT⦈_}
+  _⊢_⇀⦇_,CERTS⦈_ = ReflexiveTransitiveClosureᵇ {_⊢_⇀⟦_⟧ᵇ_ = _⊢_⇀⦇_,CERTBASE⦈_} {_⊢_⇀⦇_,CERT⦈_}
 \end{code}
 \end{AgdaMultiCode}
 \caption{Types for the transition systems relating to certificates}

--- a/src/Ledger/Certs.lagda
+++ b/src/Ledger/Certs.lagda
@@ -466,7 +466,6 @@ data _⊢_⇀⦇_,CERTBASE⦈_ where
         validVoteDelegs  = voteDelegs ∣^ (  mapˢ (credVoter DRep) (dom dReps)
                                         ∪ fromList (noConfidenceRep ∷ abstainRep ∷ []) )
     in
-    ∙ filter isKeyHash wdrlCreds ⊆ dom voteDelegs
     ∙ mapˢ (map₁ stake) (wdrls ˢ) ⊆ rewards ˢ
       ────────────────────────────────
       ⟦ e , pp , vs , wdrls , cc ⟧ ⊢

--- a/src/Ledger/Certs/Properties.agda
+++ b/src/Ledger/Certs/Properties.agda
@@ -148,15 +148,13 @@ instance
         open GState (gState cs); open DState (dState cs)
         refresh = mapPartial getDRepVote (fromList votes)
         refreshedDReps  = mapValueRestricted (const (CertEnv.epoch ce + drepActivity)) dreps refresh
-    in case ¿ filterˢ isKeyHash (mapˢ RwdAddr.stake (dom wdrls)) ⊆ dom voteDelegs
-              × mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿ of λ where
-      (yes p) → success (-, CERT-base p)
+    in case ¿ mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿ of λ where
+      (yes p) → success (-, CERT-base (p {_}))
       (no ¬p) → failure (genErrors ¬p)
-  Computational-CERTBASE .completeness ce st _ st' (CERT-base p)
-    rewrite let dState = CertState.dState st; open DState dState in
-      dec-yes ¿ filterˢ isKeyHash (mapˢ RwdAddr.stake (dom (CertEnv.wdrls ce))) ⊆ dom voteDelegs
-                × mapˢ (map₁ RwdAddr.stake) (CertEnv.wdrls ce ˢ) ⊆ rewards ˢ ¿
-        p .proj₂ = refl
+  Computational-CERTBASE .completeness ce st _ st' (CERT-base p) with 
+    ¿ mapˢ (map₁ RwdAddr.stake) (CertEnv.wdrls ce ˢ) ⊆ (st .CertState.dState .DState.rewards) ˢ ¿
+  ... | yes _ = refl
+  ... | no ¬q = ⊥-elim (¬q p)
 
 Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_ String
 Computational-CERTS = it
@@ -256,7 +254,7 @@ module _  {Γ : CertEnv}
 
     CERTBASE-pov  {s  = cs}
                   {s' = cs'}
-                  (CERT-base {pp}{vs}{e}{dreps}{wdrls} (_ , wdrlsCC⊆rwds)) =
+                  (CERT-base {pp}{vs}{e}{dreps}{wdrls} wdrlsCC⊆rwds) =
       let
         open DState (dState cs )
         open DState (dState cs') renaming (rewards to rewards')

--- a/src/Ledger/Certs/Properties.agda
+++ b/src/Ledger/Certs/Properties.agda
@@ -301,16 +301,9 @@ module _  {Γ : CertEnv}
           getCoin (zeroMap ∪ˡ rewards) + getCoin wdrls
             ∎
 
-    sts-pov  : {s₁ sₙ : CertState} → ReflexiveTransitiveClosure {sts = _⊢_⇀⦇_,CERT⦈_} Γ s₁ l sₙ
-             → getCoin s₁ ≡ getCoin sₙ
-    sts-pov (BS-base Id-nop) = refl
-    sts-pov (BS-ind x xs) = trans (CERT-pov x) (sts-pov xs)
-
     CERTS-pov : {s₁ sₙ : CertState} → Γ ⊢ s₁ ⇀⦇ l ,CERTS⦈ sₙ → getCoin s₁ ≡ getCoin sₙ + getCoin (CertEnv.wdrls Γ)
-    CERTS-pov (RTC {s' = s'} {s'' = sₙ} (bsts , BS-base Id-nop)) = CERTBASE-pov bsts
-    CERTS-pov (RTC (bsts , BS-ind x sts)) = trans  (CERTBASE-pov bsts)
-                                                   (cong  (_+ getCoin (CertEnv.wdrls Γ))
-                                                          (trans (CERT-pov x) (sts-pov sts)))
+    CERTS-pov (BS-base x) = CERTBASE-pov x
+    CERTS-pov {s₁ = s₁} {sₙ} (BS-ind x y) = trans (CERT-pov x) (CERTS-pov y)
 
 -- TODO: Prove the following property.
 -- range vDelegs ⊆ map (credVoter DRep) (dom DReps)

--- a/src/Ledger/Conway/Conformance/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Certs.agda
@@ -200,20 +200,18 @@ data _⊢_⇀⦇_,CERT⦈_ : CertEnv → CertState → DCert → CertState → T
 data _⊢_⇀⦇_,CERTBASE⦈_ : CertEnv → CertState → ⊤ → CertState → Type where
   CERT-base :
     let open PParams pp
-        refresh         = mapPartial getDRepVote (fromList vs)
-        refreshedDReps  = mapValueRestricted (const (e + drepActivity)) dReps refresh
-        wdrlCreds       = mapˢ stake (dom wdrls)
+        refresh          = mapPartial getDRepVote (fromList vs)
+        refreshedDReps   = mapValueRestricted (const (e + drepActivity)) dReps refresh
+        wdrlCreds        = mapˢ stake (dom wdrls)
         validVoteDelegs  = voteDelegs ∣^ (mapˢ (credVoter DRep) (dom dReps) ∪ fromList (noConfidenceRep ∷ abstainRep ∷ []))
     in
-    ∙ mapˢ (map₁ stake) (wdrls ˢ) ⊆ rewards ˢ
-      ────────────────────────────────
       ⟦ e , pp , vs , wdrls , cc ⟧ ⊢
       ⟦ ⟦ voteDelegs , stakeDelegs , rewards , ddep ⟧
       , stᵖ
       , ⟦ dReps , ccHotKeys , gdep ⟧
       ⟧
       ⇀⦇ _ ,CERTBASE⦈
-      ⟦ ⟦ validVoteDelegs , stakeDelegs , constMap wdrlCreds 0 ∪ˡ rewards , ddep ⟧
+      ⟦ ⟦ validVoteDelegs , stakeDelegs , rewards , ddep ⟧
       , stᵖ
       , ⟦ refreshedDReps , ccHotKeys , gdep ⟧
       ⟧

--- a/src/Ledger/Conway/Conformance/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Certs.agda
@@ -205,7 +205,6 @@ data _⊢_⇀⦇_,CERTBASE⦈_ : CertEnv → CertState → ⊤ → CertState →
         wdrlCreds       = mapˢ stake (dom wdrls)
         validVoteDelegs  = voteDelegs ∣^ (mapˢ (credVoter DRep) (dom dReps) ∪ fromList (noConfidenceRep ∷ abstainRep ∷ []))
     in
-    ∙ filterˢ isKeyHash wdrlCreds ⊆ dom voteDelegs
     ∙ mapˢ (map₁ stake) (wdrls ˢ) ⊆ rewards ˢ
       ────────────────────────────────
       ⟦ e , pp , vs , wdrls , cc ⟧ ⊢

--- a/src/Ledger/Conway/Conformance/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Certs.agda
@@ -220,4 +220,4 @@ data _⊢_⇀⦇_,CERTBASE⦈_ : CertEnv → CertState → ⊤ → CertState →
       ⟧
 
 _⊢_⇀⦇_,CERTS⦈_     : CertEnv → CertState → List DCert → CertState → Type
-_⊢_⇀⦇_,CERTS⦈_ = ReflexiveTransitiveClosureᵇ' {_⊢_⇀⟦_⟧ᵇ_ = _⊢_⇀⦇_,CERTBASE⦈_}{_⊢_⇀⦇_,CERT⦈_}
+_⊢_⇀⦇_,CERTS⦈_ = ReflexiveTransitiveClosureᵇ {_⊢_⇀⟦_⟧ᵇ_ = _⊢_⇀⦇_,CERTBASE⦈_}{_⊢_⇀⦇_,CERT⦈_}

--- a/src/Ledger/Conway/Conformance/Certs/Properties.agda
+++ b/src/Ledger/Conway/Conformance/Certs/Properties.agda
@@ -194,15 +194,13 @@ instance
 
     goal : ComputationResult String
            (∃-syntax (_⊢_⇀⦇_,CERTBASE⦈_ ⟦ CertEnv.epoch ce , pp , votes , wdrls , _ ⟧ st sig))
-    goal = case ¿ filterˢ isKeyHash (mapˢ RwdAddr.stake (dom wdrls)) ⊆ dom voteDelegs
-              × mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿ of λ where
-      (yes p) → success (-, CERT-base p)
-      (no ¬p) → failure (genErr ¬p)
-  Computational-CERTBASE .completeness ce st _ st' (CERT-base p)
-    rewrite let dState = CertState.dState st; open DState dState; open CertEnv ce in
-      dec-yes ¿ filterˢ isKeyHash (mapˢ RwdAddr.stake (dom wdrls)) ⊆ dom voteDelegs
-                × mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿
-        p .proj₂ = refl
+    goal = case ¿ mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿ of λ where
+      (yes p) → success (-, CERT-base (p {_}))
+      (no ¬p) → failure (genErrors ¬p)
+  Computational-CERTBASE .completeness ce st _ st' (CERT-base p) with
+    ¿ mapˢ (map₁ RwdAddr.stake) (CertEnv.wdrls ce ˢ) ⊆ (st .CertState.dState .DState.rewards) ˢ ¿
+  ... | yes _ = refl
+  ... | no ¬q = ⊥-elim (¬q p)
 
 Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_ String
 Computational-CERTS = it

--- a/src/Ledger/Conway/Conformance/Certs/Properties.agda
+++ b/src/Ledger/Conway/Conformance/Certs/Properties.agda
@@ -194,13 +194,8 @@ instance
 
     goal : ComputationResult String
            (∃-syntax (_⊢_⇀⦇_,CERTBASE⦈_ ⟦ CertEnv.epoch ce , pp , votes , wdrls , _ ⟧ st sig))
-    goal = case ¿ mapˢ (map₁ RwdAddr.stake) (wdrls ˢ) ⊆ rewards ˢ ¿ of λ where
-      (yes p) → success (-, CERT-base (p {_}))
-      (no ¬p) → failure (genErrors ¬p)
-  Computational-CERTBASE .completeness ce st _ st' (CERT-base p) with
-    ¿ mapˢ (map₁ RwdAddr.stake) (CertEnv.wdrls ce ˢ) ⊆ (st .CertState.dState .DState.rewards) ˢ ¿
-  ... | yes _ = refl
-  ... | no ¬q = ⊥-elim (¬q p)
+    goal = success (-, CERT-base)
+  Computational-CERTBASE .completeness ce st _ st' CERT-base = refl
 
 Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_ String
 Computational-CERTS = it

--- a/src/Ledger/Conway/Conformance/Equivalence.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence.agda
@@ -190,9 +190,9 @@ WellformedLState s = certDepositsC (C.LState.certState s) ≡ᵈ certDeposits (c
 
 getValidCertDepositsCERTS : ∀ {Γ s certs s'} deposits (open L.CertEnv Γ using (pp))
                           → certDepositsC s ≡ᵈ (certDDeps deposits , certGDeps deposits)
-                          → ReflexiveTransitiveClosure {sts = C._⊢_⇀⦇_,CERT⦈_} Γ s certs s'
+                          → Γ C.⊢ s ⇀⦇ certs ,CERTS⦈ s'
                           → L.ValidCertDeposits pp deposits certs
-getValidCertDepositsCERTS deposits wf (BS-base Id-nop) = L.[]
+getValidCertDepositsCERTS deposits wf (BS-base _) = L.[]
 getValidCertDepositsCERTS {Γ} {s} {cert ∷ _} deposits wf (BS-ind (C.CERT-deleg (C.DELEG-delegate (a , b))) rs) =
   L.delegate (getValidCertDepositsCERTS _ (lemUpdCert (L.CertEnv.pp Γ) (certDepositsC s) deposits cert wf) rs)
 getValidCertDepositsCERTS {Γ} {s} {cert ∷ _} deposits wf (BS-ind (C.CERT-deleg (C.DELEG-dereg (_ , h , h'))) rs) =
@@ -211,20 +211,6 @@ getValidCertDepositsCERTS {Γ} {s} {cert ∷ _} deposits wf (BS-ind (C.CERT-vdel
               (getValidCertDepositsCERTS _ (lemUpdCert (L.CertEnv.pp Γ) (certDepositsC s) deposits cert wf) rs)
 getValidCertDepositsCERTS {Γ} {s} {cert ∷ _} deposits wf (BS-ind (C.CERT-vdel (C.GOVCERT-ccreghot x)) rs) =
   L.ccreghot(getValidCertDepositsCERTS _ (lemUpdCert (L.CertEnv.pp Γ) (certDepositsC s) deposits cert wf) rs)
-
-getValidCertDepositsC : ∀ Γ s {s'} tx
-                     → (let open C.LEnv Γ using (pparams; slot; enactState)
-                            open TxBody (tx .Tx.body) using (txcerts; txvote; txwdrls)
-                            open C.LState s
-                            open C.UTxOState utxoSt using (deposits)
-                            cc = C.allColdCreds govSt enactState
-                       )
-                     → WellformedLState s
-                     → isValid tx ≡ true
-                     → ⟦ epoch slot , pparams , txvote , txwdrls , cc ⟧ C.⊢ certState ⇀⦇ txcerts ,CERTS⦈ s'
-                     → L.ValidCertDeposits pparams deposits txcerts
-getValidCertDepositsC Γ s tx wf refl (RTC (C.CERT-base _ , step)) =
-  getValidCertDepositsCERTS (C.UTxOState.deposits (C.LState.utxoSt s)) wf step
 
 lemUtxowDeposits : ∀ {Γ s s' tx}
                       (let open C.UTxOEnv Γ using (pparams))
@@ -254,7 +240,7 @@ instance
       open C.UTxOState utxoSt using (deposits)
 
       valid-deps : L.ValidCertDeposits pparams deposits txcerts
-      valid-deps = getValidCertDepositsC Γ s tx wf refl certs
+      valid-deps = getValidCertDepositsCERTS (C.UTxOState.deposits (C.LState.utxoSt s)) wf certs
 
       utxow' : _ L.⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ (setDeposits (utxowDeposits utxow) utxoSt')
       utxow' = inj₂ valid-deps ⊢conv utxow
@@ -270,9 +256,9 @@ instance
 open IsEquivalence ≡ᵈ-isEquivalence renaming (refl to ≡ᵈ-refl; sym to ≡ᵈ-sym; trans to ≡ᵈ-trans)
 
 lemCERTS'DepositsC : ∀ {Γ s dcerts s'} (open C.CertEnv Γ using (pp))
-                   → ReflexiveTransitiveClosure {sts = C._⊢_⇀⦇_,CERT⦈_} Γ s dcerts s'
+                   → C._⊢_⇀⦇_,CERTS⦈_ Γ s dcerts s'
                    → certDepositsC s' ≡ ⟨ updateDDeps pp dcerts , updateGDeps pp dcerts ⟩ (certDepositsC s)
-lemCERTS'DepositsC (BS-base Id-nop)                                  = refl
+lemCERTS'DepositsC (BS-base (C._⊢_⇀⦇_,CERTBASE⦈_.CERT-base _))       = refl
 lemCERTS'DepositsC (BS-ind (C.CERT-deleg (C.DELEG-delegate   _)) rs) = lemCERTS'DepositsC rs
 lemCERTS'DepositsC (BS-ind (C.CERT-deleg (C.DELEG-dereg      _)) rs) = lemCERTS'DepositsC rs
 lemCERTS'DepositsC (BS-ind (C.CERT-deleg (C.DELEG-reg        _)) rs) = lemCERTS'DepositsC rs
@@ -281,11 +267,6 @@ lemCERTS'DepositsC (BS-ind (C.CERT-pool C.POOL-retirepool)       rs) = lemCERTS'
 lemCERTS'DepositsC (BS-ind (C.CERT-vdel (C.GOVCERT-regdrep   _)) rs) = lemCERTS'DepositsC rs
 lemCERTS'DepositsC (BS-ind (C.CERT-vdel (C.GOVCERT-deregdrep _)) rs) = lemCERTS'DepositsC rs
 lemCERTS'DepositsC (BS-ind (C.CERT-vdel (C.GOVCERT-ccreghot  _)) rs) = lemCERTS'DepositsC rs
-
-lemCERTSDepositsC : ∀ {Γ s txcerts s'} (open C.CertEnv Γ using (pp))
-                  → Γ C.⊢ s ⇀⦇ txcerts ,CERTS⦈ s'
-                  → certDepositsC s' ≡ ⟨ updateDDeps pp txcerts , updateGDeps pp txcerts ⟩ (certDepositsC s)
-lemCERTSDepositsC (RTC (C.CERT-base _ , step)) = lemCERTS'DepositsC step
 
 lemWellformed : ∀ {Γ s tx s'} → WellformedLState s → Γ C.⊢ s ⇀⦇ tx ,LEDGER⦈ s' → WellformedLState s'
 lemWellformed {Γ} {s = ls} {tx} {s' = ls'} wf (C.LEDGER-V⋯ refl utxo certs gov) = goal
@@ -310,7 +291,7 @@ lemWellformed {Γ} {s = ls} {tx} {s' = ls'} wf (C.LEDGER-V⋯ refl utxo certs go
     lem rewrite lemDepositsC utxo = refl
 
     lem₁ : (ddeps' , gdeps') ≡ (updateDDeps pparams txcerts ddeps , updateGDeps pparams txcerts gdeps)
-    lem₁ = lemCERTSDepositsC certs
+    lem₁ = lemCERTS'DepositsC certs
 
     lem₂ :  (updateDDeps pparams txcerts (certDDeps deposits) , updateGDeps pparams txcerts (certGDeps deposits))
          ≡ᵈ (certDDeps deposits' , certGDeps deposits')
@@ -342,9 +323,10 @@ updateCDep pp cert (ddep , gdep) = updateDDep pp cert ddep , updateGDep pp cert 
 opaque
   castCERTS' : ∀ {Γ certs} {s s' : L.CertState} deps₁ deps₂ deps₁'
              → deps₁ ≡ᵈ deps₂
-             → Γ ⊢ deps₁ ⊢conv s ⇀⦇ certs ,CERTS'⦈ (deps₁' ⊢conv s')
-             → ∃[ deps₂' ] deps₁' ≡ᵈ deps₂' × Γ ⊢ deps₂ ⊢conv s ⇀⦇ certs ,CERTS'⦈ (deps₂' ⊢conv s')
-  castCERTS' deps₁ deps₂ deps₁' eqd (BS-base Id-nop) = deps₂ , eqd , BS-base Id-nop
+             → Γ C.⊢ deps₁ ⊢conv s ⇀⦇ certs ,CERTS⦈ (deps₁' ⊢conv s')
+             → ∃[ deps₂' ] deps₁' ≡ᵈ deps₂' × Γ C.⊢ deps₂ ⊢conv s ⇀⦇ certs ,CERTS⦈ (deps₂' ⊢conv s')
+  castCERTS' deps₁ deps₂ deps₁' eqd (BS-base (C._⊢_⇀⦇_,CERTBASE⦈_.CERT-base h)) = 
+    deps₂ , eqd , BS-base (C.CERT-base h)
   castCERTS' {Γ} deps₁ deps₂ deps₁' eqd (BS-ind (C.CERT-deleg {dCert = cert} (C.DELEG-delegate h))    rs) =
     let open C.CertEnv Γ using (pp)
         deps₂' , eqd' , rs' = castCERTS' (updateCDep pp cert deps₁) (updateCDep pp cert deps₂) deps₁'
@@ -387,14 +369,6 @@ opaque
     let deps₂' , eqd' , rs' = castCERTS' deps₁ deps₂ deps₁' eqd rs
     in  deps₂' , eqd' , BS-ind (C.CERT-vdel (C.GOVCERT-ccreghot h)) rs'
 
-  castCERTS : ∀ {Γ certs} {s s' : L.CertState} deps₁ deps₂ deps₁'
-            → deps₁ ≡ᵈ deps₂
-            → Γ C.⊢ deps₁ ⊢conv s ⇀⦇ certs ,CERTS⦈ (deps₁' ⊢conv s')
-            → ∃[ deps₂' ] deps₁' ≡ᵈ deps₂' × Γ C.⊢ deps₂ ⊢conv s ⇀⦇ certs ,CERTS⦈ (deps₂' ⊢conv s')
-  castCERTS deps₁ deps₂ deps₁' eqd (RTC (C.CERT-base h , step)) =
-    let deps₂' , eqd' , step' = castCERTS' deps₁ deps₂ deps₁' eqd step
-    in  deps₂' , eqd' , RTC (C.CERT-base h , step')
-
 _⊢_⇀⦇_,GOVn⦈_ : L.GovEnv × ℕ → L.GovState → List (GovVote ⊎ GovProposal) → L.GovState → Type
 _⊢_⇀⦇_,GOVn⦈_ = _⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS} {_⊢_⇀⟦_⟧_ = L._⊢_⇀⦇_,GOV⦈_}
 
@@ -404,7 +378,7 @@ opaque
             → Γ C.⊢ deps₁ ⊢conv s ⇀⦇ tx ,LEDGER⦈ (deps₁' ⊢conv s')
             → ∃[ deps₂' ] deps₁' ≡ᵈ deps₂' × Γ C.⊢ deps₂ ⊢conv s ⇀⦇ tx ,LEDGER⦈ (deps₂' ⊢conv s')
   castLEDGER {Γ} {tx} {s} {s'} deps₁ deps₂ deps₁' eqd (C.LEDGER-V⋯ refl utxo certs gov) =
-    let deps₂' , eqd' , certs' = castCERTS deps₁ deps₂ deps₁' eqd certs
+    let deps₂' , eqd' , certs' = castCERTS' deps₁ deps₂ deps₁' eqd certs
     in  deps₂' , eqd' , C.LEDGER-V⋯ refl utxo certs' gov
   castLEDGER deps₁ deps₂ deps₁' eqd (C.LEDGER-I⋯ refl utxo) = _ , eqd , C.LEDGER-I⋯ refl utxo
 

--- a/src/Ledger/Conway/Conformance/Equivalence/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Certs.agda
@@ -153,7 +153,7 @@ instance
                  → L.Deposits × L.Deposits
                    ⊢ Γ L.⊢ s ⇀⦇ _ ,CERTBASE⦈ s' ⭆ⁱ λ deposits _ →
                      Γ C.⊢ (deposits ⊢conv s) ⇀⦇ _ ,CERTBASE⦈ (deposits ⊢conv s')
-  CERTBASEToConf .convⁱ deposits (L.CERT-base h) = C.CERT-base h
+  CERTBASEToConf .convⁱ deposits L.CERT-base = C.CERT-base
 
   DELEGToConf : ∀ {Γ s dcert dcerts s'}
                   (open L.DelegEnv Γ renaming (pparams to pp))
@@ -235,7 +235,7 @@ instance
   CERTBASEFromConf : ∀ {Γ s s'}
                    → Γ C.⊢ s ⇀⦇ _ ,CERTBASE⦈ s' ⭆
                      Γ L.⊢ (conv s) ⇀⦇ _ ,CERTBASE⦈ (conv s')
-  CERTBASEFromConf .convⁱ _ (C.CERT-base h) = L.CERT-base h
+  CERTBASEFromConf .convⁱ _ C.CERT-base = L.CERT-base
 
   CERTS'FromConf : ∀ {Γ s dcerts s'}
                  → ReflexiveTransitiveClosure {sts = C._⊢_⇀⦇_,CERT⦈_} Γ s dcerts s' ⭆

--- a/src/Ledger/Conway/Conformance/Equivalence/Certs.agda
+++ b/src/Ledger/Conway/Conformance/Equivalence/Certs.agda
@@ -204,8 +204,8 @@ instance
                 ⊢ Γ L.⊢ s ⇀⦇ dcerts ,CERTS⦈ s' ⭆ⁱ λ deposits _ →
                   Γ C.⊢ (getCertDeps* deposits ⊢conv s) ⇀⦇ dcerts ,CERTS⦈
                         (getCertDeps* (updateCertDeps* dcerts deposits) ⊢conv s')
-  CERTSToConf .convⁱ deposits (RTC (base , step)) =
-    RTC (getCertDeps* deposits ⊢conv base , deposits ⊢conv step)
+  CERTSToConf .convⁱ ⟦ depsᵈ , depsᵍ , _ , _ ⟧* (BS-base x) = BS-base ((depsᵈ , depsᵍ) ⊢conv x)
+  CERTSToConf .convⁱ deposits (BS-ind x y) = BS-ind (deposits ⊢conv x) (updateCertDeps deposits ⊢conv y)
 
 -- Converting form Conformance is easier since the deposit tracking disappears.
 instance
@@ -246,4 +246,5 @@ instance
   CERTSFromConf : ∀ {Γ s dcerts s'}
                 → Γ C.⊢ s ⇀⦇ dcerts ,CERTS⦈ s' ⭆
                   Γ L.⊢ conv s ⇀⦇ dcerts ,CERTS⦈ conv s'
-  CERTSFromConf .convⁱ _ (RTC (base , step)) = RTC (conv base , conv step)
+  CERTSFromConf .convⁱ _ (BS-base x) = BS-base (conv x)
+  CERTSFromConf .convⁱ _ (BS-ind x x₁) = BS-ind (conv x) (conv x₁)

--- a/src/Ledger/Conway/Conformance/Ledger.agda
+++ b/src/Ledger/Conway/Conformance/Ledger.agda
@@ -54,10 +54,12 @@ data
     let open LState s; txb = tx .body; open TxBody txb; open LEnv Γ
         open CertState certState; open DState dState
         utxoSt'' = record utxoSt' { deposits = updateDeposits pparams txb (deposits utxoSt') }
+        wdrlCreds   = mapˢ RwdAddr.stake (dom txwdrls)
      in
     ∙  isValid tx ≡ true
     ∙  record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     ∙  ⟦ epoch slot , pparams , txvote , txwdrls , allColdCreds govSt enactState ⟧ ⊢ certState ⇀⦇ txcerts ,CERTS⦈ certState'
+    ∙  filterˢ isKeyHash wdrlCreds ⊆ dom voteDelegs
     ∙  ⟦ txid , epoch slot , pparams , ppolicy , enactState ,  certState' , dom
     rewards ⟧ ⊢ govSt ⇀⦇ txgov txb ,GOVS⦈ govSt'
        ────────────────────────────────
@@ -70,8 +72,8 @@ data
        ────────────────────────────────
        Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt' , govSt , certState ⟧
 
-pattern LEDGER-V⋯ w x y z = LEDGER-V (w , x , y , z)
-pattern LEDGER-I⋯ y z     = LEDGER-I (y , z)
+pattern LEDGER-V⋯ w x y z t = LEDGER-V (w , x , y , z , t)
+pattern LEDGER-I⋯ y z       = LEDGER-I (y , z)
 
 _⊢_⇀⦇_,LEDGERS⦈_ : LEnv → LState → List Tx → LState → Type
 _⊢_⇀⦇_,LEDGERS⦈_ = ReflexiveTransitiveClosure {sts = _⊢_⇀⦇_,LEDGER⦈_}

--- a/src/Ledger/Ledger.lagda
+++ b/src/Ledger/Ledger.lagda
@@ -116,10 +116,12 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LEnv → LState → Tx → LState → Type where
 \end{code}
 \begin{code}
          rewards     = certState .dState .rewards
+         wdrlCreds   = mapˢ RwdAddr.stake (dom txwdrls)
     in
     ∙ isValid tx ≡ true
     ∙ ⟦ slot , pp , treasury ⟧  ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     ∙ ⟦ epoch slot , pp , txvote , txwdrls , allColdCreds govSt enactState ⟧ ⊢ certState ⇀⦇ txcerts ,CERTS⦈ certState'
+    ∙ filterˢ isKeyHash wdrlCreds ⊆ dom (certState .dState .voteDelegs)
     ∙ ⟦ txid , epoch slot , pp , ppolicy , enactState , certState' , dom rewards ⟧ ⊢ rmOrphanDRepVotes certState' govSt ⇀⦇ txgov txb ,GOVS⦈ govSt'
       ────────────────────────────────
       ⟦ slot , ppolicy , pp , enactState , treasury ⟧ ⊢ ⟦ utxoSt , govSt , certState ⟧ ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt' , govSt' , certState' ⟧
@@ -134,7 +136,7 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LEnv → LState → Tx → LState → Type where
 \caption{LEDGER transition system}
 \end{figure*}
 \begin{code}[hide]
-pattern LEDGER-V⋯ w x y z = LEDGER-V (w , x , y , z)
+pattern LEDGER-V⋯ w x y z a = LEDGER-V (w , x , y , z , a)
 pattern LEDGER-I⋯ y z     = LEDGER-I (y , z)
 \end{code}
 


### PR DESCRIPTION
# Description

Previously the `CERTBASE` rule was applied to the state before the `CERT` transitions happened, but this caused the DRep delegations not get removed when the DRep was removed with the `deregdrep` certificate.

I've modified `CERTS` so that `CERTBASE` now gets applied last, after all of the certificates have been applied. I also moved reward withdrawals from `CERTS` to `LEDGER`.

closes #635
 
# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
