### PR TITLE
Fix the broken table in the `Gov.Actions` module

### DIFF
--- a/src/Ledger/Conway/Specification/Gov/Actions.lagda
+++ b/src/Ledger/Conway/Specification/Gov/Actions.lagda
@@ -110,24 +110,23 @@ The governance actions carry the following information:
   \item \ChangePParams{}: the updates to the parameters; and
   \item \TreasuryWdrl{}: a map of withdrawals.
 \end{itemize}
-\begin{figure*}[h]
-\begin{longtable}[]{@{}
- >{\raggedright\arraybackslash}p{(\columnwidth - 2\tabcolsep) * \real{0.2}}
- >{\raggedright\arraybackslash}p{(\columnwidth - 2\tabcolsep) * \real{0.75}}@{}}
+
+\subsubsection{Table: Types of governance actions}
+\label{fig:types-of-governance-actions}
+
+\begin{tabular}{ll}
 \textbf{Action}  & \textbf{Description}\\
 \hline
 \endhead{}
-\NoConfidence{}            & a motion to create a \emph{state of no-confidence} in the current constitutional committee \\[10pt]
-\UpdateCommittee{}         & changes to the members of the constitutional committee and/or to its signature threshold and/or terms \\[10pt]
-\NewConstitution{}         & a modification to the off-chain Constitution and the proposal policy script \\[10pt]
-\TriggerHF{}\footnotemark  & triggers a non-backwards compatible upgrade of the network; requires a prior software upgrade  \\[10pt]
-\ChangePParams{}           & a change to \emph{one or more} updatable protocol parameters, excluding changes to major protocol versions (``hard forks'')\\[10pt]
+\NoConfidence{}            & a motion to create a \emph{state of no-confidence} in the current constitutional committee \\
+\UpdateCommittee{}         & changes to the members of the constitutional committee and/or to its signature threshold and/or terms \\
+\NewConstitution{}         & a modification to the off-chain Constitution and the proposal policy script \\
+\TriggerHF{}\footnotemark  & triggers a non-backwards compatible upgrade of the network; requires a prior software upgrade  \\
+\ChangePParams{}           & a change to \emph{one or more} updatable protocol parameters, excluding changes to major protocol versions (``hard forks'')\\
 \TreasuryWdrl{}            & movements from the treasury\\
 \Info{}                    & an action that has no effect on-chain, other than an on-chain record
-\end{longtable}
-\caption{Types of governance actions}
-\label{fig:types-of-governance-actions}
-\end{figure*}
+\end{tabular}
+
 \footnotetext{There are many varying definitions of the term ``hard fork'' in the blockchain industry. Hard forks typically refer
   to non-backwards compatible updates of a network. In Cardano, we attach a bit more meaning to the definition by calling any upgrade that
   would lead to \emph{more blocks} being validated a ``hard fork'' and force nodes to comply with the new protocol version, effectively


### PR DESCRIPTION
# Description

The LaTeX `longtable` (and even the simple `table`) environment causes pandoc to put the markdown version of the table inside a `<div>` `</div>` block and this apparently prevents mkdocs from rendering the table correctly, despite the fact that we are using the markdown extension `md_in_html`.  Until a better solution is found, a workaround is to simply omit the table environment altogether, just use a tabular environment, and move the caption ("Types of Governance Actions") to a subsection title called "Table: Types of Governance Actions".

Also, for some reason, pandoc silently deletes the footnote in the table.

To resolve both the table rendering issue and the lost footnote, I suggest we hand-tweak the `Actions.lagda.md` file and commit it to the repo soon.  For now, however, the workaround in the PR is an easy improvement.


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
