### PR TITLE
[Dijkstra] Computational instance for `UTXOW`

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -114,8 +114,8 @@ allowedLanguagesLegacyMode tx utxo =
 <!--
 ```agda
 -- Consolidate Witnessing Logic into a single Record
-record WitnessData (tx : Tx ℓ) (Γ : UTxOEnv) : Type where
-  constructor mkWitnessData
+record WitnessLogic (tx : Tx ℓ) (Γ : UTxOEnv) : Type where
+  constructor mkWitnessLogic
   open Tx tx; open TxBody txBody; open TxWitnesses txWitnesses
 
   field
@@ -149,33 +149,33 @@ record WitnessData (tx : Tx ℓ) (Γ : UTxOEnv) : Type where
                   _  ← lookupHash sh p2ScriptsNeeded
                   d >>= isInj₂) (range (UTxOOf Γ ∣ txIns))
 
--- The WitnessData record type is inhabited in one of two ways:
+-- The WitnessLogic record type is inhabited in one of two ways:
 -- 1. Normal mode (legacy=false) uses the DataPool and ScriptPool;
 -- 2. Legacy mode (legacy=true) uses the UTxO to determine data and scripts.
-collectWitnessData : (legacy : Bool) (tx : Tx ℓ) (Γ : UTxOEnv) → WitnessData tx Γ
-collectWitnessData legacy tx Γ .WitnessData.dataProvided =
+collectWitnessLogic : (legacy : Bool) (tx : Tx ℓ) (Γ : UTxOEnv) → WitnessLogic tx Γ
+collectWitnessLogic legacy tx Γ .WitnessLogic.dataProvided =
   if legacy  then getTxData tx (UTxOOf Γ)
              else range (DataPoolOf Γ)
-collectWitnessData legacy tx Γ .WitnessData.scriptsProvided =
+collectWitnessLogic legacy tx Γ .WitnessLogic.scriptsProvided =
   if legacy  then witnessScripts tx ∪ spendScripts tx (UTxOOf Γ) ∪ referenceScripts tx (UTxOOf Γ)
              else ScriptPoolOf Γ
 
 -- Mode trigger: legacy mode is selected iff at least one *needed* phase-2 script
 -- (based on legacy=true witness collection) uses PlutusV1–V3.
-LegacyTrigger : UTxOEnv → TopLevelTx → Type
-LegacyTrigger Γ txTop = ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ [])
+Legacy : UTxOEnv → TopLevelTx → Type
+Legacy Γ txTop = ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ [])
   where
-  wd : WitnessData txTop Γ
-  wd = collectWitnessData true txTop Γ
-  open WitnessData wd
+  wd : WitnessLogic txTop Γ
+  wd = collectWitnessLogic true txTop Γ
+  open WitnessLogic wd
 
 -- Define Named Premise Records (replaces long tuples and makes Computational instance much faster).
 record UTXOW-Normal-Premises (Γ : UTxOEnv) (s : UTxOState) (txTop : TopLevelTx) : Type where
   constructor mkNormalPremises
 
   -- centralized witness collector with legacy=false
-  wd = collectWitnessData false txTop Γ
-  open WitnessData wd
+  wd = collectWitnessLogic false txTop Γ
+  open WitnessLogic wd
 
   field
     -- (2) No bootstrap addresses if using scripts
@@ -198,8 +198,8 @@ record UTXOW-Legacy-Premises (Γ : UTxOEnv) (s : UTxOState) (txTop : TopLevelTx)
   constructor mkLegacyPremises
 
   -- centralized witness collector with legacy=true
-  wd = collectWitnessData true txTop Γ
-  open WitnessData wd
+  wd = collectWitnessLogic true txTop Γ
+  open WitnessLogic wd
 
   field
     -- (3) Legacy mode cannot handle bootstrap addresses
@@ -217,8 +217,8 @@ record UTXOW-Legacy-Premises (Γ : UTxOEnv) (s : UTxOState) (txTop : TopLevelTx)
     legacyLanguages     : languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguagesLegacyMode txTop (UTxOOf Γ)
     auxDataHashValid    : TxBody.txADhash (Tx.txBody txTop) ≡ map hash (Tx.txAuxData txTop)
 
-record WitnessDataSubTx (tx : Tx ℓ) (utxo₀ : UTxO) (Γ : SubUTxOEnv) : Type where
-  constructor mkWitnessDataSubTx
+record WitnessLogicSubTx (tx : Tx ℓ) (utxo₀ : UTxO) (Γ : SubUTxOEnv) : Type where
+  constructor mkWitnessLogicSubTx
   open Tx tx; open TxBody txBody; open TxWitnesses txWitnesses
 
   field
@@ -250,20 +250,20 @@ record WitnessDataSubTx (tx : Tx ℓ) (utxo₀ : UTxO) (Γ : SubUTxOEnv) : Type 
                        d >>= isInj₂)
                (range (utxo₀ ∣ txIns))
 
-collectWitnessDataSubTx : (tx : Tx ℓ) (Γ : SubUTxOEnv) → WitnessDataSubTx tx (UTxOOf Γ) Γ
-collectWitnessDataSubTx tx Γ = record
+collectWitnessLogicSubTx : (tx : Tx ℓ) (Γ : SubUTxOEnv) → WitnessLogicSubTx tx (UTxOOf Γ) Γ
+collectWitnessLogicSubTx tx Γ = record
   { vKeyHashesProvided = mapˢ hash (dom (TxWitnesses.vKeySigs (Tx.txWitnesses tx)))
   ; scriptsProvided    = ScriptPoolOf Γ
   ; dataProvided       = range (DataPoolOf Γ)
   ; credentialsNeeded  = mapˢ proj₂ (credsNeeded (UTxOOf Γ) tx) }
-  where open WitnessData; open Tx tx; open TxBody txBody; open TxWitnesses txWitnesses; open SubUTxOEnv Γ
+  where open WitnessLogic; open Tx tx; open TxBody txBody; open TxWitnesses txWitnesses; open SubUTxOEnv Γ
 
 -- Define Named Premise Records (replaces long tuples and makes Computational instance much faster).
 record SUBUTXOW-Premises (Γ : SubUTxOEnv) (s : UTxOState) (tx : SubLevelTx) : Type where
   constructor mkSUBUTXOWPremises
   -- Re-use our centralized witness collector
-  wd = collectWitnessDataSubTx tx Γ
-  open WitnessDataSubTx wd
+  wd = collectWitnessLogicSubTx tx Γ
+  open WitnessLogicSubTx wd
 
   field
     sigsValid          : ∀[ (vk , σ) ∈ TxWitnesses.vKeySigs (Tx.txWitnesses tx) ] isSigned vk (txidBytes (TxIdOf tx)) σ
@@ -275,8 +275,7 @@ record SUBUTXOW-Premises (Γ : SubUTxOEnv) (s : UTxOState) (tx : SubLevelTx) : T
     auxDataHashValid   : TxBody.txADhash (Tx.txBody tx) ≡ map hash (Tx.txAuxData tx)
 
 -- These deciders use the ¿ _ ¿ syntax from the Ledger prelude to decide each field.
--- Since the WitnessData is computed once at the start, these are very efficient.
-
+-- Since the WitnessLogic is computed once at the start, these are very efficient.
 ```
 -->
 
