### PR TITLE
Make links to markdown files point to the "Code" view.

### DIFF
--- a/build-tools/scripts/md/build.py
+++ b/build-tools/scripts/md/build.py
@@ -101,9 +101,9 @@ def main(run_agda_html_flag: bool = False, test_mode_flag: bool = False) -> None
     header_result = ensure_headers_for_docs_dir(
         docs_dir=config.build_paths.mkdocs_docs_dir,
         src_root=config.source_paths.src_dir,
-        branch="master",                 # or hoist to config if you prefer
+        branch="master",                 # or hoist to config
         preserve_existing=True,
-        skip_names=set()                 # e.g., {"index.md"} if you want to skip it
+        skip_names=set()                 # e.g., {"index.md"} to skip index.md
     )
     if header_result.is_ok:
         logging.info(f"📝 Ensured source headers in {header_result.unwrap()} pages.")

--- a/build-tools/static/md/mkdocs/mkdocs.yml
+++ b/build-tools/static/md/mkdocs/mkdocs.yml
@@ -8,7 +8,7 @@ site_author: Formal Methods Ledger Team
 repo_url: https://github.com/IntersectMBO/formal-ledger-specifications
 
 # Use edit_uri_template to build file URLs (GitHub "blob" view)
-edit_uri_template: 'blob/main/docs/{path}'
+edit_uri_template: 'blob/main/docs/{path}?plain=1'
 
 # Theme configuration (using mkdocs-material)
 theme:


### PR DESCRIPTION
# Description

We merely add `?plain=1` to urls of .md and .lagda.md files. Url of links to other file types, e.g., `.agda` and `.lagda`, remain unchanged since there's no "Preview" view for those file types.

Closes issue #887.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
