### PR TITLE
Disable upload-artifacts on external branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     with:
       pdf_name: conway-ledger.pdf
 
-  upload-artifacts:
+  push-artifacts-to-branch:
     # This job runs only if the workflow has not been manually dispached,
     # and the origininating branch belongs to the repository
     if: ${{ github.event_name != 'workflow_dispatch' }} && ${{ github.repository == 'IntersectMBO/formal-ledger-specifications' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
   # which CI isn't run automatically
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   formal-ledger-agda:
     runs-on: ubuntu-latest
@@ -94,8 +91,11 @@ jobs:
       pdf_name: conway-ledger.pdf
 
   upload-artifacts:
-    # This job runs only if the workflow has not been manually dispached
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    # This job runs only if the workflow has not been manually dispached,
+    # and the origininating branch belongs to the repository
+    if: ${{ github.event_name != 'workflow_dispatch' }} && ${{ github.repository == 'IntersectMBO/formal-ledger-specifications' }}
+    permissions:
+      contents: write
     needs: [formal-ledger-agda, hs, html, conway-ledger-pdf, cardano-ledger-pdf, mkdocs-site]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

Closes #859,renames `upload-artifacts` to `push-artifacts-to-branch` and minimizes CI permissions.

For security reasons `GITHUB_TOKEN` has read-only permissions for pull requests originating on forks of the repository ([source](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/)). This seems like a reasonable thing since it disallows forks from making arbitrary changes.

This PR resolves #859 by adding a check to run `upload-artifacts` only on branches originating from within the repository. This means that *-artifacts  branches will not be created for these PR's branches and thus the CI status will not depend on this step.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
