### PR TITLE
Refactor accepted by CC

### DIFF
--- a/src/Ledger/Conway/Specification/Ratify.lagda.md
+++ b/src/Ledger/Conway/Specification/Ratify.lagda.md
@@ -335,7 +335,7 @@ module AcceptedByCC (currentEpoch : Epoch)
 
   actualVotes : Credential ⇀ Vote
   actualVotes =
-    mapWithKey (λ coldCredential hotCredential → maybe id Vote.no (lookupᵐ? castVotes hotCredential))
+    mapValues (λ hotCredential → maybe id Vote.no (lookupᵐ? castVotes hotCredential))
                activeCC
 
   mT : Maybe ℚ
@@ -348,8 +348,10 @@ module AcceptedByCC (currentEpoch : Epoch)
   acceptedStake  = ∑[ x ← stakeDistr ∣ actualVotes ⁻¹ Vote.yes ] x
   totalStake     = ∑[ x ← stakeDistr ∣ dom (actualVotes ∣^ (❴ Vote.yes ❵ ∪ ❴ Vote.no ❵)) ] x
 
-  accepted = if mT then (λ {t} → sizeActiveCC ≥ ccMinSize × (acceptedStake /₀ totalStake) ≥ t)
-                   else ⊤
+  accepted : Type
+  accepted = case mT of λ where
+    (just t) → sizeActiveCC ≥ ccMinSize × (acceptedStake /₀ totalStake) ≥ t
+    nothing  → ⊤
 ```
 
 ```agda


### PR DESCRIPTION
# Description

Currently `acceptedByCC` rejects a NoConfidence proposal if the committee is empty but the `minSize` is not 0. 

I'm not sure if this is the intended behaviour but I suppose no since CC has no bearing on NoConfidence motions. 

This is related to #209 and (likely the cause of) https://github.com/IntersectMBO/cardano-ledger/issues/5418

Pinging @Soupstraw and @WhatisRT 

EDIT:
This PR refactors `acceptedByCC` to simplify the logic.
1. It makes explicit the set of active CC members as a map from cold to hot credentials
2. Adds the precondition that the CC should be able to vote on the governance action

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
