### PR TITLE
Change update cost models to retain old values

### DIFF
--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Foreign/API.hs
@@ -8,7 +8,7 @@ import MAlonzo.Code.Ledger.Prelude.Foreign.HSTypes                   as X
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.Address           as X
   (Credential(..), BaseAddr(..), BootstrapAddr(..), RewardAddress(..), Addr, HSVKey (..))
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.PParams           as X
-  (DrepThresholds(..), PoolThresholds(..), Acnt(..), PParams(..), PParamsUpdate(..))
+  (LanguageCostModels, DrepThresholds(..), PoolThresholds(..), Acnt(..), PParams(..), PParamsUpdate(..))
 import MAlonzo.Code.Ledger.Conway.Foreign.HSLedger.Transaction       as X
   ( Tag(..), Timelock(..), TxWitnesses(..), TxBody(..), Tx(..), TxId, Ix, TxIn, P1Script, P2Script
   , Script, Datum, DataHash, Value, TxOut, RdmrPtr, ScriptHash, AuxiliaryData, Withdrawals

--- a/src/Ledger/Conway/Foreign/HSLedger/PParams.lagda.md
+++ b/src/Ledger/Conway/Foreign/HSLedger/PParams.lagda.md
@@ -7,6 +7,9 @@ module Ledger.Conway.Foreign.HSLedger.PParams where
 
 open import Ledger.Conway.Foreign.HSLedger.BaseTypes
 
+unquoteDecl = do
+  hsTypeAlias LanguageCostModels
+
 instance
   HsTy-DrepThresholds = autoHsType DrepThresholds
     ⊣ withConstructor "MkDrepThresholds"

--- a/src/Ledger/Conway/Specification/PParams.lagda.md
+++ b/src/Ledger/Conway/Specification/PParams.lagda.md
@@ -507,7 +507,8 @@ module PParamsUpdate where
       ; Emax                        = U.Emax ?↗ P.Emax
       ; nopt                        = U.nopt ?↗ P.nopt
       ; collateralPercentage        = U.collateralPercentage ?↗ P.collateralPercentage
-      ; costmdlsAssoc               = U.costmdls ?↗ P.costmdlsAssoc
+      ; costmdlsAssoc               = if U.costmdls then (λ {cm} → setToList (fromListᵐ (cm ++ P.costmdlsAssoc) ˢ))
+                                                    else P.costmdlsAssoc
       ; drepThresholds              = U.drepThresholds ?↗ P.drepThresholds
       ; poolThresholds              = U.poolThresholds ?↗ P.poolThresholds
       ; govActionLifetime           = U.govActionLifetime ?↗ P.govActionLifetime


### PR DESCRIPTION
# Description

The current specification discards old values in a pparam update of cost models. The implementation instead treats the update as a refinement of the old values. This PR changes the specification to match the implementation.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
