### PR TITLE
Implement POOLREAP on epoch transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### WIP
 
+- Implement the POOLREAP state transition relation from Shelley
 - Move `txsize` from `TxBody` to `Tx`.
 - Change the return type of `refScripts` to a set
 - Add `poolParameters` field to `Snapshot` and compute it in `SNAP`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ There are two ways to do this.
     **Note**. This currently works in Chrome but may not work in Brave or
     Firefox.  If you want to use one of those browsers to view the generated
     documentation, you can run a local server on the result,
-    `(cd result/site; python3 -m http.server)`, and then point your browser
+    `cd result/site; python3 -m http.server`, and then point your browser
     to <http://127.0.0.1:8000/>.
 
 2.  **Manually**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,21 +221,24 @@ There are two ways to do this.
 1.  **With Nix**
 
     Enter the command `nix build .#mkdocs` (or `nix-build -A mkdocs`) then open the
-    file `result/site/index.html` in a browser.
+    file `result/site/index.html` in a browser. This method always type-checks the
+    Agda code, and generates the HTML documentation from documentation from scratch.
 
     **Note**. This currently works in Chrome but may not work in Brave or
     Firefox.  If you want to use one of those browsers to view the generated
     documentation, you can run a local server on the result,
-    `cd result/site; python3 -m http.server`, and then point your browser
+    `(cd result/site; python3 -m http.server)`, and then point your browser
     to <http://127.0.0.1:8000/>.
 
 2.  **Manually**
 
+    This method only type-checks the Agda code that has changed since last time and
+    then generates the HTML documentation.
+
     ```bash
     nix develop .#docs
     python build-tools/scripts/md/build.py --run-agda
-    cd _build/md/mkdocs
-    mkdocs serve
+    (cd _build/md/mkdocs; mkdocs serve)
     ```
 
     Then point your browser to  <http://127.0.0.1:8000/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,8 +221,8 @@ There are two ways to do this.
 1.  **With Nix**
 
     Enter the command `nix build .#mkdocs` (or `nix-build -A mkdocs`) then open the
-    file `result/site/index.html` in a browser. This method always type-checks the
-    Agda code, and generates the HTML documentation from documentation from scratch.
+    file `result/site/index.html` in a browser. This type-checks the
+    Agda code, and generates the HTML documentation from scratch.
 
     **Note**. This currently works in Chrome but may not work in Brave or
     Firefox.  If you want to use one of those browsers to view the generated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,8 @@ First, build `agdaWithPackages` and create a stable symlink to it in your home d
 nix-build -A agdaWithPackages -o ~/ledger-agda
 ```
 
+Then make sure that the `~/ledger-agda/bin` directory is in your `PATH` when starting your editor.
+
 ---
 
 ### Setting up multiple versions with `update-alternatives` (OPTIONAL)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,8 @@ There are two ways to do this.
     ```bash
     nix develop .#docs
     python build-tools/scripts/md/build.py --run-agda
