### PR TITLE
Add `createRUpd` (PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### WIP
 
+- Add `poolParameters` field to `Snapshot` and compute it in `SNAP`.
 - Add `treasuryCut` (formerly `tau`) and `monetaryExpansion` (formerly `rho`) to `PParams`
 - Change the `DELEG-dereg` transition so that the deposit field can be empty
 - Require witnessing of `reg` credential if the deposit is non-zero

--- a/src/Ledger/Conway/Foreign/HSLedger/Core.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Core.agda
@@ -7,6 +7,8 @@ open Computational public
 open import Algebra.Construct.DirectProduct using (commutativeMonoid)
 open import Algebra.Morphism    using (module MonoidMorphisms)
 open import Data.Nat.Properties using (+-0-commutativeMonoid) public
+import      Data.Integer as ℤ
+import      Data.Rational as ℚ
 
 open import Foreign.Convertible           public
 open import Foreign.Convertible.Deriving  public
@@ -61,6 +63,7 @@ unquoteDecl Show-HSVKey = derive-Show
 module Implementation where
   Network          = ℕ
   SlotsPerEpochᶜ   = 4320 -- TODO pass this externally instead of hardcoding
+  ActiveSlotCoeff  = ℤ.1ℤ ℚ./ 20  
   StabilityWindowᶜ = 10
   Quorum           = 1
   NetworkId        = 0 -- Testnet

--- a/src/Ledger/Epoch.lagda
+++ b/src/Ledger/Epoch.lagda
@@ -27,6 +27,7 @@ open import Ledger.Gov txs
 open import Ledger.Ledger txs abs
 open import Ledger.Prelude hiding (iterate)
 open import Ledger.Ratify txs
+open import Ledger.Rewards govStructure
 open import Ledger.Utxo txs abs
 
 open import Agda.Builtin.FromNat
@@ -36,24 +37,6 @@ open import Data.Nat.GeneralisedArithmetic using (iterate)
 open import Data.Nat.Properties using (+-0-monoid; +-0-commutativeMonoid)
 
 \end{code}
-\begin{NoConway}
-\begin{figure*}[ht]
-\begin{AgdaMultiCode}
-\begin{code}
-record RewardUpdate : Set where
-\end{code}
-\begin{code}[hide]
-  constructor ⟦_,_,_,_⟧ʳᵘ
-\end{code}
-\begin{code}
-  field
-    Δt Δr Δf : ℤ
-    rs : Credential ⇀ Coin
-\end{code}
-\end{AgdaMultiCode}
-\end{figure*}
-\end{NoConway}
-
 \begin{figure*}[ht]
 \begin{AgdaMultiCode}
 \begin{NoConway}

--- a/src/Ledger/Epoch.lagda
+++ b/src/Ledger/Epoch.lagda
@@ -42,9 +42,9 @@ open import Ledger.Utxo txs abs
 \begin{code}
 record Snapshot : Set where
   field
-    stake        : Credential ⇀ Coin
-    delegations  : Credential ⇀ KeyHash
-    -- poolParameters : KeyHash ⇀ PoolParam
+    stake           : Credential ⇀ Coin
+    delegations     : Credential ⇀ KeyHash
+    poolParameters  : KeyHash ⇀ PoolParams
 
 record Snapshots : Set where
   field
@@ -201,7 +201,7 @@ createRUpd slotsPerEpoch b es total
     feeSS       = es .EpochState.ss .Snapshots.feeSS
     stake       = pstakego .Snapshot.stake
     delegs      = pstakego .Snapshot.delegations
-    poolParams  = ∅ᵐ -- FIXME: Add pool parameters to Snapshots
+    poolParams  = pstakego .Snapshot.poolParameters
 
     blocksMade = ∑[ m ← b ] m
 
@@ -275,8 +275,10 @@ open RwdAddr using (stake)
 \end{code}
 \begin{code}
 stakeDistr : UTxO → DState → PState → Snapshot
-stakeDistr utxo stᵈ pState = ⟦ aggregate₊ (stakeRelation ᶠˢ) , stakeDelegs ⟧
+stakeDistr utxo stᵈ pState =
+    ⟦ aggregate₊ (stakeRelation ᶠˢ) , stakeDelegs , poolParams ⟧
   where
+    poolParams = pState .PState.pools
     open DState stᵈ using (stakeDelegs; rewards)
     m = mapˢ (λ a → (a , cbalance (utxo ∣^' λ i → getStakeCred i ≡ just a))) (dom rewards)
     stakeRelation = m ∪ ∣ rewards ∣

--- a/src/Ledger/Rewards.lagda
+++ b/src/Ledger/Rewards.lagda
@@ -424,13 +424,44 @@ reward pp blocks rewardPot poolParams stake delegs total = rewards
 
 \subsection{Reward Update}
 \label{sec:reward-update}
-TODO: This section defines the \AgdaRecord{RewardUpdate} type,
+This section defines the \AgdaRecord{RewardUpdate} type,
 which records the net flow of Ada due to paying out rewards
 after an epoch.
-NOTE: The function \AgdaFunction{createRUpd} calculates the
+This type is defined in \Cref{fig:functions:RewardUpdate}.
+The update consists of four net flows:
+\begin{itemize}
+  \item \AgdaField{Δt}: The change to the treasury.
+    This will be a positive value.
+  \item \AgdaField{Δr}: The change to the reserves.
+    We typically expect this to be a negative value.
+  \item \AgdaField{Δf}: The change to the fee pot.
+    This will be a negative value.
+  \item \AgdaField{rs}: The map of new individual rewards,
+    to be added to the existing rewards.
+\end{itemize}
+
+\begin{figure*}[ht]
+\begin{AgdaMultiCode}
+\begin{code}
+record RewardUpdate : Set where
+\end{code}
+\begin{code}[hide]
+  constructor ⟦_,_,_,_⟧ʳᵘ
+\end{code}
+\begin{code}
+  field
+    Δt Δr Δf : ℤ
+    rs : Credential ⇀ Coin
+\end{code}
+\end{AgdaMultiCode}
+\caption{RewardUpdate type}
+\label{fig:functions:RewardUpdate}
+\end{figure*}
+
+The function \AgdaFunction{createRUpd} calculates the
 \AgdaRecord{RewardUpdate},
-but requires the definition \AgdaRecord{EpochState},
-so we have to defer its definition to a later section.
+but requires the definition of the type \AgdaRecord{EpochState},
+so we have to defer the definition of this function to \cref{sec:epoch-boundary}.
 
 \subsection{Stake Distribution Snapshots}
 \label{sec:stake-dstribution-snapshots-}

--- a/src/Ledger/Rewards.lagda
+++ b/src/Ledger/Rewards.lagda
@@ -463,6 +463,66 @@ The function \AgdaFunction{createRUpd} calculates the
 but requires the definition of the type \AgdaRecord{EpochState},
 so we have to defer the definition of this function to \cref{sec:epoch-boundary}.
 
+\Cref{fig:rewardPot} captures the potential movement of funds
+in the entire system
+that can happen during one transition step as described in this document.
+Exception: Withdrawals from the ``Treasury'' are not shown in this diagram,
+they can move funds into ``Reward accounts''.
+Value is moved between accounting pots,
+but the total amount of value in the system remains constant.
+In particular, the red subgraph
+represents the inputs and outputs to the \AgdaFunction{rewardPot},
+a temporary variable used during the reward update calculation
+in the function \AgdaFunction{createRUpd}.
+Each red arrow corresponds to one field of the \AgdaRecord{RewardUpdate}
+data type.
+The blue arrows represent the movement of funds
+after they have passed through the \AgdaFunction{rewardPot}.
+
+\begin{figure}[htb]
+  \begin{center}
+    \begin{tikzpicture}
+      [ x=30mm, y=30mm
+      , direct/.style={black, draw}
+      , implied/.style={blue, draw}
+      , toTotPot/.style={red, draw}
+      ]
+    \node (C) at (3,2.5) {\LARGE Circulation};
+    \node (R) at (5, 1) {\LARGE Reserves};
+    \node (D) at (1, 2) {\LARGE Deposits};
+    \node (FR) at (1,1) {\LARGE Fees};
+    \node (RA) at (5, 2) {\LARGE Reward accounts};
+    \node (T) at (3,0.5) {\LARGE Treasury};
+
+    \draw[->, direct, ultra thick]
+    (C) edge (D)
+    (C) edge (FR)
+
+    (D) edge (C)
+
+    (RA) edge (C);
+
+    \draw[->, implied, ultra thick]
+    (FR) edge (T)
+    (FR) edge (RA)
+
+    (R) edge (T)
+    (R) edge (RA);
+
+    \node (TP) at (3, 1.15) {\LARGE rewardPot};
+
+    \draw[->, toTotPot, ultra thick]
+    (FR) edge node[below] {$-\Delta f$} (TP)
+    (R)  edge node[below] {$-\Delta r$} (TP)
+
+    (TP) edge node[below] {\textit{rs}} (RA)
+    (TP) edge node[right] {$\Delta t$} (T);
+    \end{tikzpicture}
+  \end{center}
+  \caption{Preservation of funds and rewards}
+  \label{fig:rewardPot}
+\end{figure}
+
 \subsection{Stake Distribution Snapshots}
 \label{sec:stake-dstribution-snapshots-}
 TODO: This section defines the SNAP transition rule

--- a/src/Ledger/Types/Epoch.agda
+++ b/src/Ledger/Types/Epoch.agda
@@ -8,6 +8,8 @@ open import Agda.Builtin.FromNat
 open import Algebra using (Semiring)
 open import Relation.Binary
 open import Data.Nat.Properties using (+-*-semiring)
+open import Data.Rational using (ℚ)
+import      Data.Rational as ℚ
 
 additionVia : ∀{A : Set} → (A → A) → ℕ → A → A
 additionVia sucFun zero r = r
@@ -71,7 +73,8 @@ record EpochStructure : Type₁ where
 
 record GlobalConstants : Type₁ where
   field  Network : Type; ⦃ DecEq-Netw ⦄ : DecEq Network; ⦃ Show-Network ⦄ : Show Network
-         SlotsPerEpochᶜ : ℕ; ⦃ NonZero-SlotsPerEpochᶜ ⦄ : NonZero SlotsPerEpochᶜ
+         SlotsPerEpochᶜ   : ℕ; ⦃ NonZero-SlotsPerEpochᶜ ⦄ : NonZero SlotsPerEpochᶜ
+         ActiveSlotCoeff  : ℚ; ⦃ NonZero-ActiveSlotCoeff ⦄ : ℚ.NonZero ActiveSlotCoeff
          StabilityWindowᶜ : ℕ
          Quorum : ℕ
          NetworkId : Network

--- a/src/ScriptVerification/LedgerImplementation.agda
+++ b/src/ScriptVerification/LedgerImplementation.agda
@@ -7,7 +7,9 @@ module ScriptVerification.LedgerImplementation
   where
 
 open import Ledger.Prelude hiding (fromList; ε); open Computational
+import      Data.Integer as ℤ
 open import Data.Rational using (0ℚ; ½)
+import      Data.Rational as ℚ
 open import Algebra.Morphism    using (module MonoidMorphisms)
 open import Data.Nat.Properties using (+-0-commutativeMonoid)
 open import Relation.Binary.Morphism.Structures
@@ -33,6 +35,7 @@ instance
 module Implementation where
   Network          = ℕ
   SlotsPerEpochᶜ   = 100
+  ActiveSlotCoeff  = ℤ.1ℤ ℚ./ 20
   StabilityWindowᶜ = 10
   Quorum           = 1
   NetworkId        = 0


### PR DESCRIPTION
# Description

This pull request adds the function `createRUpd` to the specification.

Comments:

* I have decided to stay very close to the notation from the original Shelley specification in order to make it straightforward to check that the two specifications agree.
* 6 lines in the `where` clause of `createRUpd` are devoted to extracting fields from records. This is somewhat lengthy, but I am under the impression that `where` clauses in Agda do not support pattern matching. It would be beneficial to join at least 3 lines into a single line `open Snapshot pstakego;`, but I am not quite sure what the policy on record modules is — `open` is used a couple of times in the specification, but it is never explained in Section 1 or 2 of the PDF.
* I have added `poolParameters` to the `SnapShot` type and the `SNAP` rule, as they are needed by the `createRUpd` function.
* I have also added the "Preservation of funds" diagram from the original Shelley specification for good measure.

Context:

#706, #679

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
