### PR TITLE
Rename Lib to MAlonzo.Code.Ledger.Foreign.API

### DIFF
--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -200,14 +200,13 @@ hsRule = phony "hs" $ do
               [ "src/Ledger/Conway/Foreign/HSLedger.agda" ]
 
   -- copy over the Agda-generated MAlonzo files to _hs
-  malonzofiles <- getDirectoryFiles _malonzo [ "//*.hs" ]
+  malonzofiles <- map ("MAlonzo" </>) <$> getDirectoryFiles _malonzo [ "//*.hs" ]
   forM_ malonzofiles $ \file -> do
-    copyFileChanged (_malonzo </> file) (hsDist </> malonzo </> file)
+    copyFileChanged (_build </> file) (hsDist </> "src" </> file)
 
   -- copy the .cabal file appending the Agda-generated Haskell modules
   let agdafile2hsmodule =
         (replicate 8 ' ' ++) -- prepend 8 spaces
-        . ("MAlonzo." ++)    -- prepend 'MAlonzo'
         . agdafile2module
       hsmodules =
         map agdafile2hsmodule

--- a/conformance-example/test/UtxowSpec.hs
+++ b/conformance-example/test/UtxowSpec.hs
@@ -9,7 +9,7 @@ import Data.Text
 import Test.Hspec ( Spec, describe, it )
 import Test.HUnit ( (@?=) )
 
-import Lib
+import MAlonzo.Code.Ledger.Foreign.API
 
 (.->) :: a -> b -> (a, b)
 (.->) = (,)

--- a/hs-src/cardano-ledger-executable-spec.cabal
+++ b/hs-src/cardano-ledger-executable-spec.cabal
@@ -29,9 +29,9 @@ common globalOptions
 
 library
     import: globalOptions
-    hs-source-dirs: .
+    hs-source-dirs: src
     exposed-modules:
-        Lib
+        MAlonzo.Code.Ledger.Foreign.API
     build-depends:
         text,
         ieee

--- a/hs-src/src/MAlonzo/Code/Ledger/Foreign/API.hs
+++ b/hs-src/src/MAlonzo/Code/Ledger/Foreign/API.hs
@@ -1,6 +1,6 @@
-module Lib
+module MAlonzo.Code.Ledger.Foreign.API
   ( module X
-  , module Lib
+  , module MAlonzo.Code.Ledger.Foreign.API
   ) where
 
 import MAlonzo.Code.Ledger.Conway.Foreign.HSTypes                    as X


### PR DESCRIPTION
# Description

This is a revival of #270.

Closes #595.

Note that this does not pass conformance testing due to #745

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