-    (cd _build/md/mkdocs; mkdocs serve)
+    cd _build/md/mkdocs
+    mkdocs serve
     ```
 
     Then point your browser to  <http://127.0.0.1:8000/>.

--- a/build-tools/static/latex/macros.sty
+++ b/build-tools/static/latex/macros.sty
@@ -272,6 +272,7 @@ Scale=0.80 %% Alternatives: Scale=MatchUppercase, Scale=MatchLowercase
 \newcommand{\Ix}{\AgdaDatatype{Ix}}
 
 \newcommand{\LEDGER}{\AgdaOperator{\AgdaDatatype{LEDGER}}}
+\newcommand{\KeyHash}{\AgdaField{KeyHash}}
 \newcommand{\List}{\AgdaDatatype{List}}
 \newcommand{\LState}{\AgdaRecord{LState}}
 
@@ -309,7 +310,9 @@ Scale=0.80 %% Alternatives: Scale=MatchUppercase, Scale=MatchLowercase
 \newcommand{\Pfour}{\AgdaField{P4}}
 \newcommand{\Pone}{\AgdaField{P1}}
 \newcommand{\PoolDeposit}{\AgdaInductiveConstructor{PoolDeposit}}
+\newcommand{\PoolParams}{\AgdaRecord{PoolParams}}
 \newcommand{\poolThresholds}{\AgdaField{poolThresholds}}
+\newcommand{\posPart}{\AgdaFunction{posPart}}
 \newcommand{\PowerSet}{\AgdaFunction{ℙ}}
 \newcommand{\PParamsDiff}{\AgdaRecord{PParamsDiff}}
 \newcommand{\PParamGroup}{\AgdaDatatype{PParamGroup}}
@@ -340,7 +343,9 @@ Scale=0.80 %% Alternatives: Scale=MatchUppercase, Scale=MatchLowercase
 \newcommand{\RatifyState}{\AgdaRecord{RatifyState}}
 \newcommand{\refScriptCostStride}{\AgdaField{refScriptCostStride}}
 \newcommand{\refScriptCostMultiplier}{\AgdaField{refScriptCostMultiplier}}
+\newcommand{\retiring}{\AgdaField{retiring}}
 \newcommand{\returnAddr}{\AgdaField{returnAddr}}
+\newcommand{\rewardAddr}{\AgdaField{rewardAddr}}
 \newcommand{\RewardUpdate}{\AgdaRecord{RewardUpdate}}
 \newcommand{\roleVotes}{\AgdaFunction{roleVotes}}
 \newcommand{\RTC}{\AgdaFunction{ReflexiveTransitiveClosure}}

--- a/src/Ledger/Conway/Specification/Epoch.lagda
+++ b/src/Ledger/Conway/Specification/Epoch.lagda
@@ -475,6 +475,7 @@ EPOCH-updates fut ls dState' acnt' =
 \begin{code}
 data _⊢_⇀⦇_,EPOCH⦈_ : ⊤ → EpochState → Epoch → EpochState → Type where
 \end{code}
+\caption{EPOCH update functions}
 \end{figure*}
 \end{NoConway}
 

--- a/src/Ledger/Conway/Specification/Epoch.lagda
+++ b/src/Ledger/Conway/Specification/Epoch.lagda
@@ -436,7 +436,6 @@ module EPOCH-updates
   open UTxOState
   open EPOCH-updates0 fut ls public
   open DState
-  open Acnt
 
   refunds : Credential ⇀ Coin
   refunds = pullbackMap payout toRwdAddr (dom (dState' .rewards))

--- a/src/Ledger/Conway/Specification/Epoch.lagda
+++ b/src/Ledger/Conway/Specification/Epoch.lagda
@@ -363,14 +363,6 @@ private variable
 
 \begin{NoConway}
 \begin{figure*}[h]
-\begin{code}
-private variable
-  acnt acnt'  : Acnt
-  utxoSt''    : UTxOState
-  dState'     : DState
-  pState'     : PState
-\end{code}
-
 \begin{code}[hide]
 -- All of these definitions are used in the EPOCH transition. Initially, they
 -- were meant to be a copy, so the EPOCH transition would show them immediately
@@ -490,7 +482,8 @@ its results by carrying out each of the following tasks.
 \begin{figure*}[ht]
 \begin{AgdaMultiCode}
 \begin{code}
-  EPOCH : let
+  EPOCH : ∀ {acnt : Acnt} {utxoSt'' : UTxOState} {acnt' dState' pState'} →
+    let
     module U = EPOCH-updates fut ls acnt' dState' pState'
 
     in

--- a/src/Ledger/Conway/Specification/Epoch/Properties.agda
+++ b/src/Ledger/Conway/Specification/Epoch/Properties.agda
@@ -77,7 +77,7 @@ module _ {eps : EpochState} {e : Epoch} where
         { acnt = U.acnt''
         ; ss = ss
         ; ls = ⟦ utxoSt'' , U.govSt' , U.certState' ⟧ˡ
-        ; es = _
+        ; es = U.es
         ; fut = fut'
         }
       where module U = EPOCH-updates fut ls acnt' dState' pState'

--- a/src/Ledger/Conway/Specification/Epoch/Properties.agda
+++ b/src/Ledger/Conway/Specification/Epoch/Properties.agda
@@ -54,13 +54,9 @@ module _ {e : Epoch} (prs : PoolReapState) where
 module _ {eps : EpochState} {e : Epoch} where
 
   open EpochState eps hiding (es)
-  open RatifyState fut using (removed) renaming (es to esW)
-  open LState ls; open CertState certState; open Acnt acnt
-  es         = record esW { withdrawals = ∅ }
-  govSt'     = filter (λ x → ¿ ¬ proj₁ x ∈ mapˢ proj₁ removed ¿) govSt
 
   prs =
-    ⟦ U0.utxoSt' , acnt , dState , pState ⟧
+    ⟦ U0.utxoSt' , acnt , U0.dState , U0.pState ⟧
     where module U0 = EPOCH-updates0 fut ls
 
   EPOCH-total : ∃[ eps' ] _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
@@ -103,7 +99,7 @@ module _ {eps : EpochState} {e : Epoch} where
                                    }) ss'≡ss'')
                                    refl refl p₁ p₁'
 
-      prs'≡prs'' : ? ≡ ?
+      prs'≡prs'' : {!!} ≡ {!!}
       prs'≡prs'' = POOLREAP-deterministic prs p₃ p₃'
 
   EPOCH-complete : ∀ eps' → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps' → proj₁ EPOCH-total ≡ eps'

--- a/src/Ledger/Conway/Specification/Epoch/Properties.agda
+++ b/src/Ledger/Conway/Specification/Epoch/Properties.agda
@@ -98,7 +98,7 @@ module _ {e : Epoch} where
 
   NEWEPOCH-complete : ∀ nes nes' → _ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes' → proj₁ (NEWEPOCH-total nes) ≡ nes'
   -- NEWEPOCH-complete nes nes' h with e ≟ NewEpochState.lastEpoch nes + 1 | NewEpochState.ru nes | h
-  NEWEPOCH-complete nes nes' h with e ≟ NewEpochState.lastEpoch nes + 1 | NewEpochState.ru nes | inspect NewEpochState.ru nes | h 
+  NEWEPOCH-complete nes nes' h with e ≟ NewEpochState.lastEpoch nes + 1 | NewEpochState.ru nes | inspect NewEpochState.ru nes | h
   ... | yes p | just ru | PE.[ refl ] | NEWEPOCH-New (x , x₁) rewrite EPOCH-complete' _ x₁ = refl
   ... | yes p | ru | PE.[ refl ] | NEWEPOCH-Not-New x = ⊥-elim $ x p
   ... | yes p | nothing | PE.[ refl ] | NEWEPOCH-No-Reward-Update (x , x₁) rewrite EPOCH-complete' _ x₁ = refl

--- a/src/Ledger/Conway/Specification/Epoch/Properties.agda
+++ b/src/Ledger/Conway/Specification/Epoch/Properties.agda
@@ -82,7 +82,23 @@ module _ {eps : EpochState} {e : Epoch} where
                       → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
                       → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps''
                       → eps' ≡ eps''
-  EPOCH-deterministic eps' eps'' (EPOCH p₁ p₂ p₃) (EPOCH p₁' p₂' p₃') =
+  EPOCH-deterministic
+      eps'
+      eps''
+      (EPOCH
+        {utxoSt'' = utxoSt''₁}
+        {acnt' = acnt'₁}
+        {dState' = dState'₁}
+        {pState' = pState'₁}
+        p₁ p₂ p₃
+      )
+      (EPOCH
+        {utxoSt'' = utxoSt''₂}
+        {acnt' = acnt'₂}
+        {dState' = dState'₂}
+        {pState' = pState'₂}
+        p₁' p₂' p₃'
+      ) =
     cong₂ _$_ (cong₂ EPOCH-state ss'≡ss'' fut'≡fut'') prs'≡prs''
     where
       ss'≡ss'' : EpochState.ss eps' ≡ EpochState.ss eps''
@@ -99,7 +115,8 @@ module _ {eps : EpochState} {e : Epoch} where
                                    }) ss'≡ss'')
                                    refl refl p₁ p₁'
 
-      prs'≡prs'' : {!!} ≡ {!!}
+      prs'≡prs'' : ⟦ utxoSt''₁ , acnt'₁ , dState'₁ , pState'₁ ⟧ᵖ ≡
+                   ⟦ utxoSt''₂ , acnt'₂ , dState'₂ , pState'₂ ⟧
       prs'≡prs'' = POOLREAP-deterministic prs p₃ p₃'
 
   EPOCH-complete : ∀ eps' → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps' → proj₁ EPOCH-total ≡ eps'

--- a/src/Ledger/Conway/Specification/Epoch/Properties.agda
+++ b/src/Ledger/Conway/Specification/Epoch/Properties.agda
@@ -55,9 +55,13 @@ module _ {eps : EpochState} {e : Epoch} where
 
   open EpochState eps hiding (es)
 
-  prs =
-    ⟦ U0.utxoSt' , acnt , U0.dState , U0.pState ⟧
-    where module U0 = EPOCH-updates0 fut ls
+  prs = ⟦ u0 .utxoSt' , acnt , cs .dState , cs .pState ⟧
+    where
+      open LState
+      open CertState
+      open EPOCH-Updates0
+      cs = ls .certState
+      u0 = EPOCH-updates0 fut ls
 
   EPOCH-total : ∃[ eps' ] _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
   EPOCH-total =
@@ -69,14 +73,18 @@ module _ {eps : EpochState} {e : Epoch} where
   private
     EPOCH-state : Snapshots → RatifyState → PoolReapState → EpochState
     EPOCH-state ss fut' (⟦ utxoSt'' , acnt' , dState' , pState' ⟧ᵖ) =
-      record
-        { acnt = U.acnt''
-        ; ss = ss
-        ; ls = ⟦ utxoSt'' , U.govSt' , U.certState' ⟧ˡ
-        ; es = U.es
-        ; fut = fut'
-        }
-      where module U = EPOCH-updates fut ls acnt' dState' pState'
+      let
+        EPOCHUpdates es govSt' dState'' gState' _ acnt'' =
+          EPOCH-updates fut ls dState' acnt'
+        certState' = ⟦ dState'' , pState' , gState' ⟧ᶜˢ
+       in
+          record
+            { acnt = acnt''
+            ; ss = ss
+            ; ls = ⟦ utxoSt'' , govSt' , certState' ⟧ˡ
+            ; es = es
+            ; fut = fut'
+            }
 
   EPOCH-deterministic : ∀ eps' eps''
                       → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'

--- a/src/Ledger/Conway/Specification/Epoch/Properties/GovDepsMatch.lagda.md
+++ b/src/Ledger/Conway/Specification/Epoch/Properties/GovDepsMatch.lagda.md
@@ -182,13 +182,16 @@ For the formal statement of the lemma,
       a ∈ˡ map' (GovActionDeposit ∘ proj₁) (filter P? govSt)           ∼⟨ ∈-fromList ⟩
       a ∈ fromList (map' (GovActionDeposit ∘ proj₁) (filter P? govSt)) ∎
 
-    module U = EPOCH-updates0 (eps .fut) (eps .ls)
+    u0 = EPOCH-updates0 (eps .fut) (eps .ls)
 
-    ls₁ = record (eps' .ls) { utxoSt = U.utxoSt' }
+    ls₁ = record (eps' .ls) { utxoSt = EPOCH-Updates0.utxoSt' u0 }
 
     mutual
+      open LState
+      open CertState
+
       retiredDeposits : ℙ DepositPurpose
-      retiredDeposits = mapˢ PoolDeposit (U.pState .retiring ⁻¹ e)
+      retiredDeposits = mapˢ PoolDeposit (eps .ls .certState .pState .retiring ⁻¹ e)
 
       ratifiesSnapMatch : govDepsMatch (eps .ls) → govDepsMatch ls₁
       ratifiesSnapMatch =

--- a/src/Ledger/Conway/Specification/PParams.lagda
+++ b/src/Ledger/Conway/Specification/PParams.lagda
@@ -59,6 +59,13 @@ record Hasreserves {a} (A : Type a) : Type a where
   field reservesOf : A → Coin
 open Hasreserves ⦃...⦄ public
 
+instance
+  Hastreasury-Acnt : Hastreasury Acnt
+  Hastreasury-Acnt .treasuryOf = Acnt.treasury
+
+  Hasreserves-Acnt : Hasreserves Acnt
+  Hasreserves-Acnt .reservesOf = Acnt.reserves
+
 ProtVer : Type
 ProtVer = ℕ × ℕ
 

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -38,6 +38,7 @@ instance
   unquoteDecl HasCast-PoolReapState = derive-HasCast
                 [ (quote PoolReapState , HasCast-PoolReapState) ]
 ```
