### PR TITLE
Fix condition for chained hf proposals

### DIFF
--- a/build-tools/static/mkdocs/mkdocs.yml
+++ b/build-tools/static/mkdocs/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
     - Address: Ledger.Core.Specification.Address.md
     - Crypto: Ledger.Core.Specification.Crypto.md
     - Epoch: Ledger.Core.Specification.Epoch.md
+    - ProtocolVersion: Ledger.Core.Specification.ProtocolVersion.md
 - Conway:
   - Introduction: Ledger.Conway.Specification.md
   - Modules/:

--- a/src/Ledger/Conway/Foreign/HSLedger/Gov/Actions.lagda.md
+++ b/src/Ledger/Conway/Foreign/HSLedger/Gov/Actions.lagda.md
@@ -11,6 +11,7 @@ open import Ledger.Conway.Foreign.HSLedger.Address
 open import Ledger.Conway.Foreign.HSLedger.BaseTypes
 open import Ledger.Conway.Foreign.HSLedger.PParams
 
+open import Ledger.Core.Specification.ProtocolVersion
 open import Ledger.Conway.Specification.Gov.Base
 open import Ledger.Conway.Specification.Gov.Actions govStructure using (Vote) public
 

--- a/src/Ledger/Conway/Specification/Enact.lagda.md
+++ b/src/Ledger/Conway/Specification/Enact.lagda.md
@@ -14,6 +14,7 @@ open import Data.Rational using (ℚ)
 
 open import Ledger.Prelude
 open import Ledger.Conway.Specification.Gov.Base
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.Conway.Specification.Enact (gs : _) (open GovStructure gs) where
 

