### PR TITLE
Fix build on Mac

### DIFF
--- a/build-tools/agda/nix/fls-agda.nix
+++ b/build-tools/agda/nix/fls-agda.nix
@@ -2,15 +2,8 @@
   sources ? import ../../nix/sources.nix,
   nixpkgs ? import sources.nixpkgs { },
 }:
-let
-  fls-agda-override = oldAttrs: {
-    outputs = [ "bin" ] ++ (oldAttrs.outputs or [ ]);
-    postInstall =
-      (oldAttrs.postInstall or "")
-      + ''
-        mkdir -p $bin/bin
-        mv $out/bin/fls-agda $bin/bin/agda
-      '';
-  };
-in
-(nixpkgs.haskellPackages.callCabal2nix "fls-agda" ../. { }).overrideAttrs fls-agda-override
+(nixpkgs.haskellPackages.callCabal2nix "fls-agda" ../. { }).overrideAttrs (oldAttrs: {
+  postInstall = (oldAttrs.postInstall or "") + ''
+    ln -sf $out/bin/fls-agda $out/bin/agda
+  '';
+})

--- a/default.nix
+++ b/default.nix
@@ -14,9 +14,17 @@ let
     LOCALE_ARCHIVE = lib.optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
   };
 
-  our-agda = (
-    agdaPackages.override { Agda = import ./build-tools/agda/nix/fls-agda.nix { inherit nixpkgs; }; }
-  );
+  fls-agda = import ./build-tools/agda/nix/fls-agda.nix { inherit nixpkgs; };
+  our-agda =
+    agdaPackages.override {
+      Agda = fls-agda.overrideAttrs (oldAttrs: {
+        meta = (oldAttrs.meta or {}) // {
+          outputsToInstall = [ "out" ];
+        };
+      }) // {
+        bin = fls-agda;
+      };
+    };
 
   agda-stdlib = our-agda.mkDerivation {
     pname = "standard-library";


### PR DESCRIPTION
# Description

Resolves #827 

As spotted in the issue discussion, this is related to the circular dependency due to the naming differences for outputs on Macos.

This is the attempt of fixing this.
I would need CI to make sure that this is still working on Linux though 🙏🏼 


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
