### PR TITLE
Add script to plot typechecking times

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@
     - [Building `fls-shake` manually](#building-fls-shake-manually)
   - [Updating nixpkgs](#updating-nixpkgs)
   - [Troubleshooting](#troubleshooting)
+  - [Miscellanea](#miscellanea)
   - [Maintainers](#maintainers)
 
 <!-- markdown-toc end -->
@@ -587,6 +588,25 @@ niv update nixpkgs -v 21.11.337905.902d91def1e
 
 ---
 
+## Miscellanea
+
+### Plotting typechecking times
+
+The script `scripts/plot_typecheck_time.py` can be used to generate an `html`
+file that plots the typechecking times as recorded in the `master-artifacts`
+branch.
+
+The script uses `python` and `pandas`, and the generated `html` uses `chart.js`
+for plotting.
+
+Frome the git repository, run,
+```bash
+python scripts/plot_typecheck_time.py > index.html
+```
+and open `index.html` in your browser.
+
+---
+
 ## Maintainers
 
 This repository is maintained by [@carlostome][], [@WhatisRT][], and [@williamdemeo][].
@@ -649,3 +669,4 @@ This repository is maintained by [@carlostome][], [@WhatisRT][], and [@williamde
 [Updating nixpkgs]: #updating-nixpkgs
 [Troubleshooting]: #troubleshooting
 [Maintainers]: #maintainers
+[Miscellanea]: #miscellanea

--- a/scripts/plot_typecheck_time.py
+++ b/scripts/plot_typecheck_time.py
@@ -1,0 +1,117 @@
+# Generate a .csv file that integrates the typecheking times
+# that are stored in the branch master-artifacts
+import subprocess
+import pandas as pd
+from io import StringIO
+
+# Run git to retrieve the list of commits in master-artifacts
+result = subprocess.run([ "git"
+                        , "--no-pager"
+                        , "log"
+                        , "origin/master-artifacts"
+                        , "--reverse"
+                        , "--pretty=%H" ], capture_output=True, text=True)
+
+commits = result.stdout.splitlines()
+
+# Create a new empty dataframe
+df = pd.DataFrame(columns=['module'])
+
+# Iterate over the list of modules to retrieve the contents
+# of the typecheck.time file to merge on the dataframe
+for commit in commits:
+    typecheck_file = subprocess.run([ "git"
+                                    , "--no-pager"
+                                    , "show"
+                                    , f"{commit}:typecheck.time" ], capture_output=True, text=True)
+
+    orig_commit = subprocess.run([ "git"
+                                 , "--no-pager"
+                                 , "show"
+                                 , "-s"
+                                 , "--format=%s"
+                                 , f"{commit}" ]
+                                 , capture_output=True
+                                 , text=True).stdout.split()[-1]
+
+    time_df = pd.read_csv(StringIO(typecheck_file.stdout)
+                         , sep=r'\s+'
+                         , header=None
+                         , names=['module', f"{orig_commit}"]
+                         , converters={ f"{orig_commit}" : lambda s : int(s.replace(',','')[:-2]) } # parse the times as ints
+                         , skipinitialspace=True # skip preceding spaces
+                         , skiprows=[0] # remove the total row
+                         )
+
+    df = pd.merge(df, time_df, on='module', how='outer')
+
+# print(df.to_csv(None, header=True, index=False, float_format='%.0f'))
+data = df.to_json(None, index=False, orient="split")
+
+html = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Typechecking times</title>
+  <style>
+    html, body {{
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }}
+    #chart-wrapper {{
+      width: 100vw;
+      height: 100vh;
+      box-sizing: border-box;
+    }}
+    #chart {{
+      width: 100%;
+      height: 100%;
+      display: block;
+    }}
+  </style>
+</head>
+<body>
+  <div id="chart-wrapper">
+    <canvas id="chart"></canvas>
+  </div>
+  <!-- Chart.js -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <!-- chartjs-plugin-datasource -->
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource"></script>
+  <script>
+    const ctx = document.getElementById('chart').getContext('2d');
+    const data = {data}
+    const chart = new Chart(ctx, {{
+      type: 'bar',
+      data: {{
+        labels: data.columns.slice(1),
+        datasets: data.data.map((row, idx) => ({{
+          label: row[0],
+          data: row.slice(1),
+          }}))
+      }},
+      options: {{
+        plugins: {{
+          legend: {{ display: false }}
+        }},
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {{
+          x: {{ stacked: true,
+                ticks: {{
+                  font: {{
+                    size: 20
+                  }}
+                }}
+             }},
+          y: {{ stacked: true }}
+        }}
+      }}
+    }});
+  </script>
+</body>
+</html>
+"""
+print(html)


### PR DESCRIPTION
# Description

This PR adds a script that can be used locally to plot a graph with the recorded typechecking times in the `master-artifacts` branch.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
