### PR TITLE
Only accept CC if minsize and threshold are both zero

### DIFF
--- a/src/Ledger/Conway/Specification/Ratify.lagda.md
+++ b/src/Ledger/Conway/Specification/Ratify.lagda.md
@@ -321,6 +321,11 @@ module AcceptedByCC (currentEpoch : Epoch)
 ```
 -->
 ```agda
+  sizeActiveCC : ℕ
+  sizeActiveCC = case proj₁ cc of λ where
+    (just ((ccMembers , _) , _)) → lengthˢ (filterˢ (λ (_ , y) → currentEpoch ≤ y) ccMembers)
+    nothing → 0
+
   castVotes : Credential ⇀ Vote
   castVotes = gvCC
 
@@ -358,7 +363,7 @@ module AcceptedByCC (currentEpoch : Epoch)
   totalStake     = ∑[ x ← stakeDistr ∣ dom (actualVotes ∣^ (❴ Vote.yes ❵ ∪ ❴ Vote.no ❵)) ] x
 
   accepted = (acceptedStake /₀ totalStake) ≥ t
-    × (maybe (λ (m , _) → lengthˢ m) 0 (proj₁ cc) ≥ ccMinSize ⊎ (Is-nothing mT × ccMinSize ≡ 0))
+    × (sizeActiveCC ≥ ccMinSize ⊎ (Is-nothing mT × ccMinSize ≡ 0))
 ```
 
 ```agda


### PR DESCRIPTION
# Description

This PR changes how CC votes are counted in the case where there aren't enough CC members and the threshold is zero. According to the discussion in https://github.com/IntersectMBO/cardano-ledger/issues/5170, CC should accept only if *both* the `ccMinSize` and threshold are set to zero. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
