### PR TITLE
Add invariants to `RewardUpdate`

### DIFF
--- a/lib-exts/stdlib/Data/Rational/Properties.agda
+++ b/lib-exts/stdlib/Data/Rational/Properties.agda
@@ -65,8 +65,8 @@ fromℕ-0≤ : ∀ (n : ℕ) → 0 ≤ fromℕ n
 fromℕ-0≤ n = fromℤ-0≤ (ℤ.+ n) (+≤+ z≤n)
 
 -- The product of 2 non-negative numbers is non-negative.
-*-0≤-2⇒0≤ : ∀ (x y : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ (x * y) 
-*-0≤-2⇒0≤ x y 0≤x 0≤y =
+*-0≤⇒0≤ : ∀ (x y : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ (x * y) 
+*-0≤⇒0≤ x y 0≤x 0≤y =
   begin
     0      ≡⟨ sym (*-zeroʳ x) ⟩
     x * 0  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ nonNegative 0≤x ⦄ 0≤y ⟩
@@ -76,15 +76,15 @@ fromℕ-0≤ n = fromℤ-0≤ (ℤ.+ n) (+≤+ z≤n)
 -- The product of 3 non-negative numbers is non-negative.
 *-0≤-3⇒0≤ : ∀ (x y z : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ z → 0 ≤ (x * y * z) 
 *-0≤-3⇒0≤ x y z 0≤x 0≤y 0≤z =
-  *-0≤-2⇒0≤ (x * y) z (*-0≤-2⇒0≤ x y 0≤x 0≤y) 0≤z
+  *-0≤⇒0≤ (x * y) z (*-0≤⇒0≤ x y 0≤x 0≤y) 0≤z
 
 -- Division by a non-negative number 
-lemma-÷ : ∀ (x y : ℚ) → .{{_ : NonZero y}} → 0 ≤ x → 0 ≤ y → 0 ≤ x ÷ y 
-lemma-÷ x y 0≤x 0≤y = nonNegative⁻¹ (x ÷ y)
+÷-0≤⇒0≤ : ∀ (x y : ℚ) → .{{_ : NonZero y}} → 0 ≤ x → 0 ≤ y → 0 ≤ x ÷ y 
+÷-0≤⇒0≤ x y 0≤x 0≤y = nonNegative⁻¹ (x ÷ y)
   where
     instance
       lemma-1/y : Positive (1/ y)
-      lemma-1/y = 1/pos⇒pos y ⦃ nonNeg∧nonZero⇒pos y ⦃ nonNegative 0≤y ⦄ ⦄
+      lemma-1/y = 1/pos⇒pos y {{nonNeg∧nonZero⇒pos y {{nonNegative 0≤y}}}}
 
       lemma-x÷y : NonNegative (x * 1/ y)
-      lemma-x÷y = nonNeg*nonNeg⇒nonNeg x ⦃ nonNegative 0≤x ⦄ (1/ y) ⦃ pos⇒nonNeg (1/ y) ⦄
+      lemma-x÷y = nonNeg*nonNeg⇒nonNeg x {{nonNegative 0≤x}} (1/ y) {{pos⇒nonNeg (1/ y)}}

--- a/lib-exts/stdlib/Data/Rational/Properties.agda
+++ b/lib-exts/stdlib/Data/Rational/Properties.agda
@@ -1,0 +1,89 @@
+{-# OPTIONS --safe #-}
+module stdlib.Data.Rational.Properties where
+
+open import Data.Integer using (ℤ)
+import      Data.Integer as ℤ
+import      Data.Integer.DivMod as ℤ
+import      Data.Integer.Properties as ℤ
+open import Data.Nat using (ℕ)
+import      Data.Nat as ℕ
+open import Data.Rational as ℚ
+import      Data.Rational.Properties as ℚ
+open import Data.Unit.Base using (⊤)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym)
+
+-- Natural number literals
+open import Agda.Builtin.FromNat
+import      Data.Integer.Literals as ℤ
+import      Data.Rational.Literals as ℚ
+open import Data.Rational.Literals using (fromℤ)
+instance Number-ℤ = ℤ.number
+instance Number-ℚ = ℚ.number
+open Number ℚ.number using () renaming (fromNat to fromℕ)
+
+-- Properties of 'floor'
+
+-- 'floor' is defined such that it typically does not normalize,
+-- but we can use its definition as a propositional equality.
+floor-def : ∀ (x : ℚ) → floor x ≡ ℚ.numerator x ℤ./ ℚ.denominator x
+floor-def x@record{} = refl
+
+-- A non-negative rational number has a non-negative numerator.
+0≤⇒0≤numerator : ∀ (x : ℚ) → 0 ≤ x → 0 ℤ.≤ ℚ.numerator x
+0≤⇒0≤numerator x 0≤x =
+  begin
+    0                       ≡⟨ sym (ℤ.*-zeroˡ (ℚ.denominator x)) ⟩
+    0 ℤ.* ℚ.denominator x   ≤⟨ drop-*≤* 0≤x ⟩
+    ℚ.numerator x ℤ.* 1     ≡⟨ ℤ.*-identityʳ _ ⟩
+    ℚ.numerator x           ∎
+  where open ℤ.≤-Reasoning
+
+-- The 'floor' of a non-negative number is again non-negative.
+0≤⇒0≤floor : ∀ (x : ℚ) → 0 ≤ x → 0 ℤ.≤ floor x
+0≤⇒0≤floor x 0≤x =
+  begin
+    0                                     ≤⟨ ℤ.0≤n⇒0≤n/ℕd _ _ (0≤⇒0≤numerator x 0≤x) ⟩
+    (ℚ.numerator x ℤ./ℕ ℚ.denominatorℕ x) ≡⟨ sym (ℤ.div-pos-is-/ℕ (ℚ.numerator x) (ℚ.denominatorℕ x)) ⟩
+    (ℚ.numerator x ℤ./ ℚ.denominator x)   ≡⟨ sym (floor-def x) ⟩
+    floor x                               ∎
+  where open ℤ.≤-Reasoning
+
+-- Properties related to non-negativity
+
+-- Any non-negative integer is a non-negative rational number.
+fromℤ-0≤ : ∀ (i : ℤ) → 0 ℤ.≤ i → 0 ≤ fromℤ i
+fromℤ-0≤ i 0≤i = *≤* (begin
+    0 ℤ.* i ≡⟨ sym (ℤ.*-zeroˡ i) ⟩
+    0       ≤⟨ 0≤i ⟩
+    i       ≡⟨ sym (ℤ.*-identityʳ i) ⟩
+    i ℤ.* 1 ∎)
+  where open ℤ.≤-Reasoning
+
+-- Any natural number is a non-negative rational number.
+fromℕ-0≤ : ∀ (n : ℕ) → 0 ≤ fromℕ n
+fromℕ-0≤ n = fromℤ-0≤ (ℤ.+ n) (ℤ.+≤+ ℕ.z≤n)
+
+-- The product of 2 non-negative numbers is non-negative.
+*-0≤-2⇒0≤ : ∀ (x y : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ (x * y) 
+*-0≤-2⇒0≤ x y 0≤x 0≤y =
+  begin
+    0      ≡⟨ sym (ℚ.*-zeroʳ x) ⟩
+    x * 0  ≤⟨ ℚ.*-monoˡ-≤-nonNeg x ⦃ ℚ.nonNegative 0≤x ⦄ 0≤y ⟩
+    x * y  ∎
+  where open ℚ.≤-Reasoning
+
+-- The product of 3 non-negative numbers is non-negative.
+*-0≤-3⇒0≤ : ∀ (x y z : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ z → 0 ≤ (x * y * z) 
+*-0≤-3⇒0≤ x y z 0≤x 0≤y 0≤z =
+  *-0≤-2⇒0≤ (x * y) z (*-0≤-2⇒0≤ x y 0≤x 0≤y) 0≤z
+
+-- Division by a non-negative number 
+lemma-÷ : ∀ (x y : ℚ) → .{{_ : ℚ.NonZero y}} → 0 ≤ x → 0 ≤ y → 0 ≤ x ÷ y 
+lemma-÷ x y 0≤x 0≤y = ℚ.nonNegative⁻¹ (x ÷ y)
+  where
+    instance
+      lemma-1/y : ℚ.Positive (1/ y)
+      lemma-1/y = ℚ.1/pos⇒pos y {{ℚ.nonNeg∧nonZero⇒pos y {{ℚ.nonNegative 0≤y}}}}
+
+      lemma-x÷y : ℚ.NonNegative (x * 1/ y)
+      lemma-x÷y = ℚ.nonNeg*nonNeg⇒nonNeg x {{ℚ.nonNegative 0≤x}} (1/ y) {{ℚ.pos⇒nonNeg (1/ y)}}

--- a/lib-exts/stdlib/Data/Rational/Properties.agda
+++ b/lib-exts/stdlib/Data/Rational/Properties.agda
@@ -1,14 +1,15 @@
 {-# OPTIONS --safe #-}
 module stdlib.Data.Rational.Properties where
 
-open import Data.Integer using (ℤ)
+open import Data.Integer using (ℤ; _/ℕ_; +≤+)
 import      Data.Integer as ℤ
-import      Data.Integer.DivMod as ℤ
-import      Data.Integer.Properties as ℤ
-open import Data.Nat using (ℕ)
-import      Data.Nat as ℕ
-open import Data.Rational as ℚ
-import      Data.Rational.Properties as ℚ
+open import Data.Integer.DivMod using (div-pos-is-/ℕ; 0≤n⇒0≤n/ℕd)
+open import Data.Integer.Properties using (module ≤-Reasoning; *-identityʳ; *-zeroˡ)
+open import Data.Nat using (ℕ; z≤n)
+open import Data.Rational
+open import Data.Rational.Properties renaming (module ≤-Reasoning to ≤ℚ-Reasoning)
+                                     using (*-monoˡ-≤-nonNeg; *-zeroʳ; 1/pos⇒pos; nonNeg∧nonZero⇒pos;
+                                           nonNeg*nonNeg⇒nonNeg; pos⇒nonNeg; nonNegative⁻¹)
 open import Data.Unit.Base using (⊤)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym)
 
@@ -25,52 +26,52 @@ open Number ℚ.number using () renaming (fromNat to fromℕ)
 
 -- 'floor' is defined such that it typically does not normalize,
 -- but we can use its definition as a propositional equality.
-floor-def : ∀ (x : ℚ) → floor x ≡ ℚ.numerator x ℤ./ ℚ.denominator x
+floor-def : ∀ (x : ℚ) → floor x ≡ ↥ x ℤ./ ↧ x
 floor-def x@record{} = refl
 
 -- A non-negative rational number has a non-negative numerator.
-0≤⇒0≤numerator : ∀ (x : ℚ) → 0 ≤ x → 0 ℤ.≤ ℚ.numerator x
+0≤⇒0≤numerator : ∀ (x : ℚ) → 0 ≤ x → 0 ℤ.≤ ↥ x
 0≤⇒0≤numerator x 0≤x =
   begin
-    0                       ≡⟨ sym (ℤ.*-zeroˡ (ℚ.denominator x)) ⟩
-    0 ℤ.* ℚ.denominator x   ≤⟨ drop-*≤* 0≤x ⟩
-    ℚ.numerator x ℤ.* 1     ≡⟨ ℤ.*-identityʳ _ ⟩
-    ℚ.numerator x           ∎
-  where open ℤ.≤-Reasoning
+    0         ≡⟨ sym (*-zeroˡ (↧ x)) ⟩
+    0 ℤ.* ↧ x ≤⟨ drop-*≤* 0≤x ⟩
+    ↥ x ℤ.* 1 ≡⟨ *-identityʳ _ ⟩
+    ↥ x       ∎
+  where open ≤-Reasoning
 
 -- The 'floor' of a non-negative number is again non-negative.
 0≤⇒0≤floor : ∀ (x : ℚ) → 0 ≤ x → 0 ℤ.≤ floor x
 0≤⇒0≤floor x 0≤x =
   begin
-    0                                     ≤⟨ ℤ.0≤n⇒0≤n/ℕd _ _ (0≤⇒0≤numerator x 0≤x) ⟩
-    (ℚ.numerator x ℤ./ℕ ℚ.denominatorℕ x) ≡⟨ sym (ℤ.div-pos-is-/ℕ (ℚ.numerator x) (ℚ.denominatorℕ x)) ⟩
-    (ℚ.numerator x ℤ./ ℚ.denominator x)   ≡⟨ sym (floor-def x) ⟩
-    floor x                               ∎
-  where open ℤ.≤-Reasoning
+    0             ≤⟨ 0≤n⇒0≤n/ℕd _ _ (0≤⇒0≤numerator x 0≤x) ⟩
+    (↥ x /ℕ ↧ₙ x) ≡⟨ sym (div-pos-is-/ℕ (↥ x) (↧ₙ x)) ⟩
+    (↥ x ℤ./ ↧ x) ≡⟨ sym (floor-def x) ⟩
+    floor x       ∎
+  where open ≤-Reasoning
 
 -- Properties related to non-negativity
 
 -- Any non-negative integer is a non-negative rational number.
 fromℤ-0≤ : ∀ (i : ℤ) → 0 ℤ.≤ i → 0 ≤ fromℤ i
 fromℤ-0≤ i 0≤i = *≤* (begin
-    0 ℤ.* i ≡⟨ sym (ℤ.*-zeroˡ i) ⟩
+    0 ℤ.* i ≡⟨ sym (*-zeroˡ i) ⟩
     0       ≤⟨ 0≤i ⟩
-    i       ≡⟨ sym (ℤ.*-identityʳ i) ⟩
+    i       ≡⟨ sym (*-identityʳ i) ⟩
     i ℤ.* 1 ∎)
-  where open ℤ.≤-Reasoning
+  where open ≤-Reasoning
 
 -- Any natural number is a non-negative rational number.
 fromℕ-0≤ : ∀ (n : ℕ) → 0 ≤ fromℕ n
-fromℕ-0≤ n = fromℤ-0≤ (ℤ.+ n) (ℤ.+≤+ ℕ.z≤n)
+fromℕ-0≤ n = fromℤ-0≤ (ℤ.+ n) (+≤+ z≤n)
 
 -- The product of 2 non-negative numbers is non-negative.
 *-0≤-2⇒0≤ : ∀ (x y : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ (x * y) 
 *-0≤-2⇒0≤ x y 0≤x 0≤y =
   begin
-    0      ≡⟨ sym (ℚ.*-zeroʳ x) ⟩
-    x * 0  ≤⟨ ℚ.*-monoˡ-≤-nonNeg x ⦃ ℚ.nonNegative 0≤x ⦄ 0≤y ⟩
+    0      ≡⟨ sym (*-zeroʳ x) ⟩
+    x * 0  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ nonNegative 0≤x ⦄ 0≤y ⟩
     x * y  ∎
-  where open ℚ.≤-Reasoning
+  where open ≤ℚ-Reasoning
 
 -- The product of 3 non-negative numbers is non-negative.
 *-0≤-3⇒0≤ : ∀ (x y z : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ z → 0 ≤ (x * y * z) 
@@ -78,12 +79,12 @@ fromℕ-0≤ n = fromℤ-0≤ (ℤ.+ n) (ℤ.+≤+ ℕ.z≤n)
   *-0≤-2⇒0≤ (x * y) z (*-0≤-2⇒0≤ x y 0≤x 0≤y) 0≤z
 
 -- Division by a non-negative number 
-lemma-÷ : ∀ (x y : ℚ) → .{{_ : ℚ.NonZero y}} → 0 ≤ x → 0 ≤ y → 0 ≤ x ÷ y 
-lemma-÷ x y 0≤x 0≤y = ℚ.nonNegative⁻¹ (x ÷ y)
+lemma-÷ : ∀ (x y : ℚ) → .{{_ : NonZero y}} → 0 ≤ x → 0 ≤ y → 0 ≤ x ÷ y 
+lemma-÷ x y 0≤x 0≤y = nonNegative⁻¹ (x ÷ y)
   where
     instance
-      lemma-1/y : ℚ.Positive (1/ y)
-      lemma-1/y = ℚ.1/pos⇒pos y {{ℚ.nonNeg∧nonZero⇒pos y {{ℚ.nonNegative 0≤y}}}}
+      lemma-1/y : Positive (1/ y)
+      lemma-1/y = 1/pos⇒pos y ⦃ nonNeg∧nonZero⇒pos y ⦃ nonNegative 0≤y ⦄ ⦄
 
-      lemma-x÷y : ℚ.NonNegative (x * 1/ y)
-      lemma-x÷y = ℚ.nonNeg*nonNeg⇒nonNeg x {{ℚ.nonNegative 0≤x}} (1/ y) {{ℚ.pos⇒nonNeg (1/ y)}}
+      lemma-x÷y : NonNegative (x * 1/ y)
+      lemma-x÷y = nonNeg*nonNeg⇒nonNeg x ⦃ nonNegative 0≤x ⦄ (1/ y) ⦃ pos⇒nonNeg (1/ y) ⦄

--- a/src/Ledger/Conway/Epoch.lagda
+++ b/src/Ledger/Conway/Epoch.lagda
@@ -5,23 +5,21 @@
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
 
-open import Data.Nat.Properties using (+-0-monoid; +-0-commutativeMonoid)
 open import Data.Integer using () renaming (+_ to pos)
 import      Data.Integer as ℤ
-import      Data.Integer.Properties as ℤ
+open import Data.Integer.Properties using (module ≤-Reasoning; +-mono-≤; neg-mono-≤; +-identityˡ)
+                                    renaming (nonNegative⁻¹ to nonNegative⁻¹ℤ)
 open import Data.Nat.GeneralisedArithmetic using (iterate)
-open import Data.Rational using (ℚ; floor; _*_; _÷_; _/_)
-import      Data.Rational as ℚ renaming (_⊓_ to min)
+open import Data.Rational using (ℚ; floor; _*_; _÷_; _/_; _⊓_; _≟_; ≢-nonZero)
 open import Data.Rational.Literals using (number; fromℤ)
-import      Data.Rational.Properties as ℚ
-open import stdlib.Data.Rational.Properties as ℚ
-open import Data.Irrelevant using (Irrelevant; irrelevant)
+open import Data.Rational.Properties using (nonNegative⁻¹; pos⇒nonNeg; ⊓-glb)
+open import stdlib.Data.Rational.Properties using (0≤⇒0≤floor; ÷-0≤⇒0≤; fromℕ-0≤; *-0≤⇒0≤; fromℤ-0≤)
 
-open import Data.Integer.Tactic.RingSolver as ℤ using (solve-∀)
+open import Data.Integer.Tactic.RingSolver using (solve-∀)
 
 open import Agda.Builtin.FromNat
 
-open import Ledger.Prelude hiding (iterate; _/_; _*_)
+open import Ledger.Prelude hiding (iterate; _/_; _*_; _⊓_; _≟_; ≢-nonZero)
 open Filter using (filter)
 open import Ledger.Conway.Abstract
 open import Ledger.Conway.Transaction
@@ -128,7 +126,9 @@ instance
     ( (quote EpochState     , HasCast-EpochState)
     ∷ [ (quote NewEpochState  , HasCast-NewEpochState)])
 
-instance _ = +-0-monoid; _ = +-0-commutativeMonoid
+-- instance _ = +-0-monoid; _ = +-0-commutativeMonoid
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-- It seems we don't need these anymore.
 
 toRwdAddr : Credential → RwdAddr
 toRwdAddr x = record { net = NetworkId ; stake = x }
@@ -186,8 +186,8 @@ createRUpd slotsPerEpoch b es total = record {
 \end{code}
 \begin{code}[hide]
   flowConservation = flowConservation;
-  Δt-positive = lemma-Δt₁;
-  Δf-negative = lemma-Δf;
+  Δt-positive = Δt-nonneg;
+  Δf-negative = Δf-nonpos;
 \end{code}
 \begin{code}
     Δt = Δt₁; Δr = 0 - Δr₁ + Δr₂; Δf = 0 - pos feeSS; rs = rs }
@@ -204,7 +204,7 @@ createRUpd slotsPerEpoch b es total = record {
 
     rho = fromUnitInterval (prevPp .PParams.monetaryExpansion)
     η = fromℕ blocksMade ÷₀ (fromℕ slotsPerEpoch * ActiveSlotCoeff)
-    Δr₁ = floor (ℚ.min 1 η * rho * fromℕ reserves)
+    Δr₁ = floor (1 ⊓ η * rho * fromℕ reserves)
 
     rewardPot = pos feeSS + Δr₁
     tau = fromUnitInterval (prevPp .PParams.treasuryCut)
@@ -222,43 +222,43 @@ createRUpd slotsPerEpoch b es total = record {
     -- the ring solver.
     lemmaFlow : ∀ (t₁ r₁ f z : ℤ)
       → (t₁ ℤ.+ (0 ℤ.- r₁ ℤ.+ ((f ℤ.+ r₁ ℤ.- t₁) ℤ.- z)) ℤ.+ (0 ℤ.- f) ℤ.+ z) ≡ 0
-    lemmaFlow = ℤ.solve-∀
+    lemmaFlow = solve-∀
     flowConservation = lemmaFlow Δt₁ Δr₁ (pos feeSS) (pos (∑[ c ← rs ] c))
 
-    lemma-÷₀ : ∀ (x y : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ (x ÷₀ y)
-    lemma-÷₀ x y 0≤x 0≤y with y ℚ.≟ 0
-    ... | (yes y≡0) = ℚ.nonNegative⁻¹ 0
-    ... | (no y≢0)  = ℚ.lemma-÷ x y {{ℚ.≢-nonZero y≢0}} 0≤x 0≤y
+    ÷₀-0≤⇒0≤ : ∀ (x y : ℚ) → 0 ≤ x → 0 ≤ y → 0 ≤ (x ÷₀ y)
+    ÷₀-0≤⇒0≤ x y 0≤x 0≤y with y ≟ 0
+    ... | (yes y≡0) = nonNegative⁻¹ 0
+    ... | (no y≢0)  = ÷-0≤⇒0≤ x y {{≢-nonZero y≢0}} 0≤x 0≤y
 
-    lemma-η : 0 ≤ η
-    lemma-η = lemma-÷₀ _ _ (fromℕ-0≤ blocksMade)
-      (*-0≤-2⇒0≤ _ _
+    η-nonneg : 0 ≤ η
+    η-nonneg = ÷₀-0≤⇒0≤ _ _ (fromℕ-0≤ blocksMade)
+      (*-0≤⇒0≤ _ _
         (fromℕ-0≤ slotsPerEpoch)
-        (ℚ.nonNegative⁻¹ ActiveSlotCoeff {{ℚ.pos⇒nonNeg ActiveSlotCoeff}}))
+        (nonNegative⁻¹ ActiveSlotCoeff {{pos⇒nonNeg ActiveSlotCoeff}}))
 
-    lemma-min1η : 0 ≤ ℚ.min 1 η
-    lemma-min1η = ℚ.⊓-glb (ℚ.nonNegative⁻¹ 1) lemma-η
+    min1η-nonneg : 0 ≤ 1 ⊓ η
+    min1η-nonneg = ⊓-glb (nonNegative⁻¹ 1) η-nonneg
 
-    lemma-Δr₁ : 0 ≤ Δr₁
-    lemma-Δr₁ = ℚ.0≤⇒0≤floor _
-      (ℚ.*-0≤-2⇒0≤ (ℚ.min 1 η * rho) (fromℕ reserves)
-        (UnitInterval-*-0≤ (ℚ.min 1 η) (prevPp .PParams.monetaryExpansion) lemma-min1η)
+    Δr₁-nonneg : 0 ≤ Δr₁
+    Δr₁-nonneg = 0≤⇒0≤floor _
+      (*-0≤⇒0≤ (1 ⊓ η * rho) (fromℕ reserves)
+        (UnitInterval-*-0≤ (1 ⊓ η) (prevPp .PParams.monetaryExpansion) min1η-nonneg)
         (fromℕ-0≤ reserves))
 
-    lemma-rewardPot : 0 ≤ rewardPot
-    lemma-rewardPot = ℤ.+-mono-≤ (ℤ.nonNegative⁻¹ (pos feeSS)) lemma-Δr₁
+    rewardPot-nonneg : 0 ≤ rewardPot
+    rewardPot-nonneg = +-mono-≤ (nonNegative⁻¹ℤ (pos feeSS)) Δr₁-nonneg
 
-    lemma-Δt₁ : 0 ≤ Δt₁
-    lemma-Δt₁ = ℚ.0≤⇒0≤floor _
+    Δt-nonneg : 0 ≤ Δt₁
+    Δt-nonneg = 0≤⇒0≤floor _
       (UnitInterval-*-0≤ (fromℤ rewardPot) (prevPp .PParams.treasuryCut)
-        (fromℤ-0≤ rewardPot lemma-rewardPot))
+        (fromℤ-0≤ rewardPot rewardPot-nonneg))
 
-    lemma-Δf : (0 - pos feeSS) ≤ 0
-    lemma-Δf = begin
-        0 - pos feeSS ≡⟨ ℤ.+-identityˡ _ ⟩
-        ℤ.- pos feeSS ≤⟨ ℤ.neg-mono-≤ (ℤ.+≤+ z≤n) ⟩
+    Δf-nonpos : (0 - pos feeSS) ≤ 0
+    Δf-nonpos = begin
+        0 - pos feeSS ≡⟨ +-identityˡ _ ⟩
+        ℤ.- pos feeSS ≤⟨ neg-mono-≤ (ℤ.+≤+ z≤n) ⟩
         0             ∎
-      where open ℤ.≤-Reasoning
+      where open ≤-Reasoning
 \end{code}
 \end{AgdaMultiCode}
 \caption{RewardUpdate Creation}

--- a/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
@@ -2,6 +2,8 @@ open import Ledger.Conway.Foreign.ExternalFunctions
 
 module Ledger.Conway.Foreign.HSLedger.ExternalStructures (externalFunctions : ExternalFunctions) where
 
+import      Data.Rational as ℚ using (pos) -- import an instance
+
 open import Ledger.Conway.Crypto
 open import Ledger.Conway.Types.Epoch
 open import Ledger.Conway.Foreign.HSLedger.Core

--- a/src/Ledger/Conway/PParams.lagda
+++ b/src/Ledger/Conway/PParams.lagda
@@ -56,6 +56,10 @@ record Hastreasury {a} (A : Type a) : Type a where
   field treasuryOf : A → Coin
 open Hastreasury ⦃...⦄ public
 
+record Hasreserves {a} (A : Type a) : Type a where
+  field reservesOf : A → Coin
+open Hasreserves ⦃...⦄ public
+
 ProtVer : Type
 ProtVer = ℕ × ℕ
 

--- a/src/Ledger/Conway/Rewards.lagda
+++ b/src/Ledger/Conway/Rewards.lagda
@@ -5,15 +5,11 @@
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
 
-import      Data.Nat as ℕ renaming (_⊔_ to max)
 open import Data.Integer using () renaming (+_ to pos)
-import      Data.Integer as ℤ renaming (_⊔_ to max)
-import      Data.Integer.Properties as ℤ
-open import Data.Rational using (ℚ; floor; _*_; _÷_; _/_; _-_)
-import      Data.Rational as ℚ renaming (_⊓_ to min; _⊔_ to max)
+open import Data.Rational using (ℚ; floor; _*_; _÷_; _/_; _-_; >-nonZero; _⊓_)
+                          renaming (_⊔_ to _⊔ℚ_; NonZero to NonZeroℚ)
 open import Data.Rational.Literals using (number; fromℤ)
-import      Data.Rational.Properties as ℚ
-
+open import Data.Rational.Properties using (pos⇒nonZero; positive⁻¹; +-mono-<-≤; normalize-pos; p≤p⊔q)
 open import Ledger.Conway.Abstract
 open import Ledger.Conway.Transaction
 open import Ledger.Conway.Types.Numeric.UnitInterval
@@ -28,7 +24,7 @@ module Ledger.Conway.Rewards
 
 open import Ledger.Conway.Certs govStructure
 open import Ledger.Conway.Ledger txs abs
-open import Ledger.Prelude hiding (_/_; _*_; _-_)
+open import Ledger.Prelude hiding (_/_; _*_; _-_; >-nonZero; _⊓_)
 open import Ledger.Conway.Utxo txs abs
 
 \end{code}
@@ -158,51 +154,47 @@ Relevant quantities are:
 \begin{figure*}[ht]
 \begin{AgdaMultiCode}
 \begin{code}[hide]
-nonZero-max-1 : ∀ (n : ℕ) → ℕ.NonZero (ℕ.max 1 n)
-nonZero-max-1 zero = ℕ.nonZero
-nonZero-max-1 (suc n) = ℕ.nonZero
+nonZero-max-1 : ∀ (n : ℕ) → NonZero (1 ⊔ n)
+nonZero-max-1 zero = nonZero
+nonZero-max-1 (suc n) = nonZero
 
-nonZero-1/n : ∀ (n : ℕ) → .{{_ : ℕ.NonZero n}} → ℚ.NonZero (1 / n)
+nonZero-1/n : ∀ (n : ℕ) → .{{_ : NonZero n}} → NonZeroℚ (1 / n)
 nonZero-1/n n {{prf}} =
-  ℚ.pos⇒nonZero (1 / n) {{ℚ.normalize-pos 1 n {{prf}} {{_}} }}
+  pos⇒nonZero (1 / n) {{normalize-pos 1 n {{prf}} {{_}} }}
 
-nonZero-1+max0-x : ∀ (x : ℚ) → ℚ.NonZero (1 + ℚ.max 0 x)
+nonZero-1+max0-x : ∀ (x : ℚ) → NonZeroℚ (1 + (0 ⊔ℚ x))
 nonZero-1+max0-x x =
-  ℚ.>-nonZero (ℚ.+-mono-<-≤ (ℚ.positive⁻¹ 1 {{_}}) (ℚ.p≤p⊔q 0 x))
-
-private instance
-  nonNegative : ∀ {i} → ℤ.NonNegative (ℤ.max 0 i)
-  nonNegative {i} = ℤ.nonNegative (ℤ.i≤i⊔j 0 i)
+  >-nonZero (+-mono-<-≤ (positive⁻¹ 1 {{_}}) (p≤p⊔q 0 x))
 \end{code}
 \begin{code}
 maxPool : PParams → Coin → UnitInterval → UnitInterval → Coin
 maxPool pparams rewardPot stake pledge = rewardℕ
   where
-    a0      = ℚ.max 0 (pparams .PParams.a0)
-    1+a0    = 1 + a0
-    nopt    = ℕ.max 1 (pparams .PParams.nopt)
+    a0    = 0 ⊔ℚ pparams .PParams.a0
+    1+a0  = 1 + a0
+    nopt  = 1 ⊔ pparams .PParams.nopt
 \end{code}
 \begin{code}[hide]
     instance
-      nonZero-nopt : ℕ.NonZero nopt
+      nonZero-nopt : NonZero nopt
       nonZero-nopt = nonZero-max-1 (pparams .PParams.nopt)
 \end{code}
 \begin{code}
     z0       = 1 / nopt
-    stake'   = ℚ.min (fromUnitInterval stake) z0
-    pledge'  = ℚ.min (fromUnitInterval pledge) z0
+    stake'   = fromUnitInterval stake ⊓ z0
+    pledge'  = fromUnitInterval pledge ⊓ z0
 \end{code}
 \begin{code}[hide]
     instance
-      nonZeroz0 : ℚ.NonZero z0
+      nonZeroz0 : NonZeroℚ z0
       nonZeroz0 = nonZero-1/n nopt
 
-      nonZero-1+a0 : ℚ.NonZero (1+a0)
+      nonZero-1+a0 : NonZeroℚ (1+a0)
       nonZero-1+a0 = nonZero-1+max0-x (pparams .PParams.a0)
 \end{code}
 \begin{code}
     rewardℚ =
-        ((fromℕ rewardPot) ÷ 1+a0)
+        fromℕ rewardPot ÷ 1+a0
         * (stake' + pledge' * a0 * (stake' - pledge' * (z0 - stake') ÷ z0) ÷ z0)
     rewardℕ = posPart (floor rewardℚ)
 \end{code}
@@ -231,11 +223,11 @@ mkApparentPerformance stake poolBlocks totalBlocks = ratioBlocks ÷₀ stake'
 \end{code}
 \begin{code}[hide]
     instance
-      nonZero-totalBlocks : ℕ.NonZero (ℕ.max 1 totalBlocks)
+      nonZero-totalBlocks : NonZero (1 ⊔ totalBlocks)
       nonZero-totalBlocks = nonZero-max-1 totalBlocks
 \end{code}
 \begin{code}
-    ratioBlocks = (ℤ.+ poolBlocks) / (ℕ.max 1 totalBlocks)
+    ratioBlocks = (pos poolBlocks) / (1 ⊔ totalBlocks)
 \end{code}
 \end{AgdaMultiCode}
 \caption{Function mkApparentPerformance used for computing a Reward Update}
@@ -274,9 +266,9 @@ rewardOwners rewards pool ownerStake stake = if rewards ≤ cost
   else cost + posPart (floor (
         (fromℕ rewards - fromℕ cost) * (margin + (1 - margin) * ratioStake)))
   where
-    ratioStake   = fromUnitInterval ownerStake ÷₀ fromUnitInterval stake
-    cost         = pool .PoolParams.cost
-    margin       = fromUnitInterval (pool .PoolParams.margin)
+    ratioStake  = fromUnitInterval ownerStake ÷₀ fromUnitInterval stake
+    cost        = pool .PoolParams.cost
+    margin      = fromUnitInterval (pool .PoolParams.margin)
 \end{code}
 \end{AgdaMultiCode}
 \begin{AgdaMultiCode}
@@ -287,9 +279,9 @@ rewardMember rewards pool memberStake stake = if rewards ≤ cost
   else posPart (floor (
          (fromℕ rewards - fromℕ cost) * ((1 - margin) * ratioStake)))
   where
-    ratioStake    = fromUnitInterval memberStake ÷₀ fromUnitInterval stake
-    cost          = pool .PoolParams.cost
-    margin        = fromUnitInterval (pool .PoolParams.margin)
+    ratioStake  = fromUnitInterval memberStake ÷₀ fromUnitInterval stake
+    cost        = pool .PoolParams.cost
+    margin      = fromUnitInterval (pool .PoolParams.margin)
 \end{code}
 \end{AgdaMultiCode}
 \caption{Functions rewardOwners and rewardMember}
@@ -473,12 +465,11 @@ and we state the directions of \AgdaField{Δt} and \AgdaField{Δf}.
 \begin{code}
 record RewardUpdate : Set where
   field
-    Δt Δr Δf : ℤ
-    rs : Credential ⇀ Coin
-
-    flowConservation : Δt + Δr + Δf + pos (∑[ c ← rs ] c) ≡ 0
-    Δt-positive : 0 ≤ Δt
-    Δf-negative : Δf ≤ 0
+    Δt Δr Δf          : ℤ
+    rs                : Credential ⇀ Coin
+    flowConservation  : Δt + Δr + Δf + pos (∑[ c ← rs ] c) ≡ 0
+    Δt-nonnegative    : 0 ≤ Δt
+    Δf-nonpositive    : Δf ≤ 0
 
 \end{code}
 \end{AgdaMultiCode}

--- a/src/Ledger/Conway/Rewards.lagda
+++ b/src/Ledger/Conway/Rewards.lagda
@@ -6,6 +6,7 @@
 {-# OPTIONS --safe #-}
 
 import      Data.Nat as ℕ renaming (_⊔_ to max)
+open import Data.Integer using () renaming (+_ to pos)
 import      Data.Integer as ℤ renaming (_⊔_ to max)
 import      Data.Integer.Properties as ℤ
 open import Data.Rational using (ℚ; floor; _*_; _÷_; _/_; _-_)
@@ -461,19 +462,20 @@ The update consists of four net flows:
   \item \AgdaField{rs}: The map of new individual rewards,
     to be added to the existing rewards.
 \end{itemize}
+We require these net flows to satisfy certain constraints that
+are also stored in the \AgdaRecord{RewardUpdate} data type.
+Specifically, \AgdaField{flowConservation} states that
+all four net flows add up to zero.
 
 \begin{figure*}[ht]
 \begin{AgdaMultiCode}
 \begin{code}
 record RewardUpdate : Set where
-\end{code}
-\begin{code}[hide]
-  constructor ⟦_,_,_,_⟧ʳᵘ
-\end{code}
-\begin{code}
   field
     Δt Δr Δf : ℤ
     rs : Credential ⇀ Coin
+
+    flowConservation : Δt + Δr + Δf + pos (∑[ c ← rs ] c) ≡ 0
 \end{code}
 \end{AgdaMultiCode}
 \caption{RewardUpdate type}

--- a/src/Ledger/Conway/Rewards.lagda
+++ b/src/Ledger/Conway/Rewards.lagda
@@ -168,7 +168,7 @@ nonZero-1/n n {{prf}} =
 
 nonZero-1+max0-x : ∀ (x : ℚ) → ℚ.NonZero (1 + ℚ.max 0 x)
 nonZero-1+max0-x x =
-  ℚ.>-nonZero (ℚ.+-mono-<-≤ (ℚ.positive⁻¹ 1) (ℚ.p≤p⊔q 0 x))
+  ℚ.>-nonZero (ℚ.+-mono-<-≤ (ℚ.positive⁻¹ 1 {{_}}) (ℚ.p≤p⊔q 0 x))
 
 private instance
   nonNegative : ∀ {i} → ℤ.NonNegative (ℤ.max 0 i)
@@ -465,7 +465,8 @@ The update consists of four net flows:
 We require these net flows to satisfy certain constraints that
 are also stored in the \AgdaRecord{RewardUpdate} data type.
 Specifically, \AgdaField{flowConservation} states that
-all four net flows add up to zero.
+all four net flows add up to zero,
+and we state the directions of \AgdaField{Δt} and \AgdaField{Δf}.
 
 \begin{figure*}[ht]
 \begin{AgdaMultiCode}
@@ -476,6 +477,9 @@ record RewardUpdate : Set where
     rs : Credential ⇀ Coin
 
     flowConservation : Δt + Δr + Δf + pos (∑[ c ← rs ] c) ≡ 0
+    Δt-positive : 0 ≤ Δt
+    Δf-negative : Δf ≤ 0
+
 \end{code}
 \end{AgdaMultiCode}
 \caption{RewardUpdate type}

--- a/src/Ledger/Conway/Types/Epoch.agda
+++ b/src/Ledger/Conway/Types/Epoch.agda
@@ -10,6 +10,7 @@ open import Relation.Binary
 open import Data.Nat.Properties using (+-*-semiring)
 open import Data.Rational using (ℚ)
 import      Data.Rational as ℚ
+import      Data.Rational.Properties as ℚ
 
 additionVia : ∀{A : Set} → (A → A) → ℕ → A → A
 additionVia sucFun zero r = r
@@ -74,10 +75,14 @@ record EpochStructure : Type₁ where
 record GlobalConstants : Type₁ where
   field  Network : Type; ⦃ DecEq-Netw ⦄ : DecEq Network; ⦃ Show-Network ⦄ : Show Network
          SlotsPerEpochᶜ   : ℕ; ⦃ NonZero-SlotsPerEpochᶜ ⦄ : NonZero SlotsPerEpochᶜ
-         ActiveSlotCoeff  : ℚ; ⦃ NonZero-ActiveSlotCoeff ⦄ : ℚ.NonZero ActiveSlotCoeff
+         ActiveSlotCoeff  : ℚ; ⦃ Positive-ActiveSlotCoeff ⦄ : ℚ.Positive ActiveSlotCoeff
          StabilityWindowᶜ : ℕ
          Quorum : ℕ
          NetworkId : Network
+
+  instance
+    NonZero-ActiveSlotCoeff : ℚ.NonZero ActiveSlotCoeff
+    NonZero-ActiveSlotCoeff = ℚ.>-nonZero (ℚ.positive⁻¹ ActiveSlotCoeff)
 
   ℕ+ᵉ≡+ᵉ' : ∀ {a b} → additionVia suc a b ≡ a + b
   ℕ+ᵉ≡+ᵉ' {zero} {b} = refl

--- a/src/Ledger/Conway/Types/Numeric/UnitInterval.agda
+++ b/src/Ledger/Conway/Types/Numeric/UnitInterval.agda
@@ -9,10 +9,9 @@ open import Prelude
 open import Agda.Builtin.FromNat
 open import Class.Show using (Show; show)
 open import Data.Irrelevant using ([_])
-import      Data.Rational as ℚ
+open import Data.Rational using (ℚ; _≤_; _≤?_; _*_; nonNegative)
 open import Data.Rational.Properties
-import      Data.Rational.Show as ℚshow
-open import Data.Rational using (ℚ; _≤_; _≤?_; _*_)
+open import Data.Rational.Show using () renaming (show to ℚshow)
 open import Data.Refinement using (Refinement-syntax; value; _,_)
 
 open ≤-Reasoning
@@ -29,7 +28,7 @@ isInUnitInterval x = (0 ≤? x) ×-dec (x ≤? 1)
 inUnitInterval-*-≤y : ∀ (x y : ℚ) → inUnitInterval x → 0 ≤ y → x * y ≤ y
 inUnitInterval-*-≤y x y (0≤x , x≤1) 0≤y =
   begin
-    x * y  ≤⟨ *-monoʳ-≤-nonNeg y ⦃ ℚ.nonNegative 0≤y ⦄ x≤1 ⟩
+    x * y  ≤⟨ *-monoʳ-≤-nonNeg y ⦃ nonNegative 0≤y ⦄ x≤1 ⟩
     1 * y  ≡⟨ *-identityˡ _ ⟩
     y      ∎
 
@@ -38,14 +37,14 @@ inUnitInterval-*-0≤ : ∀ (x y : ℚ) → inUnitInterval y → 0 ≤ x → 0 �
 inUnitInterval-*-0≤ x y (0≤y , _) 0≤x =
   begin
     0      ≡⟨ sym (*-zeroʳ x) ⟩
-    x * 0  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ ℚ.nonNegative 0≤x ⦄ 0≤y ⟩
+    x * 0  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ nonNegative 0≤x ⦄ 0≤y ⟩
     x * y  ∎
 
 -- Left multiplication by unit interval element preserves being upper boundeded by 1.
 inUnitInterval-*-≤1 : ∀ (x y : ℚ) → inUnitInterval x → y ≤ 1 → x * y ≤ 1
 inUnitInterval-*-≤1 x y (0≤x , x≤1) y≤1 =
   begin
-    x * y  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ ℚ.nonNegative 0≤x ⦄ y≤1 ⟩
+    x * y  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ nonNegative 0≤x ⦄ y≤1 ⟩
     x * 1  ≡⟨ *-identityʳ _ ⟩
     x      ≤⟨ x≤1 ⟩
     1      ∎
@@ -56,7 +55,7 @@ UnitInterval = [ x ∈ ℚ ∣ inUnitInterval x ]
 
 instance
   Show-UnitInterval : Show UnitInterval
-  Show-UnitInterval .show = ℚshow.show ∘ value
+  Show-UnitInterval .show = ℚshow ∘ value
 
 -- In the cardano-ledger codebase:
 --  unboundRational

--- a/src/Ledger/Conway/Types/Numeric/UnitInterval.agda
+++ b/src/Ledger/Conway/Types/Numeric/UnitInterval.agda
@@ -9,13 +9,12 @@ open import Prelude
 open import Agda.Builtin.FromNat
 open import Class.Show using (Show; show)
 open import Data.Irrelevant using ([_])
-import Data.Rational as ℚ
+import      Data.Rational as ℚ
 open import Data.Rational.Properties
-import Data.Rational.Show as ℚshow
+import      Data.Rational.Show as ℚshow
 open import Data.Rational using (ℚ; _≤_; _≤?_; _*_)
 open import Data.Refinement using (Refinement-syntax; value; _,_)
 
-open import Tactic.EquationalReasoning using (module ≡-Reasoning)
 open ≤-Reasoning
 
 -- inUnitInterval predicate
@@ -35,8 +34,8 @@ inUnitInterval-*-≤y x y (0≤x , x≤1) 0≤y =
     y      ∎
 
 -- Left multiplication by unit interval element preserves non-negativity.
-inUnitInterval-*-0≤ : ∀ (x y : ℚ) → inUnitInterval x → 0 ≤ y → 0 ≤ x * y
-inUnitInterval-*-0≤ x y (0≤x , x≤1) 0≤y =
+inUnitInterval-*-0≤ : ∀ (x y : ℚ) → inUnitInterval y → 0 ≤ x → 0 ≤ x * y
+inUnitInterval-*-0≤ x y (0≤y , _) 0≤x =
   begin
     0      ≡⟨ sym (*-zeroʳ x) ⟩
     x * 0  ≤⟨ *-monoˡ-≤-nonNeg x ⦃ ℚ.nonNegative 0≤x ⦄ 0≤y ⟩
@@ -50,13 +49,6 @@ inUnitInterval-*-≤1 x y (0≤x , x≤1) y≤1 =
     x * 1  ≡⟨ *-identityʳ _ ⟩
     x      ≤⟨ x≤1 ⟩
     1      ∎
-
--- The product of two numbers from the unit interval is also in the unit interval.
-inUnitInterval-* : ∀ (x y : ℚ)
-  → inUnitInterval x → inUnitInterval y → inUnitInterval (x * y)
-inUnitInterval-* x y ux (0≤y , y≤1) =
-  inUnitInterval-*-0≤ x y ux 0≤y
-  , inUnitInterval-*-≤1 x y ux y≤1
 
 -- UnitInterval: rational number in the unit interval [0, 1].
 UnitInterval : Type
@@ -98,10 +90,22 @@ clamp x with 0 ≤? x
 
 -- UnitInterval Properties
 
+-- The predicate for 'UnitInterval' also holds in a proof-relevant context.
+fromUnitInterval-inUnitInterval
+  : ∀ (x : UnitInterval) → inUnitInterval (fromUnitInterval x)
+fromUnitInterval-inUnitInterval (x , [ p0 ]) with isInUnitInterval x
+... | no ¬p = ⊥-elim-irr (¬p p0)
+... | yes p = p
+
+-- Left multiplication by unit interval element preserves non-negativity.
+UnitInterval-*-0≤
+  : ∀ (x : ℚ) (y : UnitInterval) → 0 ≤ x → 0 ≤ x * fromUnitInterval y
+UnitInterval-*-0≤ x y 0≤x =
+  inUnitInterval-*-0≤ x (value y) (fromUnitInterval-inUnitInterval y) 0≤x
+
 -- to/from is the identity
 prop-toUnitInterval-fromUnitInterval : ∀ (x : UnitInterval)
   → toUnitInterval (fromUnitInterval x) ≡ just x
-
 prop-toUnitInterval-fromUnitInterval (x , [ p0 ]) with isInUnitInterval x
 ... | no ¬p = ⊥-elim-irr (¬p p0)
 ... | yes p = refl


### PR DESCRIPTION
# Description

This pull requests adds invariants to the type `RewardUpdate` and adds the proofs for these invariants to `createRUpd`.

### Comments

* I managed to confine the use of proof-irrelevance to the module `Ledger.Conway.Types.Numeric.UnitInterval` by using decidability via the function `fromUnitInterval-inUnitInterval`. In this way, we can avoid any discussion of this topic in the human-readable definition of `RewardUpdate`.
* The module `Data.Rational.Properties` uses special type classes such as `NonNegative` for the predicate `0 ≤`. I wasn't quite sure how to use these classes effectively — their main purpose seems to hide/automate the proof obligation that `NonZero y` in the division `x ÷ y`, but these classes have enough lemmas associated with them that they can compete with the properties of `≤`. I'm not entirely convinced about the design of the std-lib here, I have tried to formulate properties in terms of `0 ≤` for the sake of readability while using what is available for proofs.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
