### PR TITLE
Add section "Rewards"

### DIFF
--- a/latex/cardano-ledger.tex
+++ b/latex/cardano-ledger.tex
@@ -31,6 +31,7 @@
 \includeAgda{Ledger/Ledger}
 \includeAgda{Ledger/Enact}
 \includeAgda{Ledger/Ratify}
+\includeAgda{Ledger/Rewards}
 \includeAgda{Ledger/Epoch}
 \includeAgda{Ledger/Chain}
 

--- a/src/Ledger.agda
+++ b/src/Ledger.agda
@@ -33,6 +33,7 @@ open import Ledger.Chain.Properties
 open import Ledger.Gov
 open import Ledger.Enact
 open import Ledger.Ratify
+open import Ledger.Rewards
 open import Ledger.Epoch
 open import Ledger.Chain
 

--- a/src/Ledger/Rewards.lagda
+++ b/src/Ledger/Rewards.lagda
@@ -21,6 +21,55 @@ are calculated and paid out.
 
 \subsection{Rewards Motivation}
 \label{sec:rewards-motivation}
+In order to operate, any blockchain needs to attract parties that are
+willing to spend computational and network resources
+on receiving transactions and producing new blocks.
+These parties, called \defn{block producers},
+are incentivized by monetary \defn{rewards}.
+
+Cardano is a proof of stake (PoS) blockchain:
+Through a random lottery,
+one block producer is selected to produce one particular block.
+The probability for being select depends on their \defn{stake} of Ada,
+that is their attributed amount of Ada relative to the total amount of Ada.
+After successful block production,
+the block producer is eligible for a share of the rewards.
+
+The rewards for block producers come from two sources:
+During an initial period, rewards are paid out from the \defn{reserve},
+which is an initial allocation of Ada created for this very purpose.
+Over time, the reserve is depleted,
+and rewards are sourced from transaction fees.
+
+Rewards are paid out epoch by epoch.
+
+Rewards are collective, but depend on performance:
+After every epoch, a fraction of the available reserve
+and the transaction fees accumulated during that epoch
+are added together. This sum is paid out to the block producers
+proportionally to how many blocks they have created each.
+In order to avoid perverse incentives, block producers
+do not receive individual rewards that depend on the content
+of their blocks.
+
+Not all people can or want to set up and administier a dedicated computer
+that produces blocks. However, these people still own Ada,
+and their stake is relevant for block production.
+Specifically, these people have the option to \defn{delegate} their stake
+to a \defn{stake pool}, which belongs to a block producer.
+The rewards of the block producer are shared proportionally with the
+people that delegate to its stake pool, after fees.
+By design, delegation and ownership are separate
+--- delegation counts towards the stake of the block producer,
+but delegators remain in full control of their Ada,
+stake pools cannot spend delegated Ada.
+
+Stake pools compete for delegators based on fees and performance.
+In order to achieve stable blockchain operation,
+the rewards are chosen such that they incentivize the system to evolve into a
+large, but fixed number of stake pools that attract most of the stake.
+For more details about the design and rationale of the rewards and delegation
+system, see Ref.~\parencite{shelley-delegation-design}.
 
 \subsection{Rewards Distribution Calculation}
 \label{sec:rewards-distribution-calculation}

--- a/src/Ledger/Rewards.lagda
+++ b/src/Ledger/Rewards.lagda
@@ -33,20 +33,21 @@ are calculated and paid out.
 \label{sec:rewards-motivation}
 In order to operate, any blockchain needs to attract parties that are
 willing to spend computational and network resources
-on receiving transactions and producing new blocks.
+on processing transactions and producing new blocks.
 These parties, called \defn{block producers},
 are incentivized by monetary \defn{rewards}.
 
-Cardano is a proof of stake (PoS) blockchain:
-Through a random lottery,
+Cardano is a proof-of-stake (PoS) blockchain:
+through a random lottery,
 one block producer is selected to produce one particular block.
 The probability for being select depends on their \defn{stake} of Ada,
-that is their attributed amount of Ada relative to the total amount of Ada.
+that is the amount of Ada that they (and their delegators) own
+relative to the total amount of Ada. (We will explain delegation below.)
 After successful block production,
 the block producer is eligible for a share of the rewards.
 
 The rewards for block producers come from two sources:
-During an initial period, rewards are paid out from the \defn{reserve},
+during an initial period, rewards are paid out from the \defn{reserve},
 which is an initial allocation of Ada created for this very purpose.
 Over time, the reserve is depleted,
 and rewards are sourced from transaction fees.
@@ -54,7 +55,7 @@ and rewards are sourced from transaction fees.
 Rewards are paid out epoch by epoch.
 
 Rewards are collective, but depend on performance:
-After every epoch, a fraction of the available reserve
+after every epoch, a fraction of the available reserve
 and the transaction fees accumulated during that epoch
 are added together. This sum is paid out to the block producers
 proportionally to how many blocks they have created each.
@@ -62,15 +63,18 @@ In order to avoid perverse incentives, block producers
 do not receive individual rewards that depend on the content
 of their blocks.
 
-Not all people can or want to set up and administier a dedicated computer
+Not all people can or want to set up and administer a dedicated computer
 that produces blocks. However, these people still own Ada,
 and their stake is relevant for block production.
 Specifically, these people have the option to \defn{delegate} their stake
 to a \defn{stake pool}, which belongs to a block producer.
-The rewards of the block producer are shared proportionally with the
-people that delegate to its stake pool, after fees.
+This stake counts towards the stake of the pool in the block production lottery.
+In turn, the protocol distributes the rewards for produced blocks
+to the stake pool owner and their delegators.
+The owner receives a fixed fee (``cost'') and a share of the rewards (``margin'').
+The remainder is distributed among delegators in proportion to their stake.
 By design, delegation and ownership are separate
---- delegation counts towards the stake of the block producer,
+--- delegation counts towards the stake of the pool,
 but delegators remain in full control of their Ada,
 stake pools cannot spend delegated Ada.
 
@@ -79,7 +83,7 @@ In order to achieve stable blockchain operation,
 the rewards are chosen such that they incentivize the system to evolve into a
 large, but fixed number of stake pools that attract most of the stake.
 For more details about the design and rationale of the rewards and delegation
-system, see Ref.~\parencite{shelley-delegation-design}.
+system, see \textcite{shelley-delegation-design}.
 
 \subsection{Rewards Distribution Calculation}
 \label{sec:rewards-distribution-calculation}

--- a/src/Ledger/Rewards.lagda
+++ b/src/Ledger/Rewards.lagda
@@ -1,0 +1,44 @@
+\section{Rewards}
+\label{sec:rewards}
+\modulenote{\LedgerModule{Rewards}}
+
+\begin{code}[hide]
+{-# OPTIONS --safe #-}
+
+open import Agda.Builtin.FromNat
+
+open import Ledger.Prelude
+open import Ledger.Types.GovStructure
+
+module Ledger.Rewards
+  (gs : _) (open GovStructure gs)
+  where
+
+open import Ledger.Certs gs
+\end{code}
+This section defines how rewards for stake pools and their delegators
+are calculated and paid out.
+
+\subsection{Rewards Motivation}
+\label{sec:rewards-motivation}
+
+\subsection{Rewards Distribution Calculation}
+\label{sec:rewards-distribution-calculation}
+This section defines the amount of rewards that are paid out
+to stake pools and their delegators.
+
+
+\subsection{Reward Update}
+\label{sec:reward-update}
+TODO: This section defines the \AgdaRecord{RewardUpdate} type,
+which records the net flow of Ada due to paying out rewards
+after an epoch.
+NOTE: The function \AgdaFunction{createRUpd} calculates the
+\AgdaRecord{RewardUpdate},
+but requires the definition \AgdaRecord{EpochState},
+so we have to defer its definition to a later section.
+
+\subsection{Stake Distribution Snapshots}
+\label{sec:stake-dstribution-snapshots-}
+TODO: This section defines the SNAP transition rule
+for the stake distribution snapshots.

--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -74,9 +74,11 @@ syntax ∃₂-syntax (λ x y → C) = ∃₂[ x , y ] C
 
 -- Instance for number literals, not enabled by default
 import Data.Nat.Literals as ℕ
+import Data.Integer.Literals as ℤ
 import Data.Rational.Literals as ℚ
 
 instance Number-ℕ = ℕ.number
+instance Number-ℤ = ℤ.number
 instance Number-ℚ = ℚ.number
 
 -- (Pseudo)equality (for Maybe)


### PR DESCRIPTION
# Description

This pull request adds a section on the calculation of Rewards.

We begin with

* a subsection that briefly motivates the reward system, and
* the definition of the function `maxPool`.

Troubles:

* Unfortunately, I will not be able to add the definition of `createRUpd` in this section, as `EpochState` is not available until later. — This is one instance where more advanced literate programming tools would be beneficial, which allow us to decouple the order of presentation for printing from the order of presentation for compilation.

Comments:

* I managed to hide the proof obligations that we do not divide by `0` from the PDF. However, as type class inference does not work very well with expressions, I had to introduce the seemingly superfluous quantity `1+a0`.
* In order to satisfy the proof obligations, I had to locally change `a0` and `nopt` such that `a0 ≥ 0` and `nopt ≥ 1`. I intend to move these preconditions to `PParams` at a later time.

Context:

#706

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
