### PR TITLE
Break `TransactionStructure` into smaller pieces

### DIFF
--- a/src/Ledger/Conway/Conformance/Script.agda
+++ b/src/Ledger/Conway/Conformance/Script.agda
@@ -18,11 +18,11 @@ open import Ledger.Conway.Types.Epoch
 import Ledger.Conway.Script
 
 module Ledger.Conway.Conformance.Script
-  (crypto : _) (open Crypto crypto)
-  (es     : _) (open EpochStructure es)
+  (cs : _) (open CryptoStructure cs)
+  (es : _) (open EpochStructure es)
   where
 
-open Ledger.Conway.Script crypto es
+open Ledger.Conway.Script cs es
 
 record HSTimelock : Type where
   field

--- a/src/Ledger/Conway/Crypto.lagda
+++ b/src/Ledger/Conway/Crypto.lagda
@@ -61,7 +61,7 @@ record PKKScheme : Type₁ where
     ⦃ DecEq-Sig  ⦄ : DecEq Sig
     ⦃ DecEq-Ser  ⦄ : DecEq Ser
 
-record Crypto : Type₁ where
+record CryptoStructure : Type₁ where
   field pkk : PKKScheme
 
   open PKKScheme pkk public

--- a/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/ExternalStructures.agda
@@ -12,8 +12,8 @@ HSGlobalConstants = GlobalConstants ∋ record {Implementation}
 instance
   HSEpochStructure = EpochStructure  ∋ ℕEpochStructure HSGlobalConstants
 
-  HSCrypto : Crypto
-  HSCrypto = record
+  HSCryptoStructure : CryptoStructure
+  HSCryptoStructure = record
     { Implementation
     ; pkk = HSPKKScheme
     }
@@ -96,7 +96,7 @@ instance
     { Implementation
     ; epochStructure  = HSEpochStructure
     ; globalConstants = HSGlobalConstants
-    ; crypto          = HSCrypto
+    ; cryptoStructure = HSCryptoStructure
     ; govParams       = HsGovParams
     ; txidBytes       = id
     ; scriptStructure = HSScriptStructure

--- a/src/Ledger/Conway/PParams.lagda
+++ b/src/Ledger/Conway/PParams.lagda
@@ -26,9 +26,9 @@ open import Ledger.Conway.Types.Epoch
 open import Ledger.Conway.Types.Numeric using (UnitInterval)
 
 module Ledger.Conway.PParams
-  (crypto : Crypto )
-  (es     : _) (open EpochStructure es)
-  (ss     : ScriptStructure crypto es) (open ScriptStructure ss)
+  (cs : CryptoStructure )
+  (es : _) (open EpochStructure es)
+  (ss : ScriptStructure cs es) (open ScriptStructure ss)
   where
 
 private variable

--- a/src/Ledger/Conway/Script.lagda
+++ b/src/Ledger/Conway/Script.lagda
@@ -23,8 +23,8 @@ open import Ledger.Conway.Crypto
 open import Ledger.Conway.Types.Epoch
 
 module Ledger.Conway.Script
-  (crypto : _) (open Crypto crypto)
-  (es     : _) (open EpochStructure es)
+  (cs : _) (open CryptoStructure cs)
+  (es : _) (open EpochStructure es)
   where
 
 record P1ScriptStructure : Type₁ where

--- a/src/Ledger/Conway/Transaction.lagda
+++ b/src/Ledger/Conway/Transaction.lagda
@@ -79,18 +79,18 @@ record TransactionStructure : Type₁ where
   field globalConstants : _
   open GlobalConstants globalConstants public
 
-  field crypto : _
-  open Crypto crypto public
+  field cryptoStructure : _
+  open CryptoStructure cryptoStructure public
   open Ledger.Conway.TokenAlgebra ScriptHash public
   open Ledger.Conway.Address Network KeyHash ScriptHash ⦃ it ⦄ ⦃ it ⦄ ⦃ it ⦄ public
 
   field epochStructure : _
   open EpochStructure epochStructure public
-  open Ledger.Conway.Script crypto epochStructure public
+  open Ledger.Conway.Script cryptoStructure epochStructure public
 
   field scriptStructure : _
   open ScriptStructure scriptStructure public
-  open Ledger.Conway.PParams crypto epochStructure scriptStructure public
+  open Ledger.Conway.PParams cryptoStructure epochStructure scriptStructure public
 
   field govParams : _
   open GovParams govParams public
@@ -104,7 +104,7 @@ record TransactionStructure : Type₁ where
   govStructure = record
     -- TODO: figure out what to do with the hash
     { TxId = TxId; DocHash = ADHash
-    ; crypto = crypto
+    ; cryptoStructure = cryptoStructure
     ; epochStructure = epochStructure
     ; scriptStructure = scriptStructure
     ; govParams = govParams

--- a/src/Ledger/Conway/Types/GovStructure.agda
+++ b/src/Ledger/Conway/Types/GovStructure.agda
@@ -13,16 +13,16 @@ record GovStructure : Type₁ where
   field TxId DocHash : Type
         ⦃ DecEq-TxId ⦄ : DecEq TxId
 
-  field crypto : _
-  open Crypto crypto public
+  field cryptoStructure : _
+  open CryptoStructure cryptoStructure public
 
   field epochStructure : _
   open EpochStructure epochStructure public
 
-  field scriptStructure : ScriptStructure crypto epochStructure
+  field scriptStructure : ScriptStructure cryptoStructure epochStructure
   open ScriptStructure scriptStructure public
 
-  open Ledger.Conway.PParams crypto epochStructure scriptStructure public
+  open Ledger.Conway.PParams cryptoStructure epochStructure scriptStructure public
 
   field govParams : GovParams
   open GovParams govParams public

--- a/src/ScriptVerification/LedgerImplementation.agda
+++ b/src/ScriptVerification/LedgerImplementation.agda
@@ -83,8 +83,8 @@ SVGlobalConstants = GlobalConstants ∋ record {Implementation}
 SVEpochStructure  = EpochStructure  ∋ ℕEpochStructure SVGlobalConstants
 instance _ = SVEpochStructure
 
-SVCrypto : Crypto
-SVCrypto = record
+SVCryptoStructure : CryptoStructure
+SVCryptoStructure = record
   { Implementation
   ; pkk = SVPKKScheme
   }
@@ -98,7 +98,7 @@ SVCrypto = record
     ; isSigned-correct = λ where (sk , sk , refl) _ _ h → tt
     }
 
-instance _ = SVCrypto
+instance _ = SVCryptoStructure
 
 open import Ledger.Conway.Script it it
 open import Ledger.Conway.Conformance.Script it it
@@ -144,7 +144,7 @@ SVGovStructure = record
   { Implementation
   ; epochStructure  = SVEpochStructure
   ; govParams       = SVGovParams
-  ; crypto          = SVCrypto
+  ; cryptoStructure = SVCryptoStructure
   ; globalConstants = SVGlobalConstants
   }
 instance _ = SVGovStructure
@@ -158,7 +158,7 @@ SVTransactionStructure = record
   ; epochStructure  = SVEpochStructure
   ; globalConstants = SVGlobalConstants
   ; adHashingScheme = it
-  ; crypto          = SVCrypto
+  ; cryptoStructure = SVCryptoStructure
   ; govParams       = SVGovParams
   ; txidBytes       = id
   ; scriptStructure = SVScriptStructure


### PR DESCRIPTION
# Description

The goal is to refactor the record `TransactionStructure` into smaller units. This will help  "flatten" the dependency graph and improve reusability.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