+-->
 
 Recall, `PState`{.AgdaDatatype} is a record with two fields, `pools`{.AgdaField}
 and `retiring`{.AgdaField} (maps on `KeyHash`{.AgdaField} with codomains

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -50,7 +50,7 @@ data
   _⊢_⇀⦇_,POOLREAP⦈_ : ⊤ → PoolReapState → Epoch → PoolReapState → Type where
   POOLREAP : let
     open PoolReapState poolReapState
-    open PoolParams
+    open StakePoolParams
     open UTxOState
     open PState
     open DState

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -1,0 +1,99 @@
+# Pool Reaping Transition {sec:pool-reaping-transition}
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Conway.Specification.Abstract
+open import Ledger.Conway.Specification.Transaction
+
+module Ledger.Conway.Specification.PoolReap
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs)
+  where
+open import Ledger.Prelude
+open import Ledger.Conway.Specification.Utxo txs abs
+open import Ledger.Conway.Specification.Certs govStructure
+```
+-->
+
+```agda
+record PoolReapState : Type where
+```
+<!--
+```agda
+  constructor ⟦_,_,_,_⟧ᵖ
+```
+```agda
+  field
+    utxoSt     : UTxOState   -- utxo state
+    acnt       : Acnt        -- accounting
+    dState     : DState      -- delegation state
+    pState     : PState      -- pool state
+```
+
+<!--
+```agda
+instance
+  unquoteDecl HasCast-PoolReapState = derive-HasCast
+                [ (quote PoolReapState , HasCast-PoolReapState) ]
+```
+
+Recall, `PState`{.AgdaDatatype} is a record with two fields, `pools`{.AgdaField}
+and `retiring`{.AgdaField} (maps on `KeyHash`{.AgdaField} with codomains
+`PoolParams`{.AgdaRecord} and `Epoch`{.AgdaDatatype}, respectively).
+`PoolParams`{.AgdaRecord} is a record with just one field, the
+`rewardAddr`{.AgdaField} credential.
+
+```agda
+private variable
+  e lastEpoch : Epoch
+  poolReapState : PoolReapState
+
+data _⊢_⇀⦇_,POOLREAP⦈_ : ⊤ → PoolReapState → Epoch → PoolReapState → Type where
+  POOLREAP : let
+    open PoolReapState poolReapState
+    open PoolParams
+    open UTxOState
+    open PState
+    open DState
+    open Acnt
+    open PParams
+
+    retired    = pState .retiring ⁻¹ e
+    rewardAcnts : DepositPurpose ⇀ Credential
+    rewardAcnts =
+      mapKeys PoolDeposit $
+      mapValues rewardAccount $
+      pState .pools ∣ retired
+
+    rewardAcnts' : Credential ⇀ Coin
+    rewardAcnts' = aggregateBy (rewardAcnts ˢ) (utxoSt .deposits)
+
+    refunds : Credential ⇀ Coin
+    refunds = rewardAcnts' ∣ dom (dState .rewards)
+
+    mRefunds = rewardAcnts' ∣ dom (dState .rewards) ᶜ
+
+    unclaimed  = getCoin mRefunds
+
+    retiredDeposits : ℙ DepositPurpose
+    retiredDeposits = mapˢ PoolDeposit retired
+
+    utxoSt' = record utxoSt { deposits = utxoSt .deposits ∣ retiredDeposits ᶜ }
+
+    acnt' = record acnt { treasury = acnt .treasury + unclaimed }
+
+    dState' =
+      ⟦ dState .voteDelegs
+      , dState .stakeDelegs ∣^ retired ᶜ
+      , dState .rewards ∪⁺ refunds
+      ⟧
+
+    pState' = ⟦ pState .pools ∣ retired ᶜ , pState .retiring ∣ retired ᶜ ⟧
+
+    in
+    ────────────────────────────────
+    _ ⊢ ⟦ utxoSt , acnt , dState , pState ⟧ ⇀⦇ e ,POOLREAP⦈
+        ⟦ utxoSt' , acnt' , dState' , pState' ⟧
+```

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -51,7 +51,11 @@ private variable
   e lastEpoch : Epoch
   poolReapState : PoolReapState
 
-data _⊢_⇀⦇_,POOLREAP⦈_ : ⊤ → PoolReapState → Epoch → PoolReapState → Type where
+data 
+```
+-->
+```agda
+  _⊢_⇀⦇_,POOLREAP⦈_ : ⊤ → PoolReapState → Epoch → PoolReapState → Type where
   POOLREAP : let
     open PoolReapState poolReapState
     open PoolParams

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -100,6 +100,6 @@ data
 
     in
     ────────────────────────────────
-    _ ⊢ ⟦ utxoSt , acnt , dState , pState ⟧ ⇀⦇ e ,POOLREAP⦈
-        ⟦ utxoSt' , acnt' , dState' , pState' ⟧
+    _ ⊢ ⟦ utxoSt , acnt , dState , pState ⟧ ⇀⦇ e ,POOLREAP⦈ ⟦ utxoSt' , acnt' , dState' , pState' ⟧
+
 ```

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -38,17 +38,7 @@ record PoolReapState : Type where
 instance
   unquoteDecl HasCast-PoolReapState = derive-HasCast
                 [ (quote PoolReapState , HasCast-PoolReapState) ]
