### PR TITLE
Fix VV issue with line breaks inbetween unicode brackets

### DIFF
--- a/build-tools/agda/src/Main.hs
+++ b/build-tools/agda/src/Main.hs
@@ -409,8 +409,8 @@ code fileType = mconcat .
     | s == ',' && p /= 0 = "," : goInline d p ts
 
     -- opening and closing parenthesis
-    | s == '(' = "(" : goInline d (p + 1) ts
-    | s == ')' = ")" : goInline d (p - 1) ts
+    | s `elem` [ '(', '❴' ] = makeInlineKaTeX t : goInline d (p + 1) ts
+    | s `elem` [ ')', '❵' ] = makeInlineKaTeX t : goInline d (p - 1) ts
 
     | otherwise = makeInlineKaTeX t : goInline d p ts
   goInline d p [] = []

--- a/build-tools/agda/src/Main.hs
+++ b/build-tools/agda/src/Main.hs
@@ -422,7 +422,7 @@ code fileType = mconcat .
     where
 
     fixChars :: Char -> String
-    fixChars '_' = "\\"
+    fixChars '_' = "\\_"
     fixChars '^' = "\\^{}"
     fixChars c   = [c]
 

--- a/build-tools/agda/src/Main.hs
+++ b/build-tools/agda/src/Main.hs
@@ -421,8 +421,9 @@ code fileType = mconcat .
     | otherwise = toHtml . surroundingSpace . href . htmlId . htmlClasses . text $ concatMap fixChars (List1.toList s) -- remove this map fixChars, is too expensive
     where
 
-    fixChars :: Char -> [Char]
-    fixChars '_' = ['\\', '_']
+    fixChars :: Char -> String
+    fixChars '_' = "\\"
+    fixChars '^' = "\\^{}"
     fixChars c   = [c]
 
     mkTexMacro :: String -> String -> String


### PR DESCRIPTION
# Description

Addresses the bug described in #851.

Closes #861.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