@@ -323,9 +322,9 @@ mode up front rather than deciding both.
    guards at the top-level.
 
 ```agda
-  -- Normal branch is taken exactly when LegacyTrigger does *not* hold.
+  -- Normal branch is taken exactly when Legacy does *not* hold.
   UTXOW-normal :
-    ∙ (¬ LegacyTrigger Γ txTop)
+    ∙ ¬ Legacy Γ txTop
     ∙ UTXOW-Normal-Premises Γ s txTop
     ∙ (Γ , false) ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
       ────────────────────────────────
@@ -349,9 +348,9 @@ mode up front rather than deciding both.
    are also the empty set.
 
 ```agda
-  -- Legacy branch is taken exactly when LegacyTrigger holds.
+  -- Legacy branch is taken exactly when Legacy holds.
   UTXOW-legacy :
-    ∙ LegacyTrigger Γ txTop
+    ∙ Legacy Γ txTop
     ∙ UTXOW-Legacy-Premises Γ s txTop
     ∙ (Γ , true) ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
       ────────────────────────────────

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -25,8 +25,8 @@ open import Ledger.Dijkstra.Specification.Utxo.Properties.Computational txs abs
 
 decide-SUBUTXOW-Premises : ∀ Γ s tx → Dec (SUBUTXOW-Premises Γ s tx)
 decide-SUBUTXOW-Premises Γ s tx =
