### PR TITLE
add aggregate hydra jobs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,13 +39,14 @@
                   formal-ledger
                   hs-src
                   mkdocs
+                  devShells
                   ;
               };
             in
             jobs // {
               required = nixpkgs.releaseTools.aggregate {
                 name = "${system}-required";
-                constituents = builtins.attrValues jobs;
+                constituents = with nixpkgs.lib; collect isDerivation jobs;
               };
             };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -30,15 +30,24 @@
         };
 
         # Keep hydraJobs for CI
-        hydraJobs = {
-          inherit (pkgs)
-            agdaWithPackages
-            fls-shake
-            formal-ledger
-            hs-src
-            mkdocs
-            ;
-        };
+        hydraJobs =
+          let
+            jobs = {
+              inherit (pkgs)
+                agdaWithPackages
+                fls-shake
+                formal-ledger
+                hs-src
+                mkdocs
+                ;
+            };
+          in
+          jobs // {
+            required = nixpkgs.releaseTools.aggregate {
+              name = "${system}-required";
+              constituents = builtins.attrValues jobs;
+            };
+          };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,43 +11,57 @@
       # reuse the dependencies pinned by niv
       sources = import ./build-tools/nix/sources.nix;
       systems = [ "x86_64-linux" ];
-    in
-    flake-utils.lib.eachSystem systems (
-      system:
-      let
-        nixpkgs = import sources.nixpkgs { inherit system; };
-        pkgs = import ./default.nix { inherit nixpkgs; };
-      in
-      {
-        packages = pkgs // {
-          # Set default package
-          default = pkgs.formal-ledger;
-        };
-        # Expose development shells
-        devShells = pkgs.devShells // {
-          # default shell points to the main development environment
-          default = pkgs.devShells.default;
-        };
 
-        # Keep hydraJobs for CI
-        hydraJobs =
-          let
-            jobs = {
-              inherit (pkgs)
-                agdaWithPackages
-                fls-shake
-                formal-ledger
-                hs-src
-                mkdocs
-                ;
-            };
-          in
-          jobs // {
-            required = nixpkgs.releaseTools.aggregate {
-              name = "${system}-required";
-              constituents = builtins.attrValues jobs;
-            };
+      perSystem = flake-utils.lib.eachSystem systems (
+        system:
+        let
+          nixpkgs = import sources.nixpkgs { inherit system; };
+          pkgs = import ./default.nix { inherit nixpkgs; };
+        in
+        {
+          packages = pkgs // {
+            # Set default package
+            default = pkgs.formal-ledger;
           };
-      }
-    );
+          # Expose development shells
+          devShells = pkgs.devShells // {
+            # default shell points to the main development environment
+            default = pkgs.devShells.default;
+          };
+
+          # Keep hydraJobs for CI
+          hydraJobs =
+            let
+              jobs = {
+                inherit (pkgs)
+                  agdaWithPackages
+                  fls-shake
+                  formal-ledger
+                  hs-src
+                  mkdocs
+                  ;
+              };
+            in
+            jobs // {
+              required = nixpkgs.releaseTools.aggregate {
+                name = "${system}-required";
+                constituents = builtins.attrValues jobs;
+              };
+            };
+        }
+      );
+    in
+    perSystem
+    // {
+      hydraJobs = perSystem.hydraJobs // {
+        required =
+          let
+            nixpkgs = import sources.nixpkgs { system = builtins.head systems; };
+          in
+          nixpkgs.releaseTools.aggregate {
+            name = "required";
+            constituents = map (system: perSystem.hydraJobs.${system}.required) systems;
+          };
+      };
+    };
 }


### PR DESCRIPTION
# Description

Adds a `required` Hydra job for each system that is an aggregate of all the others.
Also adds a top-level `required` job that is an aggregate of all systems' `required` jobs.

This enables us to configure only the top-level `required` job as a needed check in GitHub as `ci/hydra-build:required`, so that we have status check for everything.

Unrelated but also adds Hydra jobs for the development shells so that they are pushed to the cache.

This adds the following new flake outputs:
- `hydraJobs.required`
- `hydraJobs.{x86_64-linux,…}.required`
- `hydraJobs.{x86_64-linux,…}.devShells.…`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- ~~Any semantic changes to the specifications are documented in `CHANGELOG.md`~~
- ~~Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)~~
- [x] Self-reviewed the diff
