### PR TITLE
Add `dejavu` fonts to TeX environment in `default.nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -92,6 +92,7 @@ in rec
     inherit (texlive)
       scheme-small
       xits
+      dejavu
       collection-latexextra
       collection-latexrecommended
       collection-mathscience


### PR DESCRIPTION
# Description

This pull request fixes an issue where the font "DejaVu Sans Mono" introduced in #743 is not present in the nix environment, and `fls-shake` fails to produce `cardano-ledger.pdf` on my machine.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