-  let wd = collectWitnessDataSubTx tx Γ in
-  let open WitnessDataSubTx wd in
+  let wd = collectWitnessLogicSubTx tx Γ in
+  let open WitnessLogicSubTx wd in
   case ¿ ∀[ (vk , σ) ∈ TxWitnesses.vKeySigs (Tx.txWitnesses tx) ] isSigned vk (txidBytes (TxIdOf tx)) σ ¿ of λ where
     (no ¬p) → no (λ where (record { sigsValid = p }) → ¬p p)
     (yes sigsOk) →
@@ -55,18 +55,18 @@ decide-SUBUTXOW-Premises Γ s tx =
                                            ; auxDataHashValid = adOk })
 
 
-decide-LegacyTrigger : (Γ : UTxOEnv) (txTop : TopLevelTx) → Dec (LegacyTrigger Γ txTop)
-decide-LegacyTrigger Γ txTop = ¿ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿
+decide-Legacy : (Γ : UTxOEnv) (txTop : TopLevelTx) → Dec (Legacy Γ txTop)
+decide-Legacy Γ txTop = ¿ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿
   where
-  wd : WitnessData txTop Γ
-  wd = collectWitnessData true txTop Γ
-  open WitnessData wd
+  wd : WitnessLogic txTop Γ
+  wd = collectWitnessLogic true txTop Γ
+  open WitnessLogic wd
 
 
 decide-Normal-Premises : ∀ Γ s tx → Dec (UTXOW-Normal-Premises Γ s tx)
 decide-Normal-Premises Γ s tx =
-  let wd = collectWitnessData false tx Γ in
-  let open WitnessData wd in
+  let wd = collectWitnessLogic false tx Γ in
+  let open WitnessLogic wd in
     case ¿ (UsesBootstrapAddress (UTxOOf Γ) tx → Is-∅ p2ScriptsNeeded) ¿ of λ where
       (no ¬p) → no (λ where (record { bootstrap = p }) → ¬p p)
       (yes bootOk) → case ¿ RequiredGuardsInTopLevel tx ¿ of λ where
@@ -95,8 +95,8 @@ decide-Normal-Premises Γ s tx =
 
 decide-Legacy-Premises : ∀ Γ s tx → Dec (UTXOW-Legacy-Premises Γ s tx)
 decide-Legacy-Premises Γ s tx =
-  let wd = collectWitnessData true tx Γ in
-  let open WitnessData wd in
+  let wd = collectWitnessLogic true tx Γ in
+  let open WitnessLogic wd in
     case ¿ ¬ (UsesBootstrapAddress (UTxOOf Γ) tx) ¿ of λ where
         (no ¬p) → no (λ where (record { noBootstrap = p }) → ¬p p)
         (yes noBootOk) → case ¿ Is-∅ (GuardsOf tx) ¿ of λ where
@@ -159,7 +159,7 @@ instance
     computeProof : (Γ : UTxOEnv) (s : UTxOState) (tx : TopLevelTx)
       → ComputationResult String (∃[ s' ] (Γ ⊢ s ⇀⦇ tx ,UTXOW⦈ s'))
 
