### PR TITLE
Fix nix `LOCALE_ARCHIVE` on darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,9 +10,9 @@ let
   locales = {
     LANG = "en_US.UTF-8";
     LC_ALL = "en_US.UTF-8";
-    LOCALE_ARCHIVE = if pkgs.system == "x86_64-linux"
-                     then "${pkgs.glibcLocales}/lib/locale/locale-archive"
-                     else "";
+    LOCALE_ARCHIVE = pkgs.lib.optionalString
+      pkgs.stdenv.isLinux
+      "${pkgs.glibcLocales}/lib/locale/locale-archive";
   };
 
   agdaStdlib = agdaPackages.standard-library.overrideAttrs (oldAttrs: {

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,9 @@ with pkgs;
 
 let
   specs = callPackage ./default.nix {};
+  LOCALE_ARCHIVE = pkgs.lib.optionalString
+    pkgs.stdenv.isLinux
+    "${pkgs.glibcLocales}/lib/locale/locale-archive";
 in {
   shell = mkShell {
     nativeBuildInputs = [
@@ -22,7 +25,7 @@ in {
     shellHook = ''
       export LANG=en_US.UTF-8
       export LC_ALL=en_US.UTF-8
-      export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
+      export LOCALE_ARCHIVE=${LOCALE_ARCHIVE}
     '';    
 
   };
@@ -38,7 +41,7 @@ in {
       shellHook = ''
         export LANG=en_US.UTF-8
         export LC_ALL=en_US.UTF-8
-        export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
+        export LOCALE_ARCHIVE=${LOCALE_ARCHIVE}
       '';    
     };
   };


### PR DESCRIPTION
# Description

This pull request fixes an issue where `nix-shell` fails to start a shell on macOS / darwin due to an invalid value when defining `export LOCALE_ARCHIVE`. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