-```
--->
 
-Recall, `PState`{.AgdaDatatype} is a record with two fields, `pools`{.AgdaField}
-and `retiring`{.AgdaField} (maps on `KeyHash`{.AgdaField} with codomains
-`PoolParams`{.AgdaRecord} and `Epoch`{.AgdaDatatype}, respectively).
-`PoolParams`{.AgdaRecord} is a record with just one field, the
-`rewardAddr`{.AgdaField} credential.
-
-<!--
-```agda
 private variable
   e lastEpoch : Epoch
   poolReapState : PoolReapState

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -24,6 +24,7 @@ record PoolReapState : Type where
 ```agda
   constructor ⟦_,_,_,_⟧ᵖ
 ```
+-->
 ```agda
   field
     utxoSt     : UTxOState   -- utxo state

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -46,6 +46,7 @@ and `retiring`{.AgdaField} (maps on `KeyHash`{.AgdaField} with codomains
 `PoolParams`{.AgdaRecord} is a record with just one field, the
 `rewardAddr`{.AgdaField} credential.
 
+<!--
 ```agda
 private variable
   e lastEpoch : Epoch

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -43,7 +43,7 @@ private variable
   e lastEpoch : Epoch
   poolReapState : PoolReapState
 
-data 
+data
 ```
 -->
 ```agda


### PR DESCRIPTION
This is a rebasing of #719. And it is also a follow up to #832 after rebasing master.

Implements POOLREAP as a new independent STS, rather than trying to reuse existing constructs.