-    computeProof Γ s tx with decide-LegacyTrigger Γ tx
+    computeProof Γ s tx with decide-Legacy Γ tx
     ... | no notrig = case (decide-Normal-Premises Γ s tx) of λ where
       (no  _) → failure "UTXOW failed: normal premises"
       (yes pN) → map (λ where (s' , hU) → s' , UTXOW-normal (notrig , pN , hU)) (computeP (Γ , false) s tx)
@@ -171,7 +171,7 @@ instance
       → Γ ⊢ s ⇀⦇ tx ,UTXOW⦈ s' → map proj₁ (computeProof Γ s tx) ≡ success s'
 
     completeness Γ s tx s' (UTXOW-legacy (trig , pL , hU))
-      with decide-LegacyTrigger Γ tx
+      with decide-Legacy Γ tx
     ... | no notrig = ⊥-elim (notrig trig)
     ... | yes _ with decide-Legacy-Premises Γ s tx
     ... | no ¬pL = ⊥-elim (¬pL pL)
@@ -180,7 +180,7 @@ instance
     ... | failure _ | ()
 
     completeness Γ s tx s' (UTXOW-normal (notrig , pN , hU))
-      with decide-LegacyTrigger Γ tx
+      with decide-Legacy Γ tx
     ... | yes trig = ⊥-elim (notrig trig)
     ... | no _ with decide-Normal-Premises Γ s tx
     ... | no ¬pN = ⊥-elim (¬pN pN)


### PR DESCRIPTION
# Description

This PR closes Issue #1088 by defining/proving a computational instance for the Dijkstra era `UTXOW` transition rule.

## Key Changes

+  **Record-Based Premises**. Refactored the transition rules to use named record types for premises (`UTXOW-Normal-Premises`, `UTXOW-Legacy-Premises`, `SUBUTXOW-Premises`). This significantly improves type-checking performance and scannability compared to the previous nested-tuple approach.
+  **WitnessData Consolidation**. Centralized the logic for collecting vKey hashes, scripts, and data hashes into a `WitnessData` record to avoid redundant lookups and simplify the decider logic.
+  ~**Era Toggle Logic**. Introduced a boolean flag to the `UTXOW` rule; this provides a simpler decidable mechanism to distinguish between Dijkstra-native (Normal/V4) and compatibility (Legacy/V1-V3) modes.~ Replaced with `LegacyMode` premise to avoid issues upstream (in `LEDGER`).
+  **Completeness Proof** is complete.

## To Do

Expand the `failure` strings into more descriptive error messages using a structured error type.  I propose we postpone this until after we have computational instances for all ledger rules.


---

## Copilot-generated Description

This pull request refactors the UTXOW and SUBUTXOW transition systems in `src/Ledger/Dijkstra/Specification/Utxow.lagda.md` to improve computational efficiency and clarity. The main changes consolidate witness logic into named records, replace long tuples with structured premise records, and update the transition system rules to use these records. This refactoring makes the code easier to maintain and reason about, and also speeds up computational checks by centralizing witness data collection.

Witness logic consolidation and computational efficiency:

* Introduced `WitnessData`, `WitnessDataSubTx`, and their associated collection functions to centralize and efficiently compute witness data for transactions, replacing scattered logic and repeated computations. [[1]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L114-L143) [[2]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L168-R294)
* Defined named premise records (`UTXOW-Normal-Premises`, `UTXOW-Legacy-Premises`, `SUBUTXOW-Premises`) to replace long tuples in transition system rules, improving readability and computational performance. [[1]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L114-L143) [[2]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L168-R294)

Transition system rule updates:

* Updated the `UTXOW` and `SUBUTXOW` transition system rules to reference the new premise records, simplifying the rule definitions and making the operating mode explicit via a Boolean in the environment. [[1]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L184-R313) [[2]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L203-R330) [[3]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L280-R354)

Documentation and formatting:

* Added and updated comments, including Agda code block delimiters and explanatory notes, to clarify the changes and provide context for the refactoring. [[1]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L114-L143) [[2]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L168-R294) [[3]](diffhunk://#diff-105183d3312dbed06278a40a1a26ac9588f50708549e6dd58ffbe2a8ef8747afR6)

(References: [[1]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L114-L143) [[2]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L168-R294) [[3]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L184-R313) [[4]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L203-R330) [[5]](diffhunk://#diff-63c787058d21e7cb1a2b83f682399360da91b31b657afa5085140f72eb20a3e6L280-R354) [[6]](diffhunk://#diff-105183d3312dbed06278a40a1a26ac9588f50708549e6dd58ffbe2a8ef8747afR6)

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
