### PR TITLE
Disallow hardfork proposals from increasing the major protocol version by 2 or more

### DIFF
--- a/src/Ledger/Conway/Specification/Gov.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov.lagda.md
@@ -256,7 +256,7 @@ opaque
   validHFAction (record { action = ⟦ TriggerHardFork , v ⟧ᵍᵃ ; prevAction = prev }) s e =
     (aid' ≡ prev × pvCanFollow ver v) ⊎ ∃₂[ x , v' ]  (prev , x) ∈ fromList s
                                                       × x .action ≡ ⟦ TriggerHardFork , v' ⟧ᵍᵃ
-                                                      × pvCanFollow v' v
+                                                      × pvCanFollowMinor v' v
     where
       ver : ProtVer
       ver = EnactState.pv e .proj₁

--- a/src/Ledger/Conway/Specification/Gov/Properties/Computational.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties/Computational.lagda.md
@@ -53,11 +53,11 @@ private
   isUpdateCommittee ⟦ TreasuryWithdrawal , _                ⟧ᵍᵃ = no λ()
   isUpdateCommittee ⟦ Info               , _                ⟧ᵍᵃ = no λ()
 
-  hasPrev : ∀ x v → Dec (∃[ v' ] x .action ≡ ⟦ TriggerHardFork , v' ⟧ᵍᵃ × pvCanFollow v' v)
+  hasPrev : ∀ x v → Dec (∃[ v' ] x .action ≡ ⟦ TriggerHardFork , v' ⟧ᵍᵃ × pvCanFollowMinor v' v)
   hasPrev record { action = ⟦ NoConfidence        , _   ⟧ᵍᵃ} v = no λ ()
   hasPrev record { action = ⟦ UpdateCommittee     , _   ⟧ᵍᵃ} v = no λ ()
   hasPrev record { action = ⟦ NewConstitution     , _   ⟧ᵍᵃ} v = no λ ()
-  hasPrev record { action = ⟦ TriggerHardFork     , v'  ⟧ᵍᵃ} v = case pvCanFollow? {v'} {v} of λ where
+  hasPrev record { action = ⟦ TriggerHardFork     , v'  ⟧ᵍᵃ} v = case ¿ pvCanFollowMinor v' v ¿ of λ where
     (yes p) → yes (-, refl , p)
     (no ¬p) → no  (λ where (_ , refl , h) → ¬p h)
   hasPrev record { action = ⟦ ChangePParams       , _   ⟧ᵍᵃ} v = no λ ()
@@ -74,8 +74,8 @@ opaque
     validHFAction? {record { action = ⟦ NewConstitution     , _ ⟧ᵍᵃ}} = Dec-⊤
     validHFAction? {record { action = ⟦ TriggerHardFork     , v ⟧ᵍᵃ ; prevAction = prev }} {s} {record { pv = (v' , aid') }}
       with aid' ≟ prev ×-dec pvCanFollow? {v'} {v} | any? (λ (aid , x) → aid ≟ prev ×-dec hasPrev x v) s
-    ... | yes p | _ = ⁇ yes (inj₁ p)
-    ... | no _ | yes p with ((aid , x) , x∈xs , (refl , v , h)) ← P.find p = ⁇ yes (inj₂
+    ... | yes p' | _ = ⁇ yes (inj₁ p')
+    ... | no _ | yes p' with ((aid , x) , x∈xs , (refl , v , h)) ← P.find p' = ⁇ yes (inj₂
       (x , v , to ∈-fromList x∈xs , h))
     ... | no ¬p₁ | no ¬p₂ = ⁇ no λ
       { (inj₁ x) → ¬p₁ x

--- a/src/Ledger/Conway/Specification/PParams.lagda.md
+++ b/src/Ledger/Conway/Specification/PParams.lagda.md
@@ -106,6 +106,12 @@ instance
 ```agda
 ProtVer : Type
 ProtVer = ℕ × ℕ
+
+pvMajor : ProtVer → ℕ
+pvMajor = proj₁
+
+pvMinor : ProtVer → ℕ
+pvMinor = proj₂
 ```
 
 <!--
@@ -117,9 +123,14 @@ instance
 -->
 
 ```agda
-data pvCanFollow : ProtVer → ProtVer → Type where
-  canFollowMajor : pvCanFollow (m , n) (m + 1 , 0)
-  canFollowMinor : pvCanFollow (m , n) (m , n + 1)
+data pvCanFollowMajor : ProtVer → ProtVer → Type where
+  canFollowMajor : pvCanFollowMajor (m , n) (m + 1 , 0)
+
+data pvCanFollowMinor : ProtVer → ProtVer → Type where
+  canFollowMinor : pvCanFollowMinor (m , n) (m , n + 1)
+
+pvCanFollow : ProtVer → ProtVer → Type
+pvCanFollow v₁ v₂ = pvCanFollowMajor v₁ v₂ ⊎ pvCanFollowMinor v₁ v₂
 ```
 
 <!--
@@ -515,13 +526,24 @@ module PParamsUpdate where
       ((quote PParamsUpdate , DecEq-PParamsUpdate) ∷ [])
 
 instance
-  pvCanFollow? : ∀ {pv} {pv'} → Dec (pvCanFollow pv pv')
-  pvCanFollow? {m , n} {pv} with pv ≟ (m + 1 , 0) | pv ≟ (m , n + 1)
-  ... | no ¬p    | no ¬p₁   = no $ λ where canFollowMajor → ¬p  refl
-                                           canFollowMinor → ¬p₁ refl
-  ... | no ¬p    | yes refl = yes canFollowMinor
-  ... | yes refl | no ¬p    = yes canFollowMajor
-  ... | yes refl | yes p    = ⊥-elim $ m+1+n≢m m $ ×-≡,≡←≡ p .proj₁
+  Dec-pvCanFollowMajor : ∀ {pv} {pv'} → Dec (pvCanFollowMajor pv pv')
+  Dec-pvCanFollowMajor {m , n} {pv} with pv ≟ (m + 1 , 0)
+  ... | yes refl = yes canFollowMajor
+  ... | no ¬p = no (λ { canFollowMajor → ¬p refl })
+
+  Dec-pvCanFollowMinor : ∀ {pv} {pv'} → Dec (pvCanFollowMinor pv pv')
+  Dec-pvCanFollowMinor {m , n} {pv} with pv ≟ (m , n + 1)
+  ... | yes refl = yes canFollowMinor
+  ... | no ¬p = no (λ { canFollowMinor → ¬p refl })
+
+  pvCanFollowMajor? : pvCanFollowMajor ⁇²
+  pvCanFollowMajor? = ⁇ Dec-pvCanFollowMajor
+
+  pvCanFollowMinor? : pvCanFollowMinor ⁇²
+  pvCanFollowMinor? = ⁇ Dec-pvCanFollowMinor
+
+pvCanFollow? : ∀ {pv} {pv'} → Dec (pvCanFollow pv pv')
+pvCanFollow? = Dec-pvCanFollowMajor ⊎-dec Dec-pvCanFollowMinor
 ```
 -->
 

--- a/src/Ledger/PreConway/Conformance/PPUp.lagda.md
+++ b/src/Ledger/PreConway/Conformance/PPUp.lagda.md
@@ -51,15 +51,6 @@ private variable
   e : Epoch
   pup pupˢ fpupˢ : ProposedPPUpdates
 
-instance
-  Dec-pvCanFollow : pvCanFollow ⁇²
-  Dec-pvCanFollow {(m , n)} {pv} .dec with pv ≟ (m + 1 , 0) | pv ≟ (m , n + 1)
-  ... | no ¬p    | no ¬p₁   = no $ λ where canFollowMajor → ¬p  refl
-                                           canFollowMinor → ¬p₁ refl
-  ... | no ¬p    | yes refl = yes canFollowMinor
-  ... | yes refl | no ¬p    = yes canFollowMajor
-  ... | yes refl | yes p    = ⊥-elim $ ℕ.m+1+n≢m m $ ×.×-≡,≡←≡ p .proj₁
-
 data _⊢_⇀⦇_,PPUP⦈_ : PPUpdateEnv → PPUpdateState → Maybe Update → PPUpdateState → Type where
 
   PPUpdateEmpty : Γ ⊢ s ⇀⦇ nothing ,PPUP⦈ s

--- a/src/Ledger/PreConway/PPUp.lagda.md
+++ b/src/Ledger/PreConway/PPUp.lagda.md
@@ -61,16 +61,6 @@ private variable
   s : PPUpdateState
   e : Epoch
   pup pupˢ fpupˢ : ProposedPPUpdates
-
-instance
-  Dec-pvCanFollow : pvCanFollow ⁇²
-  Dec-pvCanFollow {(m , n)} {pv} .dec with pv ≟ (m + 1 , 0) | pv ≟ (m , n + 1)
-  ... | no ¬p    | no ¬p₁   = no $ λ where canFollowMajor → ¬p  refl
-                                           canFollowMinor → ¬p₁ refl
-  ... | no ¬p    | yes refl = yes canFollowMinor
-  ... | yes refl | no ¬p    = yes canFollowMajor
-  ... | yes refl | yes p    = ⊥-elim $ ℕ.m+1+n≢m m $ ×.×-≡,≡←≡ p .proj₁
-
 ```
 -->
 


### PR DESCRIPTION
# Description

To achieve this, the condition on chained hf proposals disallows modifying the major protocol version.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
