### PR TITLE
Modify 'refScripts' to return a set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### WIP
 
+- Change the return type of `refScripts` to a set
 - Add `poolParameters` field to `Snapshot` and compute it in `SNAP`.
 - Add `treasuryCut` (formerly `tau`) and `monetaryExpansion` (formerly `rho`) to `PParams`
 - Change the `DELEG-dereg` transition so that the deposit field can be empty

--- a/src/Ledger/Conway/Conformance/Utxow.agda
+++ b/src/Ledger/Conway/Conformance/Utxow.agda
@@ -38,7 +38,7 @@ data _⊢_⇀⦇_,UTXOW⦈_ where
         witsKeyHashes     = mapˢ hash (dom vkSigs)
         witsScriptHashes  = mapˢ hash scripts
         inputHashes       = L.getInputHashes tx utxo
-        refScriptHashes   = fromList $ map hash (refScripts tx utxo)
+        refScriptHashes   = mapˢ hash (refScripts tx utxo)
         neededHashes      = L.scriptsNeeded utxo txb
         txdatsHashes      = dom txdats
         allOutHashes      = L.getDataHashes (range txouts)

--- a/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
+++ b/src/Ledger/Conway/Foreign/HSLedger/Utxo.agda
@@ -81,7 +81,7 @@ module _ (ext : ExternalFunctions) where
         open UTxOEnv (from env)
         open TxWitnesses (coerce ⦃ TrustMe ⦄ wits)
         neededHashes = scriptsNeeded utxo body
-        refScriptHashes = fromList $ map
+        refScriptHashes = mapˢ
           hash 
           (refScripts (coerce ⦃ TrustMe ⦄ (from tx)) (coerce ⦃ TrustMe ⦄ utxo))
         witsScriptHashes  = mapˢ hash scripts

--- a/src/Ledger/Conway/Transaction.lagda
+++ b/src/Ledger/Conway/Transaction.lagda
@@ -254,13 +254,13 @@ record TransactionStructure : Type₁ where
   txinsScript : ℙ TxIn → UTxO → ℙ TxIn
   txinsScript txins utxo = txins ∩ dom (proj₁ (scriptOuts utxo))
 
-  refScripts : Tx → UTxO → List Script
+  refScripts : Tx → UTxO → ℙ Script
   refScripts tx utxo =
-    mapMaybe (proj₂ ∘ proj₂ ∘ proj₂) $ setToList (range (utxo ∣ (txins ∪ refInputs)))
+    mapPartial (proj₂ ∘ proj₂ ∘ proj₂) (range (utxo ∣ (txins ∪ refInputs)))
     where open Tx; open TxBody (tx .body)
 
   txscripts : Tx → UTxO → ℙ Script
-  txscripts tx utxo = scripts (tx .wits) ∪ fromList (refScripts tx utxo)
+  txscripts tx utxo = scripts (tx .wits) ∪ refScripts tx utxo
     where open Tx; open TxWitnesses
 
   lookupScriptHash : ScriptHash → Tx → UTxO → Maybe Script

--- a/src/Ledger/Conway/Utxo.lagda
+++ b/src/Ledger/Conway/Utxo.lagda
@@ -241,7 +241,7 @@ module _ (let open Tx; open TxBody; open TxWitnesses) where opaque
 \begin{code}
 
   refScriptsSize : UTxO → Tx → ℕ
-  refScriptsSize utxo tx = sum (map scriptSize (refScripts tx utxo))
+  refScriptsSize utxo tx = sum (map scriptSize (setToList (refScripts tx utxo)))
 
   minfee : PParams → UTxO → Tx → Coin
   minfee pp utxo tx  = pp .a * tx .body .txsize + pp .b

--- a/src/Ledger/Conway/Utxow.lagda
+++ b/src/Ledger/Conway/Utxow.lagda
@@ -166,7 +166,7 @@ data _⊢_⇀⦇_,UTXOW⦈_ where
          witsKeyHashes                       = mapˢ hash (dom vkSigs)
          witsScriptHashes                    = mapˢ hash scripts
          inputHashes                         = getInputHashes tx utxo
-         refScriptHashes                     = fromList (map hash (refScripts tx utxo))
+         refScriptHashes                     = mapˢ hash (refScripts tx utxo)
          neededHashes                        = scriptsNeeded utxo txb
          txdatsHashes                        = dom txdats
          allOutHashes                        = getDataHashes (range txouts)


### PR DESCRIPTION
# Description

In all but one call sites of this function, the returned value is converted back to a set (using `fromList`). This is highly inefficient.  

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