--- a/src/Ledger/Conway/Specification/Gov.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov.lagda.md
@@ -24,6 +24,7 @@ open import Ledger.Prelude hiding (any?; Any; all?; All; Rel; lookup; ∈-filter
 
 open import Axiom.Set.Properties th using (∃-sublist-⇔)
 
+open import Ledger.Core.Specification.ProtocolVersion
 open import Ledger.Conway.Specification.Gov.Actions govStructure hiding (yes; no)
 open import Ledger.Conway.Specification.Enact govStructure
 open import Ledger.Conway.Specification.Ratify govStructure
@@ -254,11 +255,11 @@ opaque
 
   validHFAction : GovProposal → GovState → EnactState → Type
   validHFAction (record { action = ⟦ TriggerHardFork , v ⟧ᵍᵃ ; prevAction = prev }) s e =
-    (aid' ≡ prev × pvCanFollow ver v) ⊎ ∃₂[ x , v' ]  (prev , x) ∈ fromList s
+    (aid' ≡ prev × pvCanFollow v ver) ⊎ ∃₂[ x , v' ]  (prev , x) ∈ fromList s
                                                       × x .action ≡ ⟦ TriggerHardFork , v' ⟧ᵍᵃ
                                                       × (if pvMajor ver ≡ pvMajor v'
-                                                            then pvCanFollow v' v
-                                                            else pvCanFollowMinor v' v)
+                                                            then pvCanFollow v v'
+                                                            else pvCanFollowMinor v v')
     where
       ver : ProtVer
       ver = EnactState.pv e .proj₁

--- a/src/Ledger/Conway/Specification/Gov/Actions.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Actions.lagda.md
@@ -21,6 +21,7 @@ open import Data.Rational using (ℚ; 0ℚ; 1ℚ)
 open import Tactic.Derive.Show
 
 open import Ledger.Prelude as P hiding (yes; no)
+open import Ledger.Core.Specification.ProtocolVersion
 ```
 -->
 

--- a/src/Ledger/Conway/Specification/Gov/Properties/Computational.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties/Computational.lagda.md
@@ -8,6 +8,7 @@ source_path: src/Ledger/Conway/Specification/Gov/Properties/Computational.lagda.
 
 open import Ledger.Conway.Specification.Gov.Base
 open import Ledger.Conway.Specification.Transaction using (TransactionStructure)
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.Conway.Specification.Gov.Properties.Computational
   (txs : _) (open TransactionStructure txs using (govStructure))
@@ -53,14 +54,14 @@ private
   isUpdateCommittee ⟦ TreasuryWithdrawal , _                ⟧ᵍᵃ = no λ()
   isUpdateCommittee ⟦ Info               , _                ⟧ᵍᵃ = no λ()
 
-  pvFollows : ∀ v' ver v → Dec (if pvMajor ver ≡ pvMajor v' then pvCanFollow v' v else pvCanFollowMinor v' v)
+  pvFollows : ∀ v' ver v → Dec (if pvMajor ver ≡ pvMajor v' then pvCanFollow v v' else pvCanFollowMinor v v')
   pvFollows v' ver v with pvMajor ver ≟ pvMajor v'
-  ... | yes p = ¿ pvCanFollow v' v ¿
-  ... | no ¬p = ¿ pvCanFollowMinor v' v ¿
+  ... | yes p = ¿ pvCanFollow v v' ¿
+  ... | no ¬p = ¿ pvCanFollowMinor v v' ¿
 
   hasPrev : ∀ x ver v → Dec (∃[ v' ] x .action ≡ ⟦ TriggerHardFork , v' ⟧ᵍᵃ × (if pvMajor ver ≡ pvMajor v'
-                                                                                 then pvCanFollow v' v
-                                                                                 else pvCanFollowMinor v' v))
+                                                                                 then pvCanFollow v v'
+                                                                                 else pvCanFollowMinor v v'))
   hasPrev record { action = ⟦ NoConfidence        , _   ⟧ᵍᵃ} _ v = no λ ()
   hasPrev record { action = ⟦ UpdateCommittee     , _   ⟧ᵍᵃ} _ v = no λ ()
   hasPrev record { action = ⟦ NewConstitution     , _   ⟧ᵍᵃ} _ v = no λ ()
@@ -81,7 +82,7 @@ opaque
     validHFAction? {record { action = ⟦ UpdateCommittee     , _ ⟧ᵍᵃ}} = Dec-⊤
     validHFAction? {record { action = ⟦ NewConstitution     , _ ⟧ᵍᵃ}} = Dec-⊤
     validHFAction? {record { action = ⟦ TriggerHardFork     , v ⟧ᵍᵃ ; prevAction = prev }} {s} {record { pv = (v' , aid') }}
-      with aid' ≟ prev ×-dec pvCanFollow? {v'} {v} | any? (λ (aid , x) → aid ≟ prev ×-dec hasPrev x v' v) s
+      with aid' ≟ prev ×-dec pvCanFollow? {v} {v'} | any? (λ (aid , x) → aid ≟ prev ×-dec hasPrev x v' v) s
     ... | yes p' | _ = ⁇ yes (inj₁ p')
     ... | no _ | yes p' with ((aid , x) , x∈xs , (refl , v , h)) ← P.find p' = ⁇ yes (inj₂
       (x , v , to ∈-fromList x∈xs , h))

--- a/src/Ledger/Conway/Specification/PParams.lagda.md
+++ b/src/Ledger/Conway/Specification/PParams.lagda.md
@@ -21,8 +21,9 @@ open import Tactic.Derive.Show
 
 open import Ledger.Prelude
 open import Ledger.Core.Specification.Crypto
-open import Ledger.Conway.Specification.Script.Base
 open import Ledger.Core.Specification.Epoch
+open import Ledger.Core.Specification.ProtocolVersion
+open import Ledger.Conway.Specification.Script.Base
 open import Ledger.Prelude.Numeric using (UnitInterval; ℕ⁺)
 
 module Ledger.Conway.Specification.PParams
@@ -100,42 +101,7 @@ instance
 
   HasReserves-Acnt : HasReserves Acnt
   HasReserves-Acnt .ReservesOf = Acnt.reserves
-```
--->
 
-```agda
-ProtVer : Type
-ProtVer = ℕ × ℕ
-
-pvMajor : ProtVer → ℕ
-pvMajor = proj₁
-
-pvMinor : ProtVer → ℕ
-pvMinor = proj₂
-```
-
-<!--
-```agda
-instance
-  Show-ProtVer : Show ProtVer
-  Show-ProtVer = Show-×
-```
--->
-
-```agda
-data pvCanFollowMajor : ProtVer → ProtVer → Type where
-  canFollowMajor : pvCanFollowMajor (m , n) (m + 1 , 0)
-
-data pvCanFollowMinor : ProtVer → ProtVer → Type where
-  canFollowMinor : pvCanFollowMinor (m , n) (m , n + 1)
-
-pvCanFollow : ProtVer → ProtVer → Type
-pvCanFollow v₁ v₂ = pvCanFollowMajor v₁ v₂ ⊎ pvCanFollowMinor v₁ v₂
-```
-
-<!--
-```agda
-instance
   unquoteDecl HasCast-Acnt = derive-HasCast
     [ (quote Acnt , HasCast-Acnt) ]
 ```
@@ -525,26 +491,6 @@ module PParamsUpdate where
   instance
     unquoteDecl DecEq-PParamsUpdate  = derive-DecEq
       ((quote PParamsUpdate , DecEq-PParamsUpdate) ∷ [])
-
-instance
-  Dec-pvCanFollowMajor : ∀ {pv} {pv'} → Dec (pvCanFollowMajor pv pv')
-  Dec-pvCanFollowMajor {m , n} {pv} with pv ≟ (m + 1 , 0)
-  ... | yes refl = yes canFollowMajor
-  ... | no ¬p = no (λ { canFollowMajor → ¬p refl })
-
-  Dec-pvCanFollowMinor : ∀ {pv} {pv'} → Dec (pvCanFollowMinor pv pv')
-  Dec-pvCanFollowMinor {m , n} {pv} with pv ≟ (m , n + 1)
-  ... | yes refl = yes canFollowMinor
-  ... | no ¬p = no (λ { canFollowMinor → ¬p refl })
-
-  pvCanFollowMajor? : pvCanFollowMajor ⁇²
-  pvCanFollowMajor? = ⁇ Dec-pvCanFollowMajor
-
-  pvCanFollowMinor? : pvCanFollowMinor ⁇²
-  pvCanFollowMinor? = ⁇ Dec-pvCanFollowMinor
-
-pvCanFollow? : ∀ {pv} {pv'} → Dec (pvCanFollow pv pv')
-pvCanFollow? = Dec-pvCanFollowMajor ⊎-dec Dec-pvCanFollowMinor
 ```
 -->
 

--- a/src/Ledger/Core/Specification.lagda.md
+++ b/src/Ledger/Core/Specification.lagda.md
@@ -30,11 +30,18 @@ The `Crypto`{.AgdaModule} module defines cryptographic primitives and structures
 import Ledger.Core.Specification.Crypto
 ```
 
-
 ## Epoch
 
 The `Epoch`{.AgdaModule} module defines epoch-related concepts and structures.
 
 ```agda
 import Ledger.Core.Specification.Epoch
+```
+
+## Protocol Version
+
+The `ProtocolVersion{.AgdaModule} module defines protocol versions.
+
+```agda
+import Ledger.Core.Specification.ProtocolVersion
 ```

--- a/src/Ledger/Core/Specification/ProtocolVersion.lagda.md
+++ b/src/Ledger/Core/Specification/ProtocolVersion.lagda.md
@@ -1,0 +1,68 @@
+---
+source_branch: master
+source_path: src/Ledger/Core/Specification/ProtocolVersion.lagda.md
+---
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+module Ledger.Core.Specification.ProtocolVersion where
+
+open import Ledger.Prelude
+
+private
+  variable
+    m n : ℕ
+```
+-->
+
+# Protocol Version {#sec:protocol-version}
+
+```agda
+ProtVer : Type
+ProtVer = ℕ × ℕ
+
+pvMajor : ProtVer → ℕ
+pvMajor = proj₁
+
+pvMinor : ProtVer → ℕ
+pvMinor = proj₂
+```
+
+```agda
+data pvCanFollowMajor : ProtVer → ProtVer → Type where
+  canFollowMajor : pvCanFollowMajor (m + 1 , 0) (m , n)
+
+data pvCanFollowMinor : ProtVer → ProtVer → Type where
+  canFollowMinor : pvCanFollowMinor (m , n + 1) (m , n)
+
+pvCanFollow : ProtVer → ProtVer → Type
+pvCanFollow v₁ v₂ = pvCanFollowMajor v₁ v₂ ⊎ pvCanFollowMinor v₁ v₂
+```
+
+<!--
+```agda
+instance
+  Show-ProtVer : Show ProtVer
+  Show-ProtVer = Show-×
+
+  Dec-pvCanFollowMajor : ∀ {pv} {pv'} → Dec (pvCanFollowMajor pv pv')
+  Dec-pvCanFollowMajor {pv} {m , n} with pv ≟ (m + 1 , 0)
+  ... | yes refl = yes canFollowMajor
+  ... | no ¬p = no (λ { canFollowMajor → ¬p refl })
+
+  Dec-pvCanFollowMinor : ∀ {pv} {pv'} → Dec (pvCanFollowMinor pv pv')
+  Dec-pvCanFollowMinor {pv} {m , n} with pv ≟ (m , n + 1)
+  ... | yes refl = yes canFollowMinor
+  ... | no ¬p = no (λ { canFollowMinor → ¬p refl })
+
+  pvCanFollowMajor? : pvCanFollowMajor ⁇²
+  pvCanFollowMajor? = ⁇ Dec-pvCanFollowMajor
+
+  pvCanFollowMinor? : pvCanFollowMinor ⁇²
+  pvCanFollowMinor? = ⁇ Dec-pvCanFollowMinor
+
+pvCanFollow? : ∀ {pv} {pv'} → Dec (pvCanFollow pv pv')
+pvCanFollow? = Dec-pvCanFollowMajor ⊎-dec Dec-pvCanFollowMinor
+```
+-->

--- a/src/Ledger/Dijkstra/Specification/Enact.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Enact.lagda.md
@@ -14,6 +14,7 @@ open import Data.Rational using (ℚ)
 
 open import Ledger.Prelude
 open import Ledger.Dijkstra.Specification.Gov.Base
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.Dijkstra.Specification.Enact (gs : _) (open GovStructure gs) where
 

--- a/src/Ledger/Dijkstra/Specification/Gov.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov.lagda.md
@@ -17,6 +17,7 @@ open import Ledger.Prelude hiding (any?; Any; all?; All; Rel; lookup; ∈-filter
 
 open import Axiom.Set.Properties th using (∃-sublist-⇔)
 
+open import Ledger.Core.Specification.ProtocolVersion
 open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
 open import Ledger.Dijkstra.Specification.Enact govStructure
 open import Ledger.Dijkstra.Specification.Ratify govStructure

--- a/src/Ledger/Dijkstra/Specification/Gov/Actions.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov/Actions.lagda.md
@@ -21,6 +21,7 @@ open import Data.Rational using (ℚ; 0ℚ; 1ℚ)
 open import Tactic.Derive.Show
 
 open import Ledger.Prelude as P hiding (yes; no)
+open import Ledger.Core.Specification.ProtocolVersion
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Gov/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov/Properties/Computational.lagda.md
@@ -17,6 +17,7 @@ open import Ledger.Prelude hiding (Any; any?)
 
 open import Axiom.Set.Properties
 
+open import Ledger.Core.Specification.ProtocolVersion
 open import Ledger.Dijkstra.Specification.Enact govStructure
 open import Ledger.Dijkstra.Specification.Gov govStructure
 open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)

--- a/src/Ledger/Dijkstra/Specification/PParams.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/PParams.lagda.md
@@ -13,6 +13,7 @@ This section defines the adjustable protocol parameters of the Cardano ledger.
 
 open import Ledger.Core.Specification.Crypto using (CryptoStructure)
 open import Ledger.Core.Specification.Epoch using (EpochStructure)
+open import Ledger.Core.Specification.ProtocolVersion
 open import Ledger.Dijkstra.Specification.Script.Base
 
 module Ledger.Dijkstra.Specification.PParams
@@ -49,13 +50,6 @@ record Acnt : Type where
   constructor ⟦_,_⟧ᵃ
   field
     treasury reserves : Coin
-
-ProtVer : Type
-ProtVer = ℕ × ℕ
-
-data pvCanFollow : ProtVer → ProtVer → Type where
-  canFollowMajor : pvCanFollow (m , n) (m + 1 , 0)
-  canFollowMinor : pvCanFollow (m , n) (m , n + 1)
 ```
 
 <!--
@@ -66,10 +60,6 @@ instance
 
   HasReserves-Acnt : HasReserves Acnt
   HasReserves-Acnt .ReservesOf = Acnt.reserves
-
-instance
-  Show-ProtVer : Show ProtVer
-  Show-ProtVer = Show-×
 
   unquoteDecl HasCast-Acnt = derive-HasCast
     [ (quote Acnt , HasCast-Acnt) ]
@@ -409,15 +399,6 @@ module PParamsUpdate where
   instance
     unquoteDecl DecEq-PParamsUpdate  = derive-DecEq
       ((quote PParamsUpdate , DecEq-PParamsUpdate) ∷ [])
-
-instance
-  pvCanFollow? : ∀ {pv} {pv'} → Dec (pvCanFollow pv pv')
-  pvCanFollow? {m , n} {pv} with pv ≟ (m + 1 , 0) | pv ≟ (m , n + 1)
-  ... | no ¬p    | no ¬p₁   = no $ λ where canFollowMajor → ¬p  refl
-                                           canFollowMinor → ¬p₁ refl
-  ... | no ¬p    | yes refl = yes canFollowMinor
-  ... | yes refl | no ¬p    = yes canFollowMajor
-  ... | yes refl | yes p    = ⊥-elim $ m+1+n≢m m $ ×-≡,≡←≡ p .proj₁
 ```
 -->
 

--- a/src/Ledger/PreConway/Conformance/NewPP.lagda.md
+++ b/src/Ledger/PreConway/Conformance/NewPP.lagda.md
@@ -10,6 +10,7 @@ open import Relation.Nullary.Decidable
 
 open import Ledger.Prelude
 open import Ledger.Conway.Specification.Transaction
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.PreConway.Conformance.NewPP (txs : _) (open TransactionStructure txs) where
 

--- a/src/Ledger/PreConway/Conformance/PPUp.lagda.md
+++ b/src/Ledger/PreConway/Conformance/PPUp.lagda.md
@@ -13,6 +13,7 @@ import Data.Nat as ℕ; import Data.Nat.Properties as ℕ
 
 open import Ledger.Prelude hiding (_*_)
 open import Ledger.Conway.Specification.Transaction
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.PreConway.Conformance.PPUp (txs : _) (open TransactionStructure txs) where
 

--- a/src/Ledger/PreConway/Conformance/PPUp/Properties.lagda.md
+++ b/src/Ledger/PreConway/Conformance/PPUp/Properties.lagda.md
@@ -8,6 +8,7 @@ source_path: src/Ledger/PreConway/Conformance/PPUp/Properties.lagda.md
 open import Ledger.Prelude hiding (_*_)
 open Computational ⦃...⦄; open HasDecPartialOrder ⦃...⦄
 open import Ledger.Conway.Specification.Transaction
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.PreConway.Conformance.PPUp.Properties (txs : _) (open TransactionStructure txs) where
 

--- a/src/Ledger/PreConway/NewPP.lagda.md
+++ b/src/Ledger/PreConway/NewPP.lagda.md
@@ -13,6 +13,7 @@ open import Relation.Nullary.Decidable
 
 open import Ledger.Prelude
 open import Ledger.Conway.Specification.Transaction
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.PreConway.NewPP (txs : _) (open TransactionStructure txs) where
 

--- a/src/Ledger/PreConway/PPUp.lagda.md
+++ b/src/Ledger/PreConway/PPUp.lagda.md
@@ -16,6 +16,7 @@ import Data.Nat as ℕ; import Data.Nat.Properties as ℕ
 
 open import Ledger.Prelude hiding (_*_)
 open import Ledger.Conway.Specification.Transaction
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.PreConway.PPUp (txs : _) (open TransactionStructure txs) where
 

--- a/src/Ledger/PreConway/PPUp/Properties.lagda.md
+++ b/src/Ledger/PreConway/PPUp/Properties.lagda.md
@@ -9,6 +9,7 @@ source_path: src/Ledger/PreConway/PPUp/Properties.lagda.md
 open import Ledger.Prelude hiding (_*_)
 open Computational ⦃...⦄; open HasDecPartialOrder ⦃...⦄
 open import Ledger.Conway.Specification.Transaction
+open import Ledger.Core.Specification.ProtocolVersion
 
 module Ledger.PreConway.PPUp.Properties (txs : _) (open TransactionStructure txs) where
 


### PR DESCRIPTION
# Description

The current specification doesn't fully capture the implementation behaviour. It does not allow to chaine HF proposals which increase the major version. This PR fixes this.

In addition, it refactors `ProtVer` and associated functions to be reused across eras.

~Blocked by #1107~

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
