### PR TITLE
Move `SNAP` to section "Rewards"

### DIFF
--- a/src/Ledger/Epoch/Properties.agda
+++ b/src/Ledger/Epoch/Properties.agda
@@ -16,6 +16,7 @@ open import Ledger.Epoch txs abs
 open import Ledger.Ledger txs abs
 open import Ledger.Ratify txs
 open import Ledger.Ratify.Properties txs
+open import Ledger.Rewards txs abs
 
 open import Data.List using (filter)
 import Relation.Binary.PropositionalEquality as PE


### PR DESCRIPTION
# Description

This pull request moves the rule `SNAP` and associated types such as `Snapshot` and `Snapshots`, out of the section "Epoch Boundary" into the section "Rewards". In addition, we add a copy of the illustrated description of the Reward Cycle from the Shelley specification.

The goal of this and subsequent pull requests is to make the "Epoch Boundary" section lighter and to group the topics that are specific to rewards into the "Rewards" section.

Comments:

* I have moved the definition of `stakeDistr` as-is, I have not included a solution of #679 in the scope of this particular pull request.

Context: #706, #679

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
