### PR TITLE
Add Dijkstra Foreign modules

### DIFF
--- a/build-tools/shake/src/Main.hs
+++ b/build-tools/shake/src/Main.hs
@@ -123,6 +123,15 @@ hsRule = phony "hs" $ do
     ]
     ["src/Ledger/Conway/Foreign.lagda.md"]
 
+  cmd_
+    "agda"
+    [ "-c"
+    , "--ghc-dont-call-ghc"
+    , "--no-main"
+    , "--compile-dir=" ++ _build
+    ]
+    ["src/Ledger/Dijkstra/Foreign.lagda.md"]
+
   -- copy over the Agda-generated MAlonzo files to _hs
   malonzofiles <- map ("MAlonzo" </>) <$> getDirectoryFiles _malonzo ["//*.hs"]
   forM_ malonzofiles $ \file -> do

--- a/build-tools/static/hs-src/package.yaml
+++ b/build-tools/static/hs-src/package.yaml
@@ -13,4 +13,6 @@ source-dirs:
   - src
 library:
   exposed-modules:
-    - MAlonzo.Code.Ledger.Foreign.API
+    - MAlonzo.Code.Ledger.Core.Foreign.API
+    - MAlonzo.Code.Ledger.Conway.Foreign.API
+    - MAlonzo.Code.Ledger.Dijkstra.Foreign.API

--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Conway/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Conway/Foreign/API.hs
@@ -1,16 +1,10 @@
-module MAlonzo.Code.Ledger.Foreign.API
+module MAlonzo.Code.Ledger.Conway.Foreign.API
   ( module X
-  , module MAlonzo.Code.Ledger.Foreign.API
+  , module MAlonzo.Code.Ledger.Core.Foreign.API
+  , module MAlonzo.Code.Ledger.Conway.Foreign.API
   ) where
 
-import MAlonzo.Code.Ledger.Prelude.Foreign.HSTypes                   as X
-  (HSSet(..), HSMap(..), ComputationResult(..), Rational(..), Coin)
-import MAlonzo.Code.Ledger.Core.Foreign.Address           as X
-  (Credential(..), BaseAddr(..), BootstrapAddr(..), RewardAddress(..), Addr)
-import MAlonzo.Code.Ledger.Core.Foreign.Crypto.Base           as X
-  (HSVKey(..))
-import MAlonzo.Code.Ledger.Core.Foreign.Epoch           as X
-  (Epoch)
+import MAlonzo.Code.Ledger.Core.Foreign.API
 import MAlonzo.Code.Ledger.Conway.Foreign.PParams           as X
   (LanguageCostModels(..), DrepThresholds(..), PoolThresholds(..), Acnt(..), PParams(..), PParamsUpdate(..))
 import MAlonzo.Code.Ledger.Conway.Foreign.Transaction       as X
@@ -48,6 +42,3 @@ import MAlonzo.Code.Ledger.Conway.Foreign.Utxo              as X
   , utxoDebug, utxowDebug)
 import MAlonzo.Code.Ledger.Conway.Foreign.Script.Base      as X
   (HSLanguage(..))
-import MAlonzo.Code.Ledger.Core.Foreign.ExternalFunctions           as X
-  (ExternalFunctions(..), dummyExternalFunctions)
-

--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Core/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Core/Foreign/API.hs
@@ -1,0 +1,15 @@
+module MAlonzo.Code.Ledger.Core.Foreign.API
+  ( module X
+  , module MAlonzo.Code.Ledger.Core.Foreign.API
+  ) where
+
+import MAlonzo.Code.Ledger.Prelude.Foreign.HSTypes                  as X
+  (HSSet(..), HSMap(..), ComputationResult(..), Rational(..), Coin)
+import MAlonzo.Code.Ledger.Core.Foreign.Address                     as X
+  (Credential(..), BaseAddr(..), BootstrapAddr(..), RewardAddress(..), Addr)
+import MAlonzo.Code.Ledger.Core.Foreign.Crypto.Base                 as X
+  (HSVKey(..))
+import MAlonzo.Code.Ledger.Core.Foreign.Epoch                       as X
+  (Epoch)
+import MAlonzo.Code.Ledger.Core.Foreign.ExternalFunctions           as X
+  (ExternalFunctions(..), dummyExternalFunctions)

--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
@@ -5,6 +5,8 @@ module MAlonzo.Code.Ledger.Dijkstra.Foreign.API
   ) where
 
 import MAlonzo.Code.Ledger.Core.Foreign.API
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Account           as X
+  (BalanceInterval(..))
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.PParams           as X
   (LanguageCostModels(..), DrepThresholds(..), PoolThresholds(..), Acnt(..), PParams(..), PParamsUpdate(..))
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Transaction       as X

--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
@@ -1,0 +1,45 @@
+module MAlonzo.Code.Ledger.Dijkstra.Foreign.API
+  ( module X
+  , module MAlonzo.Code.Ledger.Core.Foreign.API
+  , module MAlonzo.Code.Ledger.Dijkstra.Foreign.API
+  ) where
+
+import MAlonzo.Code.Ledger.Core.Foreign.API
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.PParams           as X
+  (LanguageCostModels(..), DrepThresholds(..), PoolThresholds(..), Acnt(..), PParams(..), PParamsUpdate(..))
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Transaction       as X
+  ( TxBodyTop(..), TxTop(..), TxBodySub(..), TxSub(..)
+  , Tag(..), TxWitnesses(..)
+  , TxId, Ix, TxIn, ExUnits, P1Script, P2Script
+  , Script, Datum, DataHash, Value, TxOut, ScriptHash, AuxiliaryData, Withdrawals
+  , Redeemer, RedeemerPtr
+  , Timelock(..), HSTimelock (..), HSPlutusScript (..))
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Cert              as X
+  (certStep, certsStep, CertState(..))
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Chain             as X
+  (ChainState(..), Block(..), chainStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Certs             as X
+  ( StakePoolParams(..), PState(..), DelegEnv(..), CertEnv(..), DState(..), DCert(..), GState(..)
+  , delegStep, govCertStep, poolStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Enact             as X
+  (EnactState(..), EnactEnv(..), enactStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Epoch             as X
+  (EpochState(..), epochStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Gov.Core          as X
+  (GovRole(..), Anchor(..), VDeleg(..), Vote(..), GovVote(..), GovVoter, GovVotes(..))
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Gov               as X
+  ( GovEnv(..), GovProposal(..), GovActionState(..), govStep, GovState, GovActionID)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Gov.Actions       as X
+  (GovAction (..))
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Ledger            as X
+  (LedgerEnv(..), LedgerState(..), ledgerStep, ledgersStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.NewEpoch          as X
+  (NewEpochState(..), newEpochStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Ratify            as X
+  (StakeDistrs(..), RatifyEnv(..), RatifyState(..), ratifyStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Rewards           as X
+  (RewardUpdate(..), Snapshot(..), Snapshots(..))
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Utxo              as X
+  ( UTxOEnv(..), UTxOState(..), UTxO, utxoStep, utxowStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Script.Base      as X
+  (HSLanguage(..))

--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
@@ -13,7 +13,7 @@ import MAlonzo.Code.Ledger.Dijkstra.Foreign.Transaction       as X
   , TxId, Ix, TxIn, ExUnits, P1Script, P2Script
   , Script, Datum, DataHash, Value, TxOut, ScriptHash, AuxiliaryData, Withdrawals
   , Redeemer, RedeemerPtr
-  , Timelock(..), HSTimelock (..), HSPlutusScript (..))
+  , NativeScript(..), HSNativeScript (..), HSPlutusScript (..))
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Cert              as X
   (certStep, certsStep, CertState(..))
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Chain             as X

--- a/build-tools/static/mkdocs/mkdocs.yml
+++ b/build-tools/static/mkdocs/mkdocs.yml
@@ -349,6 +349,31 @@ nav:
   - Era-dependent Modules:
     - Dijkstra:
       - Ledger.Dijkstra: Ledger.Dijkstra.md
+      - Foreign:
+        - Foreign: Ledger.Dijkstra.Foreign.md
+        - Foreign/:
+          - HSStructures: Ledger.Dijkstra.Foreign.HSStructures.md
+          - Cert: Ledger.Dijkstra.Foreign.Cert.md
+          - Certs: Ledger.Dijkstra.Foreign.Certs.md
+          - Chain: Ledger.Dijkstra.Foreign.Chain.md
+          - Enact: Ledger.Dijkstra.Foreign.Enact.md
+          - Epoch: Ledger.Dijkstra.Foreign.Epoch.md
+          - ExternalStructures: Ledger.Dijkstra.Foreign.ExternalStructures.md
+          - Gov: Ledger.Dijkstra.Foreign.Gov.md
+          - Gov/:
+            - Core: Ledger.Dijkstra.Foreign.Gov.Core.md
+            - Actions: Ledger.Dijkstra.Foreign.Gov.Actions.md
+          - Ledger: Ledger.Dijkstra.Foreign.Ledger.md
+          - NewEpoch: Ledger.Dijkstra.Foreign.NewEpoch.md
+          - PParams: Ledger.Dijkstra.Foreign.PParams.md
+          - Ratify: Ledger.Dijkstra.Foreign.Ratify.md
+          - Rewards: Ledger.Dijkstra.Foreign.Rewards.md
+          - Transaction: Ledger.Dijkstra.Foreign.Transaction.md
+          - Script: Ledger.Dijkstra.Foreign.Script.md
+          - Script/:
+            - Base: Ledger.Dijkstra.Foreign.Script.Base.md
+            - Structure: Ledger.Dijkstra.Foreign.Script.Structure.md
+          - Utxo: Ledger.Dijkstra.Foreign.Utxo.md
     - PreConway:
       - Ledger.PreConway: Ledger.PreConway.md
       - Ledger.PreConway/:

--- a/build-tools/static/mkdocs/mkdocs.yml
+++ b/build-tools/static/mkdocs/mkdocs.yml
@@ -352,7 +352,7 @@ nav:
       - Foreign:
         - Foreign: Ledger.Dijkstra.Foreign.md
         - Foreign/:
-          - HSStructures: Ledger.Dijkstra.Foreign.HSStructures.md
+          - Account: Ledger.Dijkstra.Foreign.Account.md
           - Cert: Ledger.Dijkstra.Foreign.Cert.md
           - Certs: Ledger.Dijkstra.Foreign.Certs.md
           - Chain: Ledger.Dijkstra.Foreign.Chain.md
@@ -363,16 +363,17 @@ nav:
           - Gov/:
             - Core: Ledger.Dijkstra.Foreign.Gov.Core.md
             - Actions: Ledger.Dijkstra.Foreign.Gov.Actions.md
+          - HSStructures: Ledger.Dijkstra.Foreign.HSStructures.md
           - Ledger: Ledger.Dijkstra.Foreign.Ledger.md
           - NewEpoch: Ledger.Dijkstra.Foreign.NewEpoch.md
           - PParams: Ledger.Dijkstra.Foreign.PParams.md
           - Ratify: Ledger.Dijkstra.Foreign.Ratify.md
           - Rewards: Ledger.Dijkstra.Foreign.Rewards.md
-          - Transaction: Ledger.Dijkstra.Foreign.Transaction.md
           - Script: Ledger.Dijkstra.Foreign.Script.md
           - Script/:
             - Base: Ledger.Dijkstra.Foreign.Script.Base.md
             - Structure: Ledger.Dijkstra.Foreign.Script.Structure.md
+          - Transaction: Ledger.Dijkstra.Foreign.Transaction.md
           - Utxo: Ledger.Dijkstra.Foreign.Utxo.md
     - PreConway:
       - Ledger.PreConway: Ledger.PreConway.md

--- a/src/Ledger/Dijkstra.lagda.md
+++ b/src/Ledger/Dijkstra.lagda.md
@@ -8,8 +8,5 @@ module Ledger.Dijkstra where
 
 --- Cardano ledger in the Dijkstra era
 import Ledger.Dijkstra.Specification
-
--- TODO:
--- import Ledger.Dijkstra.Conformance       -- Conformance test reconciliation
--- import Ledger.Dijkstra.Foreign.HSLedger  -- Haskell code extraction
+import Ledger.Dijkstra.Foreign
 ```

--- a/src/Ledger/Dijkstra/Foreign.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign.lagda.md
@@ -1,0 +1,19 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign where
+
+open import Ledger.Dijkstra.Foreign.Cert public
+open import Ledger.Dijkstra.Foreign.Chain public
+open import Ledger.Dijkstra.Foreign.Certs public
+open import Ledger.Dijkstra.Foreign.Enact public
+open import Ledger.Dijkstra.Foreign.Epoch public
+open import Ledger.Dijkstra.Foreign.Gov public
+open import Ledger.Dijkstra.Foreign.Ledger public
+open import Ledger.Dijkstra.Foreign.NewEpoch public
+open import Ledger.Dijkstra.Foreign.Ratify public
+open import Ledger.Dijkstra.Foreign.Utxo public
+open import Ledger.Dijkstra.Foreign.Script public
+```

--- a/src/Ledger/Dijkstra/Foreign/Account.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Account.lagda.md
@@ -24,7 +24,7 @@ private
     if      s ≟ "⟦_,_⦆" then "Both"
     else if s ≟ "⟦_,∞⦆" then "Lower"
     else if s ≟ "⟦0,_⦆" then "Upper"
-    else ""
+    else s
 
 instance
   HsTy-BalanceInterval = autoHsType BalanceInterval ⊣ onConstructors toHaskellConstr

--- a/src/Ledger/Dijkstra/Foreign/Account.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Account.lagda.md
@@ -1,0 +1,31 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Account.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Account where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+import Data.String as S
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Core.Foreign.Crypto.Base
+open import Ledger.Dijkstra.Foreign.HSStructures
+
+private
+  toHaskellConstr : String → String
+  toHaskellConstr s =
+    if      s ≟ "⟦_,_⦆" then "Both"
+    else if s ≟ "⟦_,∞⦆" then "Lower"
+    else if s ≟ "⟦0,_⦆" then "Upper"
+    else ""
+
+instance
+  HsTy-BalanceInterval = autoHsType BalanceInterval ⊣ onConstructors toHaskellConstr
+  Conv-BalanceInterval = autoConvert BalanceInterval

--- a/src/Ledger/Dijkstra/Foreign/Cert.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Cert.lagda.md
@@ -1,0 +1,38 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Cert.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Cert where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.Certs public
+open import Ledger.Dijkstra.Specification.Certs.Properties.Computational DummyGovStructure
+  using ( Computational-CERT
+        ; Computational-CERTS
+        )
+
+open Computational
+
+instance
+  HsTy-CertState = autoHsType CertState ⊣ withConstructor "MkCertState"
+  Conv-CertState = autoConvert CertState
+
+cert-step : HsType (CertEnv → CertState → DCert → ComputationResult String CertState)
+cert-step = to (compute Computational-CERT)
+
+{-# COMPILE GHC cert-step as certStep #-}
+
+certs-step : HsType (CertEnv → CertState → List DCert → ComputationResult String CertState)
+certs-step = to (compute Computational-CERTS)
+
+{-# COMPILE GHC certs-step as certsStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Certs.lagda.md
@@ -1,0 +1,99 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Certs.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Certs where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.Gov.Core
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Specification.Certs.Properties.Computational DummyGovStructure
+  using ( Computational-DELEG
+        ; Computational-POOL
+        ; Computational-GOVCERT
+        )
+
+open Computational
+
+instance
+  HsTy-StakePoolParams = autoHsType StakePoolParams
+  Conv-StakePoolParams = autoConvert StakePoolParams
+
+  HsTy-DCert = autoHsType DCert
+  Conv-DCert = autoConvert DCert
+
+  HsTy-DelegEnv = autoHsType DelegEnv
+    ⊣ withConstructor "MkDelegEnv"
+    • fieldPrefix "de"
+    • withName "DelegEnv"
+  Conv-DelegEnv = autoConvert DelegEnv
+
+  HsTy-PState = autoHsType PState
+    ⊣ withConstructor "MkPState"
+    • fieldPrefix "ps"
+  Conv-PState = autoConvert PState
+
+  HsTy-DState = autoHsType DState
+    ⊣ withConstructor "MkDState"
+    • withName "DState"
+    • fieldPrefix "ds"
+  Conv-DState = autoConvert DState
+
+  HsTy-GState = autoHsType GState
+    ⊣ withConstructor "MkGState"
+    • fieldPrefix "gs"
+  Conv-GState = autoConvert GState
+
+-- CertEnv needs a wrapper because the votes field uses GovVote
+-- which requires non-trivial conversion through GovVote'.
+
+record CertEnv' : Type where
+  field
+    epoch     : Epoch
+    pp        : PParams
+    votes     : List GovVote'
+    wdrls     : RewardAddress ⇀ Coin
+    coldCreds : ℙ Credential
+
+instance
+  HsTy-CertEnv' = autoHsType CertEnv'
+    ⊣ withConstructor "MkCertEnv"
+    • withName "CertEnv"
+    • fieldPrefix "ce"
+  Conv-CertEnv' = autoConvert CertEnv'
+
+  mkCertEnv' : Convertible CertEnv CertEnv'
+  mkCertEnv' = λ where
+    .to   ce → let module ce = CertEnv ce in record { epoch = ce.epoch ; pp = ce.pp ; votes = to ce.votes ; wdrls = ce.wdrls ; coldCreds = ce.coldCreds }
+    .from ce → let module ce = CertEnv' ce in record { epoch = ce.epoch ; pp = ce.pp ; votes = from ce.votes ; wdrls = ce.wdrls ; coldCreds = ce.coldCreds }
+
+  HsTy-CertEnv = MkHsType CertEnv (HsType CertEnv')
+  Conv-CertEnv = mkCertEnv' ⨾ Conv-CertEnv'
+
+-- Computational step functions
+
+deleg-step : HsType (DelegEnv → DState → DCert → ComputationResult String DState)
+deleg-step = to (compute Computational-DELEG)
+
+{-# COMPILE GHC deleg-step as delegStep #-}
+
+pool-step : HsType (PParams → PState → DCert → ComputationResult String PState)
+pool-step = to (compute Computational-POOL)
+
+{-# COMPILE GHC pool-step as poolStep #-}
+
+govcert-step : HsType (CertEnv → GState → DCert → ComputationResult String GState)
+govcert-step = to (compute Computational-GOVCERT)
+
+{-# COMPILE GHC govcert-step as govCertStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/Chain.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Chain.lagda.md
@@ -51,25 +51,6 @@ record HSBlock : Type where
 
 open HSBlock
 
-convBlock : HSBlock → Block
-convBlock b
-  with bBodySize b ≟ BHBody.hBbsize (BHeader.bhbody (bheader b))
-... | no _ = error $ "bBodySize check failed: " S.++
-               show (bBodySize b) S.++ " ≠ " S.++
-               show (BHBody.hBbsize (BHeader.bhbody (bheader b)))
-... | yes p
-  with bBodyHash b ≟ BHBody.bhash (BHeader.bhbody (bheader b))
-... | no _ = error $ "BBodyHash check failed: " S.++
-               show (bBodyHash b) S.++ " ≠ " S.++
-               show (BHBody.bhash (BHeader.bhbody (bheader b)))
-... | yes q = record
-  { bheader = bheader b
-  ; ts = ts b
-  ; bBodySize = bBodySize b
-  ; ≡-bBodySize = p
-  ; ≡-bBodyHash = q
-  }
-
 instance
   Conv-Block-HSBlock : Convertible Block HSBlock
   Conv-Block-HSBlock .to b = record { Block b }

--- a/src/Ledger/Dijkstra/Foreign/Chain.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Chain.lagda.md
@@ -1,0 +1,113 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Chain.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Chain where
+
+import Data.String as S
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.Util
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Core.Foreign.Crypto.Base
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Foreign.Enact
+open import Ledger.Dijkstra.Foreign.Gov
+open import Ledger.Dijkstra.Foreign.Ratify
+open import Ledger.Dijkstra.Foreign.Rewards
+open import Ledger.Dijkstra.Foreign.Utxo
+open import Ledger.Dijkstra.Foreign.Ledger
+open import Ledger.Dijkstra.Foreign.NewEpoch
+open import Ledger.Dijkstra.Foreign.Transaction
+open import Ledger.Dijkstra.Specification.Chain it DummyAbstractFunctions
+open import Ledger.Dijkstra.Specification.Chain.Properties.Computational it DummyAbstractFunctions
+
+open Computational
+
+instance
+  HsTy-BHBody = autoHsType BHBody ⊣ withConstructor "MkBHBody"
+                                    • fieldPrefix "bhb"
+  Conv-BHBody = autoConvert BHBody
+
+  HsTy-BHeader = autoHsType BHeader ⊣ withConstructor "MkBHeader"
+                                      • fieldPrefix "bh"
+  Conv-BHeader = autoConvert BHeader
+
+record HSBlock : Type where
+  field
+    bheader   : BHeader
+    ts        : List TopLevelTx
+    bBodySize : ℕ
+    bBodyHash : KeyHash
+
+postulate
+  trustMe-≡ : ∀ {a} {A : Type a} {x y : A} → x ≡ y
+
+open HSBlock
+
+convBlock : HSBlock → Block
+convBlock b
+  with bBodySize b ≟ BHBody.hBbsize (BHeader.bhbody (bheader b))
+... | no _ = error $ "bBodySize check failed: " S.++
+               show (bBodySize b) S.++ " ≠ " S.++
+               show (BHBody.hBbsize (BHeader.bhbody (bheader b)))
+... | yes p
+  with bBodyHash b ≟ BHBody.bhash (BHeader.bhbody (bheader b))
+... | no _ = error $ "BBodyHash check failed: " S.++
+               show (bBodyHash b) S.++ " ≠ " S.++
+               show (BHBody.bhash (BHeader.bhbody (bheader b)))
+... | yes q = record
+  { bheader = bheader b
+  ; ts = ts b
+  ; bBodySize = bBodySize b
+  ; ≡-bBodySize = p
+  ; ≡-bBodyHash = q
+  }
+
+instance
+  Conv-Block-HSBlock : Convertible Block HSBlock
+  Conv-Block-HSBlock .to b = record { Block b }
+  Conv-Block-HSBlock .from b
+     with bBodySize b ≟ BHBody.hBbsize (BHeader.bhbody (bheader b))
+  ... | no _ = error $ "bBodySize check failed: " S.++
+                  show (bBodySize b) S.++ " ≠ " S.++
+                  show (BHBody.hBbsize (BHeader.bhbody (bheader b)))
+  ... | yes p
+     with bBodyHash b ≟ BHBody.bhash (BHeader.bhbody (bheader b))
+  ... | no _ = error $ "BBodyHash check failed: " S.++
+                 show (bBodyHash b) S.++ " ≠ " S.++
+                 show (BHBody.bhash (BHeader.bhbody (bheader b)))
+  ... | yes q = record
+    { bheader = bheader b
+    ; ts = ts b
+    ; bBodySize = bBodySize b
+    ; ≡-bBodySize = p
+    ; ≡-bBodyHash = q
+    }
+
+  HsTy-HSBlock = autoHsType HSBlock ⊣ withName "Block"
+                                   • withConstructor "MkBlock"
+                                   • fieldPrefix "b"
+  Conv-HSBlock = autoConvert HSBlock
+
+  HsTy-Block = MkHsType Block (HsType HSBlock)
+  Conv-Block = Conv-Block-HSBlock ⨾ Conv-HSBlock
+
+  HsTy-ChainState = autoHsType ChainState ⊣ withConstructor "MkChainState"
+                                            • fieldPrefix "cs"
+  Conv-ChainState = autoConvert ChainState
+
+chain-step : HsType (⊤ → ChainState → Block → ComputationResult String ChainState)
+chain-step = to (compute Computational-CHAIN)
+
+{-# COMPILE GHC chain-step as chainStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/Chain.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Chain.lagda.md
@@ -49,9 +49,6 @@ record HSBlock : Type where
     bBodySize : ℕ
     bBodyHash : KeyHash
 
-postulate
-  trustMe-≡ : ∀ {a} {A : Type a} {x y : A} → x ≡ y
-
 open HSBlock
 
 convBlock : HSBlock → Block

--- a/src/Ledger/Dijkstra/Foreign/Enact.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Enact.lagda.md
@@ -1,0 +1,38 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Enact.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Enact where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Gov.Actions
+open import Ledger.Dijkstra.Specification.Enact DummyGovStructure
+open import Ledger.Dijkstra.Specification.Enact.Properties.Computational DummyGovStructure
+
+open Computational
+
+instance
+  HsTy-EnactEnv = autoHsType EnactEnv ⊣ withConstructor "MkEnactEnv"
+                                       • fieldPrefix "ee"
+  Conv-EnactEnv = autoConvert EnactEnv
+
+  HsTy-EnactState = autoHsType EnactState ⊣ withConstructor "MkEnactState"
+                                           • fieldPrefix "es"
+  Conv-EnactState = autoConvert EnactState
+
+enact-step : HsType (EnactEnv → EnactState → GovAction → ComputationResult String EnactState)
+enact-step = to (compute Computational-ENACT)
+
+{-# COMPILE GHC enact-step as enactStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/Epoch.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Epoch.lagda.md
@@ -1,0 +1,40 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Epoch.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Epoch where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Foreign.Enact
+open import Ledger.Dijkstra.Foreign.Gov
+open import Ledger.Dijkstra.Foreign.Ratify
+open import Ledger.Dijkstra.Foreign.Rewards
+open import Ledger.Dijkstra.Foreign.Utxo
+open import Ledger.Dijkstra.Foreign.Ledger
+open import Ledger.Dijkstra.Specification.Epoch it DummyAbstractFunctions
+open import Ledger.Dijkstra.Specification.Epoch.Properties.Computational it DummyAbstractFunctions
+
+open Computational
+
+instance
+  HsTy-EpochState = autoHsType EpochState ⊣ withConstructor "MkEpochState"
+                                            • fieldPrefix "eps"
+  Conv-EpochState = autoConvert EpochState
+
+epoch-step : HsType (⊤ → EpochState → Epoch → ComputationResult ⊥ EpochState)
+epoch-step = to (compute Computational-EPOCH)
+
+{-# COMPILE GHC epoch-step as epochStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/ExternalStructures.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/ExternalStructures.lagda.md
@@ -30,7 +30,7 @@ instance
   _ = HSScriptStructure
 
 module Crypto = CryptoStructure it
-open import Ledger.Dijkstra.Specification.PParams it it it hiding (Acnt; DrepThresholds; PoolThresholds)
+open import Ledger.Dijkstra.Specification.PParams it it (GlobalConstants.Network it) it it hiding (Acnt; DrepThresholds; PoolThresholds)
 
 HsGovParams : GovParams
 HsGovParams = record
@@ -75,7 +75,7 @@ instance
     ; AuxiliaryData   = ℕ
     ; epochStructure  = it
     ; globalConstants = it
-    ; crypto          = it
+    ; cryptoStructure = it
     ; govParams       = HsGovParams
     ; txidBytes       = id
     ; scriptStructure = it
@@ -86,7 +86,7 @@ instance
 
 open TransactionStructure HSTransactionStructure public
 open import Ledger.Dijkstra.Specification.Certs govStructure public
-open import Ledger.Dijkstra.Specification.Account govStructure public
+-- open import Ledger.Dijkstra.Specification.Account govStructure public
 
 open import Ledger.Dijkstra.Specification.Abstract it
 
@@ -117,7 +117,7 @@ instance
           λ x xs → Data.Fin.toℕ <$> findIndexᵇ (_== x) xs
       }
     ; scriptSize = λ where
-        (inj₁ x) → HSTimelock.tlScriptSize x
+        (inj₁ x) → HSNativeScript.nsScriptSize x
         (inj₂ x) → HSPlutusScript.psScriptSize x
     ; valContext = λ _ _ → zero
     }

--- a/src/Ledger/Dijkstra/Foreign/ExternalStructures.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/ExternalStructures.lagda.md
@@ -1,0 +1,138 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/ExternalStructures.lagda.md
+---
+```agda
+open import Ledger.Core.Foreign.ExternalFunctions
+
+module Ledger.Dijkstra.Foreign.ExternalStructures (externalFunctions : ExternalFunctions) where
+
+open import Data.Nat.Instances using (ℕ-≤-isDecTotalOrder)
+open import Relation.Binary.Bundles
+open import Data.Product.Relation.Binary.Lex.NonStrict using (×-isDecTotalOrder)
+open import Data.Sum.Relation.Binary.LeftOrder using (⊎-<-isDecTotalOrder)
+open import Tactic.Derive.Show
+import Data.Fin
+import Data.List.Sort
+
+open import Ledger.Prelude
+
+open import Ledger.Core.Foreign.Epoch
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Specification.Transaction public
+open import Ledger.Core.Foreign.Crypto externalFunctions
+open import Ledger.Dijkstra.Foreign.Script externalFunctions public
+
+instance
+  _ = HSCryptoStructure
+  _ = HSEpochStructure
+  _ = HSGlobalConstants
+  _ = HSScriptStructure
+
+module Crypto = CryptoStructure it
+open import Ledger.Dijkstra.Specification.PParams it it it hiding (Acnt; DrepThresholds; PoolThresholds)
+
+HsGovParams : GovParams
+HsGovParams = record
+  { ppUpd = let open PParamsDiff in λ where
+      .UpdateT      → PParamsUpdate
+      .updateGroups → modifiedUpdateGroups
+      .applyUpdate  → applyPParamsUpdate
+      .ppWF? {u}    → ppWF u
+  }
+  where
+    open PParamsUpdate
+    -- FIXME Replace `trustMe` with an actual proof
+    ppWF : (u : PParamsUpdate) →
+      ((pp : PParams) →
+      paramsWellFormed pp →
+      paramsWellFormed (applyPParamsUpdate pp u))
+      ⁇
+    ppWF u with paramsUpdateWellFormed? u
+    ... | yes _ = ⁇ (yes trustMe)
+      where
+        postulate
+          trustMe :
+            ((pp : PParams) →
+            paramsWellFormed pp →
+            paramsWellFormed (applyPParamsUpdate pp u))
+    ... | no _  = ⁇ (no trustMe)
+      where
+        postulate
+          trustMe :
+            ¬((pp : PParams) →
+            paramsWellFormed pp →
+            paramsWellFormed (applyPParamsUpdate pp u))
+
+open import Ledger.Conway.Specification.TokenAlgebra.Coin Crypto.ScriptHash
+   using (Coin-TokenAlgebra)
+
+instance
+  HSTransactionStructure : TransactionStructure
+  HSTransactionStructure = record
+    { TxId            = ℕ
+    ; Ix              = ℕ
+    ; AuxiliaryData   = ℕ
+    ; epochStructure  = it
+    ; globalConstants = it
+    ; crypto          = it
+    ; govParams       = HsGovParams
+    ; txidBytes       = id
+    ; scriptStructure = it
+    ; adHashingScheme = isHashableSet-ℕ
+    ; Hashable-ScriptIntegrity = record { hash = λ x → 0 }
+    ; tokenAlgebra    = Coin-TokenAlgebra
+    }
+
+open TransactionStructure HSTransactionStructure public
+open import Ledger.Dijkstra.Specification.Certs govStructure public
+open import Ledger.Dijkstra.Specification.Account govStructure public
+
+open import Ledger.Dijkstra.Specification.Abstract it
+
+instance
+  HSAbstractFunctions : AbstractFunctions
+  HSAbstractFunctions = record
+    { txScriptFee    = λ tt y → 0
+    ; serializedSize = λ v → 0
+    ; indexOfImp  = record
+      { indexOfDCert          =
+          λ x xs → Data.Fin.toℕ <$> findIndexᵇ (_== x) xs
+      ; indexOfRewardAddress  =
+          λ x xs →
+            Data.Fin.toℕ <$>
+            findIndexᵇ
+              (_== rewardAddressToSOP x)
+              (Data.List.Sort.sort
+                DecTotalOrder-RewardAddressSOP
+                (setToList $ mapˢ rewardAddressToSOP $ dom xs)
+              )
+
+      ; indexOfTxIn           = λ x xs → Data.Fin.toℕ <$> findIndexᵇ (_== x) (setToList xs)
+      ; indexOfPolicyId       = λ _ _ → nothing
+      ; indexOfVote           = λ _ _ → nothing
+      ; indexOfProposal       =
+          λ x xs → Data.Fin.toℕ <$> findIndexᵇ (==-GovProposal x) xs
+      ; indexOfGuard          =
+          λ x xs → Data.Fin.toℕ <$> findIndexᵇ (_== x) xs
+      }
+    ; scriptSize = λ where
+        (inj₁ x) → HSTimelock.tlScriptSize x
+        (inj₂ x) → HSPlutusScript.psScriptSize x
+    ; valContext = λ _ _ → zero
+    }
+   where
+    rewardAddressToSOP : RewardAddress → Network × (KeyHash ⊎ ScriptHash)
+    rewardAddressToSOP ra@(RewardAddress.constructor n (KeyHashObj k)) =
+      (n , inj₁ k)
+    rewardAddressToSOP ra@(RewardAddress.constructor n (ScriptObj s)) =
+      (n , inj₂ s)
+
+    DecTotalOrder-RewardAddressSOP : DecTotalOrder _ _ _
+    DecTotalOrder-RewardAddressSOP = record
+      { isDecTotalOrder =
+          ×-isDecTotalOrder
+            ℕ-≤-isDecTotalOrder
+            (⊎-<-isDecTotalOrder ℕ-≤-isDecTotalOrder ℕ-≤-isDecTotalOrder)
+      }
+```

--- a/src/Ledger/Dijkstra/Foreign/Gov.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Gov.lagda.md
@@ -1,0 +1,135 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Gov.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Gov where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Foreign.Enact
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Gov.Core
+open import Ledger.Dijkstra.Foreign.Gov.Actions
+open import Ledger.Dijkstra.Specification.Gov DummyGovStructure as Gov
+open import Ledger.Dijkstra.Specification.Gov.Properties.Computational it
+
+open Computational
+
+-- NeedsHash depends on a GovAction, so a little bit of manual work is
+-- required to get the types using it into Haskell.
+
+-- First we define to/fromNeedsHash that replaces the ⊤ cases by a
+-- dummy GovActionID.
+
+toNeedsHash : ∀ {action} → GovActionID → NeedsHash action
+toNeedsHash {NoConfidence}        x = x
+toNeedsHash {UpdateCommittee}     x = x
+toNeedsHash {NewConstitution}     x = x
+toNeedsHash {TriggerHardFork}     x = x
+toNeedsHash {ChangePParams}       x = x
+toNeedsHash {TreasuryWithdrawal}  x = tt
+toNeedsHash {Info}                x = tt
+
+fromNeedsHash : ∀ {action} → NeedsHash action → GovActionID
+fromNeedsHash {NoConfidence}        x = x
+fromNeedsHash {UpdateCommittee}     x = x
+fromNeedsHash {NewConstitution}     x = x
+fromNeedsHash {TriggerHardFork}     x = x
+fromNeedsHash {ChangePParams}       x = x
+fromNeedsHash {TreasuryWithdrawal}  x = 0 , 0
+fromNeedsHash {Info}                x = 0 , 0
+
+-- Then we define non-dependent versions of the types that use
+-- NeedsHash.
+
+record GovProposal' : Type where
+  field
+    action      : GovAction'
+    prevAction  : GovActionID       -- NeedsHash action
+    policy      : Maybe ScriptHash
+    deposit     : Coin
+    returnAddr  : RewardAddress
+    anchor      : Anchor
+
+-- We can convert between the dependent and non-dependent versions
+-- using to/fromNeedsHash.
+
+private
+  mkGovProposal' : Convertible GovProposal GovProposal'
+  mkGovProposal' = λ where
+    .to   p → let module p = GovProposal  p in record { p; action = to p.action  ; prevAction = fromNeedsHash p.prevAction }
+    .from p → let module p = GovProposal' p in record { p; action = from p.action; prevAction = toNeedsHash   p.prevAction }
+
+-- Auto-generated conversions for the non-dependent types
+
+instance
+  HsTy-GovProposal' = autoHsType GovProposal' ⊣ withName "GovProposal"
+                                              • withConstructor "MkGovProposal"
+                                              • fieldPrefix "gp"
+  Conv-GovProposal' = autoConvert GovProposal'
+
+  HsTy-GovProposal = MkHsType GovProposal (HsType GovProposal')
+  Conv-GovProposal = mkGovProposal' ⨾ Conv-GovProposal'
+
+-- GovActionState also has a dependent prevAction field.
+
+record GovActionState' : Type where
+  field
+    votes       : GovVotes
+    returnAddr  : RewardAddress
+    expiresIn   : Epoch
+    action      : GovAction'
+    prevAction  : GovActionID
+
+private
+  mkGovActionState' : Convertible GovActionState GovActionState'
+  mkGovActionState' = λ where
+    .to   s → let module s = GovActionState s in
+      record { votes = s.votes ; returnAddr = s.returnAddr ; expiresIn = s.expiresIn
+             ; action = to s.action ; prevAction = fromNeedsHash s.prevAction }
+    .from s → let module s = GovActionState' s in
+      record { votes = s.votes ; returnAddr = s.returnAddr ; expiresIn = s.expiresIn
+             ; action = from s.action ; prevAction = toNeedsHash s.prevAction }
+
+instance
+  HsTy-GovActionState' = autoHsType GovActionState' ⊣ withName "GovActionState"
+                                                     • withConstructor "MkGovActionState"
+                                                     • fieldPrefix "gas"
+  Conv-GovActionState' = autoConvert GovActionState'
+
+  HsTy-GovActionState = MkHsType GovActionState (HsType GovActionState')
+  Conv-GovActionState = mkGovActionState' ⨾ Conv-GovActionState'
+
+-- GovEnv has no dependent types, so autoHsType works directly.
+
+  HsTy-GovEnv = autoHsType Gov.GovEnv ⊣ withConstructor "MkGovEnv"
+                                       • fieldPrefix "ge"
+  Conv-GovEnv = autoConvert Gov.GovEnv
+
+unquoteDecl = do
+  hsTypeAlias GovActionID
+  hsTypeAlias GovState
+  hsTypeAlias GovVoter'
+
+-- Computational step functions
+
+gov-step : HsType (GovEnv × ℕ → GovState → GovVote ⊎ GovProposal → ComputationResult String GovState)
+gov-step = to (compute Computational-GOV)
+
+{-# COMPILE GHC gov-step as govStep #-}
+
+govs-step : HsType (GovEnv → GovState → List (GovVote ⊎ GovProposal) → ComputationResult String GovState)
+govs-step = to (compute Computational-GOVS)
+
+{-# COMPILE GHC govs-step as govsStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/Gov/Actions.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Gov/Actions.lagda.md
@@ -1,0 +1,55 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Gov/Actions.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Gov.Actions where
+
+open import Data.Rational using (ℚ)
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Core.Foreign.Address
+open import Ledger.Core.Specification.ProtocolVersion
+
+-- nondependent version of GovAction
+data GovAction' : Type where
+  NoConfidence        :                                             GovAction'
+  UpdateCommittee     : (Credential ⇀ Epoch) → ℙ Credential → ℚ  →  GovAction'
+  NewConstitution     : ADHash → Maybe ScriptHash               →  GovAction'
+  TriggerHardFork     : ProtVer                                  →  GovAction'
+  ChangePParams       : PParamsUpdate                            →  GovAction'
+  TreasuryWithdrawal  : (RewardAddress ⇀ Treasury)               →  GovAction'
+  Info                :                                             GovAction'
+
+instance
+  mkGovAction' : Convertible GovAction GovAction'
+  mkGovAction' = λ where
+    .to ⟦ NoConfidence        , _           ⟧ᵍᵃ → NoConfidence
+    .to ⟦ UpdateCommittee     , (m , s , q) ⟧ᵍᵃ → UpdateCommittee m s q
+    .to ⟦ NewConstitution     , (h , s)     ⟧ᵍᵃ → NewConstitution h s
+    .to ⟦ TriggerHardFork     , v           ⟧ᵍᵃ → TriggerHardFork v
+    .to ⟦ ChangePParams       , u           ⟧ᵍᵃ → ChangePParams u
+    .to ⟦ TreasuryWithdrawal  , w           ⟧ᵍᵃ → TreasuryWithdrawal w
+    .to ⟦ Info                , _           ⟧ᵍᵃ → Info
+    .from NoConfidence              → ⟦ NoConfidence        , tt          ⟧ᵍᵃ
+    .from (UpdateCommittee m s q)   → ⟦ UpdateCommittee     , (m , s , q) ⟧ᵍᵃ
+    .from (NewConstitution h s)     → ⟦ NewConstitution     , (h , s)     ⟧ᵍᵃ
+    .from (TriggerHardFork v)       → ⟦ TriggerHardFork     , v           ⟧ᵍᵃ
+    .from (ChangePParams u)         → ⟦ ChangePParams       , u           ⟧ᵍᵃ
+    .from (TreasuryWithdrawal w)    → ⟦ TreasuryWithdrawal  , w           ⟧ᵍᵃ
+    .from Info                      → ⟦ Info                , tt          ⟧ᵍᵃ
+
+  HsTy-GovAction' = autoHsType GovAction' ⊣ withName "GovAction"
+  Conv-GovAction' = autoConvert GovAction'
+
+  HsTy-GovAction = MkHsType GovAction (HsType GovAction')
+  Conv-GovAction = mkGovAction' ⨾ Conv-GovAction'
+```

--- a/src/Ledger/Dijkstra/Foreign/Gov/Core.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Gov/Core.lagda.md
@@ -1,0 +1,77 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Gov/Core.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Gov.Core where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+open import Ledger.Prelude.Foreign.Util
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures hiding (Vote)
+open import Ledger.Dijkstra.Specification.Gov.Actions DummyGovStructure using (Vote)
+
+instance
+  HsTy-GovRole = autoHsType GovRole
+  Conv-GovRole = autoConvert GovRole
+
+  HsTy-Anchor = autoHsType Anchor
+  Conv-Anchor = autoConvert Anchor
+
+  HsTy-VDeleg = autoHsType VDeleg
+  Conv-VDeleg = autoConvert VDeleg
+
+  HsTy-Vote = autoHsType Vote
+  Conv-Vote = autoConvert Vote
+
+  HsTy-GovVotes = autoHsType GovVotes
+  Conv-GovVotes = autoConvert GovVotes
+
+GovVoter' : Type
+GovVoter' = GovRole × Credential
+
+instance
+  mkGovVoter' : Convertible GovVoter GovVoter'
+  mkGovVoter' .to ⟦ CC   , c ⟧ᵍᵛ = CC   , c
+  mkGovVoter' .to ⟦ DRep , c ⟧ᵍᵛ = DRep , c
+  mkGovVoter' .to ⟦ SPO  , c ⟧ᵍᵛ = SPO  , KeyHashObj c
+  mkGovVoter' .from (CC   , c)   = ⟦ CC   , c ⟧ᵍᵛ
+  mkGovVoter' .from (DRep , c)   = ⟦ DRep , c ⟧ᵍᵛ
+  mkGovVoter' .from (SPO  , c)   =
+    case c of λ where
+      (KeyHashObj kh) → ⟦ SPO , kh ⟧ᵍᵛ
+      (ScriptObj _)   → error "mkGovVoter: Converting from SPO with ScriptObj credential"
+
+  HsTy-GovVoter = MkHsType GovVoter (HsType GovVoter')
+  Conv-GovVoter : Convertible GovVoter (HsType GovVoter')
+  Conv-GovVoter = mkGovVoter' ⨾ Convertible-Pair
+
+unquoteDecl = do
+  hsTypeAlias GovVoter
+
+record GovVote' : Type where
+  field
+    gid         : GovActionID
+    voter       : GovVoter'
+    vote        : Vote
+    anchor      : Maybe Anchor
+
+instance
+  mkGovVote' : Convertible GovVote GovVote'
+  mkGovVote' = λ where
+    .to v   → let module v = GovVote v in record { gid = v.gid ; voter = to v.voter  ; vote = v.vote ; anchor = v.anchor }
+    .from v → let module v = GovVote' v in record { gid = v.gid ; voter = from v.voter ; vote = v.vote ; anchor = v.anchor }
+
+  HsTy-GovVote' = autoHsType GovVote' ⊣ withConstructor "MkGovVote"
+                                      • withName "GovVote"
+  Conv-GovVote' = autoConvert GovVote'
+
+  HsTy-GovVote = MkHsType GovVote (HsType GovVote')
+  Conv-GovVote = mkGovVote' ⨾ Conv-GovVote'
+```

--- a/src/Ledger/Dijkstra/Foreign/HSStructures.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/HSStructures.lagda.md
@@ -1,0 +1,12 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/HSStructures.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.HSStructures where
+
+open import Ledger.Core.Foreign.ExternalFunctions
+open import Ledger.Dijkstra.Foreign.ExternalStructures dummyExternalFunctions
+  renaming (HSTransactionStructure to DummyTransactionStructure; HSAbstractFunctions to DummyAbstractFunctions; govStructure to DummyGovStructure)
+  public
+```

--- a/src/Ledger/Dijkstra/Foreign/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Ledger.lagda.md
@@ -1,0 +1,51 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Ledger.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Ledger where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Foreign.Enact
+open import Ledger.Dijkstra.Foreign.Gov
+open import Ledger.Dijkstra.Foreign.Utxo
+open import Ledger.Dijkstra.Foreign.Transaction
+open import Ledger.Dijkstra.Specification.Ledger it DummyAbstractFunctions
+open import Ledger.Dijkstra.Specification.Ledger.Properties.Computational it DummyAbstractFunctions
+
+open Computational
+
+instance
+  HsTy-SubLedgerEnv = autoHsType SubLedgerEnv ⊣ withConstructor "MkSubLedgerEnv"
+                                                • fieldPrefix "sle"
+  Conv-SubLedgerEnv = autoConvert SubLedgerEnv
+
+  HsTy-LedgerEnv = autoHsType LedgerEnv ⊣ withConstructor "MkLedgerEnv"
+                                          • fieldPrefix "le"
+  Conv-LedgerEnv = autoConvert LedgerEnv
+
+  HsTy-LedgerState = autoHsType LedgerState ⊣ withConstructor "MkLedgerState"
+                                              • fieldPrefix "ls"
+  Conv-LedgerState = autoConvert LedgerState
+
+ledger-step : HsType (LedgerEnv → LedgerState → Tx TxLevelTop → ComputationResult String LedgerState)
+ledger-step = to (compute Computational-LEDGER)
+
+{-# COMPILE GHC ledger-step as ledgerStep #-}
+
+ledgers-step : HsType (LedgerEnv → LedgerState → List (Tx TxLevelTop) → ComputationResult String LedgerState)
+ledgers-step = to (compute Computational-LEDGERS)
+
+{-# COMPILE GHC ledgers-step as ledgersStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/NewEpoch.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/NewEpoch.lagda.md
@@ -1,0 +1,33 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/NewEpoch.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.NewEpoch where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.Epoch
+open import Ledger.Dijkstra.Foreign.Rewards
+open import Ledger.Dijkstra.Specification.Epoch it DummyAbstractFunctions
+open import Ledger.Dijkstra.Specification.Epoch.Properties.Computational it DummyAbstractFunctions
+
+open Computational
+
+instance
+  HsTy-NewEpochState = autoHsType NewEpochState ⊣ withConstructor "MkNewEpochState"
+                                                  • fieldPrefix "nes"
+  Conv-NewEpochState = autoConvert NewEpochState
+
+newepoch-step : HsType (⊤ → NewEpochState → Epoch → ComputationResult ⊥ NewEpochState)
+newepoch-step = to (compute Computational-NEWEPOCH)
+
+{-# COMPILE GHC newepoch-step as newEpochStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/PParams.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/PParams.lagda.md
@@ -1,0 +1,40 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/PParams.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.PParams where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Dijkstra.Foreign.HSStructures
+
+instance
+  HsTy-LanguageCostModels = autoHsType LanguageCostModels ⊣ withConstructor "MkLanguageCostModels"
+                                                          • fieldPrefix "lcm"
+  Conv-LanguageCostModels = autoConvert LanguageCostModels
+
+  HsTy-DrepThresholds = autoHsType DrepThresholds
+    ⊣ withConstructor "MkDrepThresholds"
+  Conv-DrepThresholds = autoConvert DrepThresholds
+
+  HsTy-PoolThresholds = autoHsType PoolThresholds
+    ⊣ withConstructor "MkPoolThresholds"
+  Conv-PoolThresholds = autoConvert PoolThresholds
+
+  HsTy-Acnt = autoHsType Acnt ⊣ withConstructor "MkAcnt"
+  Conv-Acnt = autoConvert Acnt
+
+  HsTy-PParams = autoHsType PParams ⊣ withConstructor "MkPParams"
+                                    • fieldPrefix "pp"
+  Conv-PParams = autoConvert PParams
+
+  HsTy-PParamsUpdate = autoHsType PParamsUpdate.PParamsUpdate ⊣ withConstructor "MkPParamsUpdate"
+                                                              • fieldPrefix "ppu"
+  Conv-PParamsUpdate = autoConvert PParamsUpdate.PParamsUpdate
+```

--- a/src/Ledger/Dijkstra/Foreign/Ratify.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Ratify.lagda.md
@@ -1,0 +1,50 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Ratify.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Ratify where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Foreign.Enact
+open import Ledger.Dijkstra.Foreign.Gov.Core
+open import Ledger.Dijkstra.Foreign.Gov
+open import Ledger.Dijkstra.Specification.Ratify DummyGovStructure
+open import Ledger.Dijkstra.Specification.Ratify.Properties.Computational it
+
+open Computational
+
+instance
+  HsTy-StakeDistrs = autoHsType StakeDistrs ⊣ withConstructor "MkStakeDistrs"
+                                              • fieldPrefix "sd"
+  Conv-StakeDistrs = autoConvert StakeDistrs
+
+  HsTy-RatifyEnv = autoHsType RatifyEnv ⊣ withConstructor "MkRatifyEnv"
+                                          • fieldPrefix "re"
+  Conv-RatifyEnv = autoConvert RatifyEnv
+
+  HsTy-RatifyState = autoHsType RatifyState ⊣ withConstructor "MkRatifyState"
+                                              • fieldPrefix "rs"
+  Conv-RatifyState = autoConvert RatifyState
+
+ratify-step : HsType (RatifyEnv → RatifyState → GovActionID × GovActionState → ComputationResult ⊥ RatifyState)
+ratify-step = to (compute Computational-RATIFY)
+
+{-# COMPILE GHC ratify-step as ratifyStep #-}
+
+ratifies-step : HsType (RatifyEnv → RatifyState → List (GovActionID × GovActionState) → ComputationResult ⊥ RatifyState)
+ratifies-step = to (compute Computational-RATIFIES)
+
+{-# COMPILE GHC ratifies-step as ratifiesStep #-}
+```

--- a/src/Ledger/Dijkstra/Foreign/Rewards.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Rewards.lagda.md
@@ -1,0 +1,71 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Rewards.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Rewards where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Specification.Rewards it DummyAbstractFunctions
+
+instance
+  HsTy-Snapshot = autoHsType Snapshot ⊣ withConstructor "MkSnapshot"
+                                       • fieldPrefix "ss"
+  Conv-Snapshot = autoConvert Snapshot
+
+  HsTy-Snapshots = autoHsType Snapshots ⊣ withConstructor "MkSnapshots"
+  Conv-Snapshots = autoConvert Snapshots
+
+record HsRewardUpdate : Type where
+  field
+    Δt Δr Δf  : ℤ
+    rs        : Stake
+
+open import Data.Integer using (ℤ) renaming (+_ to pos; _≤_ to _≤ℤ_)
+
+instance
+  iHsTy-ℤ : HasHsType ℤ
+  iHsTy-ℤ = MkHsType ℤ ℤ
+  iConv-ℤ : Convertible ℤ ℤ
+  iConv-ℤ = Convertible-Refl
+
+postulate
+  trustMe-flowConservation : ∀ {Δt Δr Δf : ℤ} {rs : Stake} → Δt + Δr + Δf + pos (∑[ c ← rs ] c) ≡ pos 0
+  trustMe-nonneg : ∀ {x : ℤ} → pos 0 ≤ℤ x
+  trustMe-nonpos : ∀ {x : ℤ} → x ≤ℤ pos 0
+
+private
+  mkHsRewardUpdate : Convertible RewardUpdate HsRewardUpdate
+  mkHsRewardUpdate = λ where
+    .to   ru → let module ru = RewardUpdate ru in
+      record { Δt = ru.Δt ; Δr = ru.Δr ; Δf = ru.Δf ; rs = ru.rs }
+    .from ru → let module ru = HsRewardUpdate ru in
+      record { Δt = ru.Δt ; Δr = ru.Δr ; Δf = ru.Δf ; rs = ru.rs
+             ; flowConservation = trustMe-flowConservation {ru.Δt} {ru.Δr} {ru.Δf} {ru.rs}
+             ; Δt-nonnegative   = trustMe-nonneg {ru.Δt}
+             ; Δf-nonpositive   = trustMe-nonpos {ru.Δf}
+             }
+
+instance
+  HsTy-HsRewardUpdate = autoHsType HsRewardUpdate ⊣ withName "RewardUpdate"
+                                                    • withConstructor "MkRewardUpdate"
+                                                    • fieldPrefix "ru"
+  Conv-HsRewardUpdate = autoConvert HsRewardUpdate
+
+  HsTy-RewardUpdate = MkHsType RewardUpdate (HsType HsRewardUpdate)
+  Conv-RewardUpdate = mkHsRewardUpdate ⨾ Conv-HsRewardUpdate
+
+unquoteDecl = do
+  hsTypeAlias BlocksMade ⊣ withName "BlocksMade"
+```

--- a/src/Ledger/Dijkstra/Foreign/Script.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Script.lagda.md
@@ -1,0 +1,14 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Script.lagda.md
+---
+```agda
+open import Ledger.Core.Foreign.ExternalFunctions
+
+module Ledger.Dijkstra.Foreign.Script
+  (externalFunctions : ExternalFunctions)
+  where
+
+open import Ledger.Dijkstra.Foreign.Script.Base public
+open import Ledger.Dijkstra.Foreign.Script.Structure externalFunctions public
+```

--- a/src/Ledger/Dijkstra/Foreign/Script/Base.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Script/Base.lagda.md
@@ -1,0 +1,26 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Script/Base.lagda.md
+---
+```agda
+
+module Ledger.Dijkstra.Foreign.Script.Base
+  where
+
+open import Foreign.HaskellTypes.Deriving
+open import Foreign.Convertible.Deriving
+open import Tactic.Derive.Show
+
+open import Ledger.Prelude
+
+data HSLanguage : Type where
+  PV1 PV2 PV3 PV4 : HSLanguage
+
+instance
+  HsType-HSLanguage = autoHsType HSLanguage
+  Convert-HSLanguage = autoConvert HSLanguage
+
+instance
+  unquoteDecl DecEq-HSLanguage = derive-DecEq ((quote HSLanguage , DecEq-HSLanguage) ∷ [])
+  unquoteDecl Show-HSLanguage = derive-Show ((quote HSLanguage , Show-HSLanguage) ∷ [])
+```

--- a/src/Ledger/Dijkstra/Foreign/Script/Structure.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Script/Structure.lagda.md
@@ -28,25 +28,25 @@ instance
   _ = HSEpochStructure
   _ = HSGlobalConstants
 
-open import Ledger.Dijkstra.Specification.Script.Base it it
-open import Ledger.Conway.Specification.Script.Timelock it it
+open import Ledger.Dijkstra.Specification.Script.Base it it (GlobalConstants.Network it) it
+open import Ledger.Dijkstra.Specification.Script.Native it it (GlobalConstants.Network it) it
 
-record HSTimelock : Type where
+record HSNativeScript : Type where
   field
-    timelock     : Timelock
-    tlScriptHash : ℕ
-    tlScriptSize : ℕ
+    nativeScript : NativeScript
+    nsScriptHash  : ℕ
+    nsScriptSize  : ℕ
 
 instance
-  Hashable-HSTimelock : Hashable HSTimelock ℕ
-  Hashable-HSTimelock .hash = HSTimelock.tlScriptHash
+  Hashable-HSNativeScript : Hashable HSNativeScript ℕ
+  Hashable-HSNativeScript .hash = HSNativeScript.nsScriptHash
 
-unquoteDecl DecEq-HSTimelock = derive-DecEq ((quote HSTimelock , DecEq-HSTimelock) ∷ [])
+unquoteDecl DecEq-HSNativeScript = derive-DecEq ((quote HSNativeScript , DecEq-HSNativeScript) ∷ [])
 
 HSP1ScriptStructure : P1ScriptStructure
 HSP1ScriptStructure = record
-  { P1Script = HSTimelock
-  ; validP1Script = λ x y → evalTimelock x y ∘ HSTimelock.timelock }
+  { P1Script = HSNativeScript
+  ; validP1Script = λ x y z → EvalNativeScript x y z ∘ HSNativeScript.nativeScript }
 
 record HSPlutusScript : Type where
   constructor MkHSPlutusScript

--- a/src/Ledger/Dijkstra/Foreign/Script/Structure.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Script/Structure.lagda.md
@@ -1,0 +1,103 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Script/Structure.lagda.md
+---
+```agda
+open import Ledger.Core.Foreign.ExternalFunctions
+
+module Ledger.Dijkstra.Foreign.Script.Structure
+  (externalFunctions : ExternalFunctions)
+  where
+
+open import Algebra.Construct.DirectProduct using (commutativeMonoid)
+open import Algebra.Morphism    using (module MonoidMorphisms)
+open import Data.Nat.Properties using (+-0-commutativeMonoid)
+open import Foreign.HaskellTypes.Deriving
+open import Foreign.Convertible.Deriving
+open import Tactic.Derive.Show
+
+open import Ledger.Prelude
+
+open import Ledger.Core.Foreign.Crypto as Crypto
+open import Ledger.Core.Foreign.Crypto
+open import Ledger.Core.Foreign.Epoch
+open import Ledger.Dijkstra.Foreign.Script.Base
+
+instance
+  _ = HSCryptoStructure externalFunctions
+  _ = HSEpochStructure
+  _ = HSGlobalConstants
+
+open import Ledger.Dijkstra.Specification.Script.Base it it
+open import Ledger.Conway.Specification.Script.Timelock it it
+
+record HSTimelock : Type where
+  field
+    timelock     : Timelock
+    tlScriptHash : ℕ
+    tlScriptSize : ℕ
+
+instance
+  Hashable-HSTimelock : Hashable HSTimelock ℕ
+  Hashable-HSTimelock .hash = HSTimelock.tlScriptHash
+
+unquoteDecl DecEq-HSTimelock = derive-DecEq ((quote HSTimelock , DecEq-HSTimelock) ∷ [])
+
+HSP1ScriptStructure : P1ScriptStructure
+HSP1ScriptStructure = record
+  { P1Script = HSTimelock
+  ; validP1Script = λ x y → evalTimelock x y ∘ HSTimelock.timelock }
+
+record HSPlutusScript : Type where
+  constructor MkHSPlutusScript
+  field psScriptHash : ℕ
+        psScriptSize : ℕ
+        psScriptLanguage : HSLanguage
+
+private
+  fromPlutusLanguage : PlutusLanguage ↣ HSLanguage
+  fromPlutusLanguage .Injection.to V1 = PV1
+  fromPlutusLanguage .Injection.to V2 = PV2
+  fromPlutusLanguage .Injection.to V3 = PV3
+  fromPlutusLanguage .Injection.to V4 = PV4
+  fromPlutusLanguage .Injection.cong = cong _
+  fromPlutusLanguage .Injection.injective {V1} {y = V1} p = refl
+  fromPlutusLanguage .Injection.injective {V2} {y = V2} p = refl
+  fromPlutusLanguage .Injection.injective {V3} {y = V3} p = refl
+  fromPlutusLanguage .Injection.injective {V4} {y = V4} p = refl
+
+HSP2ScriptStructure : PlutusStructure
+HSP2ScriptStructure = record {
+    Dataʰ = HashableSet-ℕ
+  ; CostModel = ⊤
+  ; Prices = ⊤
+  ; LangDepView = ⊤
+  ; ExUnits = ℕ × ℕ
+  ; Language = HSLanguage
+  ; fromPlutusLanguage = fromPlutusLanguage 
+  ; language = λ z → HSPlutusScript.psScriptLanguage z
+  ; validPlutusScript = λ _ _ _ _ → extValidPlutusScript ≡ true
+  ; PlutusScript = HSPlutusScript
+  ; _≥ᵉ_ = _≡_
+  }
+  where
+    open ExternalFunctions externalFunctions
+    instance
+      Hashable-HSPlutusScript : Hashable HSPlutusScript ℕ
+      Hashable-HSPlutusScript .hash = HSPlutusScript.psScriptHash
+      _ = Conversion.fromBundle (commutativeMonoid +-0-commutativeMonoid +-0-commutativeMonoid)
+      _ = Show-×
+
+HSScriptStructure : ScriptStructure
+HSScriptStructure = record
+  { p1s = HSP1ScriptStructure
+  ; hashRespectsUnion = hashRespectsUnion
+  ; ps = HSP2ScriptStructure
+  }
+  where
+    hashRespectsUnion : ∀ {A B ℍ}
+      → Hashable A ℍ → Hashable B ℍ
+      → Hashable (A ⊎ B) ℍ
+    hashRespectsUnion a _ .hash (inj₁ x) = hash ⦃ a ⦄ x
+    hashRespectsUnion _ b .hash (inj₂ y) = hash ⦃ b ⦄ y
+```

--- a/src/Ledger/Dijkstra/Foreign/Transaction.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Transaction.lagda.md
@@ -27,13 +27,13 @@ instance
   HsTy-Tag = autoHsType Tag ⊣ withName "Tag"
   Conv-Tag = autoConvert Tag
 
--- Timelock and script types
-  HsTy-Timelock = autoHsType Timelock
+instance
+  HsTy-NativeScript = autoHsType NativeScript
   {-# TERMINATING #-}
-  Conv-Timelock = autoConvert Timelock
+  Conv-NativeScript = autoConvert NativeScript
 
-  HsTy-HSTimelock = autoHsType HSTimelock
-  Conv-HSTimelock = autoConvert HSTimelock
+  HsTy-HSNativeScript = autoHsType HSNativeScript
+  Conv-HSNativeScript = autoConvert HSNativeScript
 
   HsTy-HSPlutusScript = autoHsType HSPlutusScript
   Conv-HSPlutusScript = autoConvert HSPlutusScript

--- a/src/Ledger/Dijkstra/Foreign/Transaction.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Transaction.lagda.md
@@ -1,0 +1,186 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Transaction.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Transaction where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+import Data.String as S
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Core.Foreign.Crypto.Base
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Foreign.Gov.Core
+open import Ledger.Dijkstra.Foreign.Gov
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Account
+
+instance
+  HsTy-Tag = autoHsType Tag ⊣ withName "Tag"
+  Conv-Tag = autoConvert Tag
+
+-- Timelock and script types
+  HsTy-Timelock = autoHsType Timelock
+  {-# TERMINATING #-}
+  Conv-Timelock = autoConvert Timelock
+
+  HsTy-HSTimelock = autoHsType HSTimelock
+  Conv-HSTimelock = autoConvert HSTimelock
+
+  HsTy-HSPlutusScript = autoHsType HSPlutusScript
+  Conv-HSPlutusScript = autoConvert HSPlutusScript
+
+  HsTy-TxWitnesses = autoHsType TxWitnesses ⊣ withConstructor "MkTxWitnesses"
+                                              • fieldPrefix "txw"
+  Conv-TxWitnesses = autoConvert TxWitnesses
+
+unquoteDecl = do
+  hsTypeAlias Redeemer
+  hsTypeAlias RedeemerPtr
+
+record TxBodySub : Type where
+  field
+    txIns                : ℙ TxIn
+    referenceInputs      : ℙ TxIn
+    txOuts               : Ix ⇀ TxOut
+    txId                 : TxId
+    txCerts              : List DCert
+    txWithdrawals        : Withdrawals
+    txVldt               : Maybe Slot × Maybe Slot
+    txADhash             : Maybe ADHash
+    txDonation           : Donations
+    txGovVotes           : List GovVote
+    txGovProposals       : List GovProposal
+    txNetworkId          : Maybe Network
+    currentTreasury      : Maybe Coin
+    mint                 : Value
+    scriptIntegrityHash  : Maybe ScriptHash
+    txGuards                  : ℙ Credential
+    txRequiredTopLevelGuards  : ℙ (Credential × Maybe Datum)
+    txDirectDeposits          : DirectDeposits
+    txBalanceIntervals        : AccountBalanceIntervals
+
+instance
+  convTxBodySub : Convertible (TxBody TxLevelSub) TxBodySub
+  convTxBodySub = λ where
+    .to   b → record { TxBody b }
+    .from b → record { TxBodySub b }
+
+  HsTy-TxBodySub = autoHsType TxBodySub ⊣ withConstructor "MkTxBodySub"
+                                        • fieldPrefix "txbsub"
+  Conv-TxBodySub' = autoConvert TxBodySub
+
+  HsTy-TxBodySub' : HasHsType (TxBody TxLevelSub)
+  HsTy-TxBodySub' = MkHsType (TxBody TxLevelSub) (HsType TxBodySub)
+  Conv-TxBodySub'' : Convertible (TxBody TxLevelSub) (HsType TxBodySub)
+  Conv-TxBodySub'' = convTxBodySub ⨾ Conv-TxBodySub'
+
+record TxSub : Type where
+  field
+    txBody       : TxBody TxLevelSub
+    txWitnesses  : TxWitnesses
+    txSize       : ℕ
+    isValid      : ⊤
+    txAuxData    : Maybe AuxiliaryData
+
+instance
+  convTxSub : Convertible (Tx TxLevelSub) TxSub
+  convTxSub = λ where
+    .to   t → record { Tx t }
+    .from t → record { TxSub t }
+
+  HsTy-TxSub = autoHsType TxSub ⊣ withConstructor "MkTxSub"
+                                • fieldPrefix "txsub"
+  Conv-TxSub' = autoConvert TxSub
+
+  HsTy-TxSub' : HasHsType (Tx TxLevelSub)
+  HsTy-TxSub' = MkHsType (Tx TxLevelSub) (HsType TxSub)
+  Conv-TxSub'' : Convertible (Tx TxLevelSub) (HsType TxSub)
+  Conv-TxSub'' = convTxSub ⨾ Conv-TxSub'
+
+record TxBodyTop : Type where
+  field
+    txIns               : ℙ TxIn
+    referenceInputs     : ℙ TxIn
+    collateralInputs    : ℙ TxIn
+    txOuts              : Ix ⇀ TxOut
+    txId                : TxId
+    txCerts             : List DCert
+    txFee               : Fees
+    txWithdrawals       : Withdrawals
+    txVldt              : Maybe Slot × Maybe Slot
+    txADhash            : Maybe ADHash
+    txDonation          : Donations
+    txGovVotes          : List GovVote
+    txGovProposals      : List GovProposal
+    txNetworkId         : Maybe Network
+    currentTreasury     : Maybe Coin
+    mint                : Value
+    scriptIntegrityHash : Maybe ScriptHash
+    txSubTransactions   : List (Tx TxLevelSub)
+    txGuards            : ℙ Credential
+    txDirectDeposits    : DirectDeposits
+    txBalanceIntervals  : AccountBalanceIntervals
+
+instance
+  convTxBodyTop : Convertible (TxBody TxLevelTop) TxBodyTop
+  convTxBodyTop = λ where
+    .to   b → record { TxBody b }
+    .from b → record { TxBodyTop b }
+
+  HsTy-TxBodyTop = autoHsType TxBodyTop ⊣ withConstructor "MkTxBodyTop"
+                                        • fieldPrefix "txbtop"
+  Conv-TxBodyTop' = autoConvert TxBodyTop
+
+  HsTy-TxBodyTop' : HasHsType (TxBody TxLevelTop)
+  HsTy-TxBodyTop' = MkHsType (TxBody TxLevelTop) (HsType TxBodyTop)
+  Conv-TxBodyTop'' : Convertible (TxBody TxLevelTop) (HsType TxBodyTop)
+  Conv-TxBodyTop'' = convTxBodyTop ⨾ Conv-TxBodyTop'
+
+record TxTop : Type where
+  field
+    txBody       : TxBody TxLevelTop
+    txWitnesses  : TxWitnesses
+    txSize       : ℕ
+    isValid      : Bool
+    txAuxData    : Maybe AuxiliaryData
+
+instance
+  convTxTop : Convertible (Tx TxLevelTop) TxTop
+  convTxTop = λ where
+    .to   t → record { Tx t }
+    .from t → record { TxTop t }
+
+  HsTy-TxTop = autoHsType TxTop ⊣ withConstructor "MkTxTop"
+                                • fieldPrefix "txtop"
+  Conv-TxTop' = autoConvert TxTop
+
+  HsTy-TxTop' : HasHsType (Tx TxLevelTop)
+  HsTy-TxTop' = MkHsType (Tx TxLevelTop) (HsType TxTop)
+  Conv-TxTop'' : Convertible (Tx TxLevelTop) (HsType TxTop)
+  Conv-TxTop'' = convTxTop ⨾ Conv-TxTop'
+
+unquoteDecl = do
+  hsTypeAlias TxId
+  hsTypeAlias Ix
+  hsTypeAlias TxIn
+  hsTypeAlias ExUnits
+  hsTypeAlias P1Script
+  hsTypeAlias P2Script ⊣ withName "P2Script"
+  hsTypeAlias Script
+  hsTypeAlias Datum
+  hsTypeAlias DataHash ⊣ withName "DataHash"
+  hsTypeAlias Value
+  hsTypeAlias TxOut
+  hsTypeAlias ScriptHash
+  hsTypeAlias AuxiliaryData
+  hsTypeAlias Withdrawals
+```

--- a/src/Ledger/Dijkstra/Foreign/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Utxo.lagda.md
@@ -1,0 +1,65 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Utxo.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Utxo where
+
+open import Data.Integer using (ℤ)
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Foreign.Gov
+open import Ledger.Dijkstra.Foreign.Rewards
+open import Ledger.Dijkstra.Foreign.Transaction
+open import Ledger.Dijkstra.Specification.Utxo it DummyAbstractFunctions
+open import Ledger.Dijkstra.Specification.Utxow.Properties.Computational it DummyAbstractFunctions
+open import Ledger.Dijkstra.Specification.Utxo.Properties.Computational it DummyAbstractFunctions
+
+open Computational
+
+private
+  toHsConstr : String → String
+  toHsConstr c = if c ≟ "utxo₀" then "utxo0" else c
+
+instance
+  HsTy-DepositsChange = autoHsType DepositsChange ⊣ withConstructor "MkDepositsChange"
+                                                    • fieldPrefix "dc"
+  Conv-DepositsChange = autoConvert DepositsChange
+
+  HsTy-UTxOEnv = autoHsType UTxOEnv ⊣ withConstructor "MkUTxOEnv"
+                                      • fieldPrefix "ue"
+                                      • onConstructors toHsConstr
+  Conv-UTxOEnv = autoConvert UTxOEnv
+
+  HsTy-SubUTxOEnv = autoHsType SubUTxOEnv ⊣ withConstructor "MkSubUTxOEnv"
+                                            • fieldPrefix "sue"
+  Conv-SubUTxOEnv = autoConvert SubUTxOEnv
+
+  HsTy-UTxOState = autoHsType UTxOState ⊣ withConstructor "MkUTxOState"
+                                          • fieldPrefix "us"
+  Conv-UTxOState = autoConvert UTxOState
+
+unquoteDecl = do
+  hsTypeAlias UTxO
+  
+utxo-step : HsType (UTxOEnv × Bool → UTxOState → Tx TxLevelTop → ComputationResult String UTxOState)
+utxo-step = to (compute Computational-UTXO)
+
+{-# COMPILE GHC utxo-step as utxoStep #-}
+
+utxow-step : HsType (UTxOEnv → UTxOState → Tx TxLevelTop → ComputationResult String UTxOState)
+utxow-step = to (compute Computational-UTXOW)
+
+{-# COMPILE GHC utxow-step as utxowStep #-}
+```

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -324,6 +324,11 @@ to process withdrawals as part of certificate processing.
 instance
   HasCoin-CertState : HasCoin CertState
   HasCoin-CertState .getCoin = rewardsBalance ∘ DStateOf
+
+  unquoteDecl DecEq-StakePoolParams = derive-DecEq
+    ((quote StakePoolParams , DecEq-StakePoolParams) ∷ [])
+  unquoteDecl DecEq-DCert = derive-DecEq
+    ((quote DCert , DecEq-DCert) ∷ [])
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Fees.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Fees.lagda.md
@@ -21,8 +21,8 @@ open import Ledger.Dijkstra.Specification.PParams
 module Ledger.Dijkstra.Specification.Fees
   {cryptoStructure : _} {epochStructure : _}
   {Network : Type} ⦃ _ : DecEq Network ⦄
-  {scriptStructure : ScriptStructure cryptoStructure epochStructure Network}
-  (pp : PParams cryptoStructure epochStructure Network scriptStructure)
+  {scriptStructure : ScriptStructure cryptoStructure epochStructure Network it}
+  (pp : PParams cryptoStructure epochStructure Network it scriptStructure)
   where
 
 open import Data.Rational using (0ℚ; ℚ; mkℚ+; _*_; floor)

--- a/src/Ledger/Dijkstra/Specification/Gov/Actions.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov/Actions.lagda.md
@@ -279,6 +279,55 @@ instance
 
   unquoteDecl HasCast-GovVote = derive-HasCast [ (quote GovVote , HasCast-GovVote) ]
   unquoteDecl Show-VDeleg = derive-Show [ (quote VDeleg , Show-VDeleg) ]
+  unquoteDecl DecEq-Anchor        = derive-DecEq ((quote Anchor  , DecEq-Anchor)  ∷ [])
+
+==-Set : ∀ {A} ⦃ dA : DecEq A ⦄ → ℙ A → ℙ A → Bool
+==-Set xs ys =
+    all (λ x → ⌊ x ∈? ys ⌋) (setToList xs) ∧
+    all (λ y → ⌊ y ∈? xs ⌋) (setToList ys)
+
+==-GovActionData : ∀ A → GovActionData A → GovActionData A → Bool
+==-GovActionData NoConfidence = _==_
+==-GovActionData UpdateCommittee (m0 , s0 , q0) (m1 , s1 , q1) =
+    (==-Set (m0 ˢ) (m1 ˢ)) ∧ (s0 == s1) ∧ (q0 == q1)
+==-GovActionData NewConstitution = _==_
+==-GovActionData TriggerHardFork = _==_
+==-GovActionData ChangePParams = _==_
+==-GovActionData TreasuryWithdrawal w0 w1 = ==-Set (w0 ˢ) (w1 ˢ)
+==-GovActionData Info = _==_
+
+-- See note "GovAction and GovProposal equality"
+==-GovAction : GovAction → GovAction → Bool
+==-GovAction ⟦ t0 , d0 ⟧ᵍᵃ ⟦ t1 , d1 ⟧ᵍᵃ
+    with t0 ≟ t1
+... | P.yes refl = ==-GovActionData t1 d0 d1
+... | P.no _ = false
+
+DecEq-NeedsHash : ∀ {A} → DecEq (NeedsHash A)
+DecEq-NeedsHash {NoConfidence} ._≟_ = _≟_ ⦃ DecEq-×′ ⦄
+DecEq-NeedsHash {UpdateCommittee} ._≟_ = _≟_ ⦃ DecEq-×′ ⦄
+DecEq-NeedsHash {NewConstitution} ._≟_ = _≟_ ⦃ DecEq-×′ ⦄
+DecEq-NeedsHash {TriggerHardFork} ._≟_ = _≟_ ⦃ DecEq-×′ ⦄
+DecEq-NeedsHash {ChangePParams} ._≟_ = _≟_ ⦃ DecEq-×′ ⦄
+DecEq-NeedsHash {TreasuryWithdrawal} ._≟_ = _≟_ ⦃ DecEq-⊤ ⦄
+DecEq-NeedsHash {Info} ._≟_ = _≟_ ⦃ DecEq-⊤ ⦄
+
+-- See note "GovAction and GovProposal equality"
+==-GovProposal : GovProposal → GovProposal → Bool
+==-GovProposal _gp0@(GovProposal.constructor a0 b0 c0 d0 e0 f0)
+               _gp1@(GovProposal.constructor a1 b1 c1 d1 e1 f1)
+  with GovAction.gaType a0 ≟ GovAction.gaType a1
+... | P.yes refl =
+    ==-GovAction a0 a1
+    ∧ (b0 == b1)
+    ∧ (c0 == c1)
+    ∧ (d0 == d1)
+    ∧ (e0 == e1)
+    ∧ (f0 == f1)
+  where
+    open GovProposal
+    instance _ = DecEq-NeedsHash
+... | P.no _ = false
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Gov/Base.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov/Base.lagda.md
@@ -8,7 +8,7 @@ source_path: src/Ledger/Dijkstra/Specification/Gov/Base.lagda.md
 
 module Ledger.Dijkstra.Specification.Gov.Base where
 
-open import Prelude using (Type)
+open import Prelude using (Type; it)
 open import Class.DecEq
 open import Ledger.Core.Specification.Crypto
 open import Ledger.Core.Specification.Epoch
@@ -29,10 +29,10 @@ record GovStructure : Type₁ where
   field globalConstants : GlobalConstants
   open GlobalConstants globalConstants public
 
-  field scriptStructure : ScriptStructure cryptoStructure epochStructure Network
+  field scriptStructure : ScriptStructure cryptoStructure epochStructure Network it
   open ScriptStructure scriptStructure public
 
-  open Ledger.Dijkstra.Specification.PParams cryptoStructure epochStructure Network scriptStructure public
+  open Ledger.Dijkstra.Specification.PParams cryptoStructure epochStructure Network it scriptStructure public
 
   field govParams : GovParams
   open GovParams govParams public

--- a/src/Ledger/Dijkstra/Specification/Gov/Base.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov/Base.lagda.md
@@ -18,6 +18,7 @@ import Ledger.Dijkstra.Specification.PParams
 record GovStructure : Type₁ where
   field TxId DocHash : Type
         ⦃ DecEq-TxId ⦄ : DecEq TxId
+        ⦃ DecEq-DocHash ⦄ : DecEq DocHash
 
   field cryptoStructure : CryptoStructure
   open CryptoStructure cryptoStructure public

--- a/src/Ledger/Dijkstra/Specification/PParams.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/PParams.lagda.md
@@ -100,9 +100,6 @@ record PoolThresholds : Type where
 
 
 ```agda
-LanguageCostModels : Type
-LanguageCostModels = List (Language × CostModel)
-
 record PParams : Type where
   field
 
@@ -151,7 +148,7 @@ record PParams : Type where
     drepActivity                  : Epoch
 
   costmdls : Language ⇀ CostModel
-  costmdls = fromListᵐ costmdlsAssoc
+  costmdls = fromListᵐ (languageCostModels costmdlsAssoc)
 ```
 
 *Security group*
@@ -205,9 +202,6 @@ instance
     ((quote DrepThresholds , Show-DrepThresholds) ∷ [])
   unquoteDecl Show-PoolThresholds = derive-Show
     ((quote PoolThresholds , Show-PoolThresholds) ∷ [])
-  Show-LanguageCostModels : Show LanguageCostModels
-  Show-LanguageCostModels =
-    Show-List ⦃ Show-× ⦃ Show-Language ⦄ ⦃ Show-CostModel ⦄ ⦄
   unquoteDecl Show-PParams        = derive-Show
     ((quote PParams , Show-PParams) ∷ [])
 ```
@@ -240,7 +234,7 @@ module PParamsUpdate where
           Emax                          : Maybe Epoch
           nopt                          : Maybe ℕ
           collateralPercentage          : Maybe ℕ
-          costmdls                      : Maybe (List (Language × CostModel))
+          costmdls                      : Maybe LanguageCostModels
           drepThresholds                : Maybe DrepThresholds
           poolThresholds                : Maybe PoolThresholds
           govActionLifetime             : Maybe ℕ
@@ -359,6 +353,9 @@ module PParamsUpdate where
       from (inj₁ refl) = refl
       from (inj₂ (refl , refl)) = refl
 
+  _∪ˡᶜᵐ_ : LanguageCostModels → LanguageCostModels → LanguageCostModels
+  l ∪ˡᶜᵐ l' = mkLanguageCostModels (setToList (fromListᵐ (languageCostModels l ++ languageCostModels l') ˢ))
+
   applyPParamsUpdate : PParams → PParamsUpdate → PParams
   applyPParamsUpdate pp ppu =
     record
@@ -388,7 +385,8 @@ module PParamsUpdate where
       ; Emax                        = U.Emax ?↗ P.Emax
       ; nopt                        = U.nopt ?↗ P.nopt
       ; collateralPercentage        = U.collateralPercentage ?↗ P.collateralPercentage
-      ; costmdlsAssoc               = U.costmdls ?↗ P.costmdlsAssoc
+      ; costmdlsAssoc               = if U.costmdls then (λ {cm} → cm ∪ˡᶜᵐ P.costmdlsAssoc)
+                                                    else P.costmdlsAssoc
       ; drepThresholds              = U.drepThresholds ?↗ P.drepThresholds
       ; poolThresholds              = U.poolThresholds ?↗ P.poolThresholds
       ; govActionLifetime           = U.govActionLifetime ?↗ P.govActionLifetime

--- a/src/Ledger/Dijkstra/Specification/PParams.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/PParams.lagda.md
@@ -20,8 +20,8 @@ open import Ledger.Dijkstra.Specification.Script.Base
 module Ledger.Dijkstra.Specification.PParams
   (cs : CryptoStructure )
   (es : EpochStructure) (open EpochStructure es)
-  (Network : Type) ⦃ _ : DecEq Network ⦄
-  (ss : ScriptStructure cs es Network) (open ScriptStructure ss)
+  (Network : Type) ( DecEq-Network : DecEq Network )
+  (ss : ScriptStructure cs es Network DecEq-Network) (open ScriptStructure ss)
   where
 
 open import Data.Product.Properties

--- a/src/Ledger/Dijkstra/Specification/Script.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script.lagda.md
@@ -13,9 +13,9 @@ open import Ledger.Core.Specification.Epoch using (EpochStructure)
 module Ledger.Dijkstra.Specification.Script
   (cs : CryptoStructure) (open CryptoStructure cs)
   (es : EpochStructure) (open EpochStructure es)
-  (Network : Type) ⦃ _ : DecEq Network ⦄
+  (Network : Type) (DecEq-Network : DecEq Network)
   where
 
-open import Ledger.Dijkstra.Specification.Script.Base cs es Network public
-open import Ledger.Dijkstra.Specification.Script.Native cs es Network public
+open import Ledger.Dijkstra.Specification.Script.Base cs es Network DecEq-Network public
+open import Ledger.Dijkstra.Specification.Script.Native cs es Network DecEq-Network public
 ```

--- a/src/Ledger/Dijkstra/Specification/Script/Base.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/Base.lagda.md
@@ -14,9 +14,11 @@ open import Ledger.Core.Specification.Epoch
 module Ledger.Dijkstra.Specification.Script.Base
   (cs : _) (open CryptoStructure cs)
   (es : _) (open EpochStructure es)
-  (Network : Type) ⦃ _ : DecEq Network ⦄
+  (Network : Type) ( DecEq-Network : DecEq Network )
   where
 
+instance
+  _ = DecEq-Network
 open import Ledger.Core.Specification.Address Network KeyHash ScriptHash
 
 open import Algebra.Morphism

--- a/src/Ledger/Dijkstra/Specification/Script/Base.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/Base.lagda.md
@@ -27,6 +27,7 @@ open import Data.Nat.Properties using (+-0-commutativeMonoid; suc-injective)
 open import Function.Bundles
 open import stdlib.Data.List.Relation.Unary.MOf
 open Injection
+open import Tactic.Derive.Show
 
 open import Ledger.Prelude hiding (All; Any; all?; any?; _∷ʳ_; uncons; _⊆_)
 
@@ -126,4 +127,22 @@ record ScriptStructure : Type₁ where
 
   toP2Script : Script → Maybe P2Script
   toP2Script = isInj₂
+
+  record LanguageCostModels : Type where
+    eta-equality
+    constructor mkLanguageCostModels
+    field
+      languageCostModels : List (Language × CostModel)
+
+  open LanguageCostModels public
+
+  instance
+    unquoteDecl
+      DecEq-LanguageCostModels = derive-DecEq ((quote LanguageCostModels , DecEq-LanguageCostModels) ∷ [])
+
+    _ = Show-List
+    _ = Show-×
+
+    unquoteDecl
+      Show-LanguageCostModels  = derive-Show ((quote LanguageCostModels , Show-LanguageCostModels) ∷ [])
 ```

--- a/src/Ledger/Dijkstra/Specification/Script/Native.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/Native.lagda.md
@@ -9,7 +9,7 @@ This section defines native scripts, which verify the presence of
 verification keys, whether a transaction happens in a certain slot
 interval, and the presence of guarding credentials.  Native scripts
 are evaluated as part of the phase-1 validation. Native scripts
-replace Timelock scripts in Conway era.
+replace Timelock scripts from Conway era.
 
 <!--
 ```agda
@@ -24,8 +24,11 @@ module Ledger.Dijkstra.Specification.Script.Native
   (cs : _) (open CryptoStructure cs)
   (es : _) (open EpochStructure es)
   (Network : Type)
-  ⦃ _ : DecEq Network ⦄
+  (DecEq-Network : DecEq Network)
   where
+
+instance
+  _ = DecEq-Network
 
 open import Ledger.Core.Specification.Address Network KeyHash ScriptHash 
 

--- a/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
@@ -118,7 +118,7 @@ record TransactionStructure : Type₁ where
   open Ledger.Dijkstra.Specification.TokenAlgebra.Base ScriptHash public
   open Ledger.Core.Specification.Address Network KeyHash ScriptHash ⦃ it ⦄ ⦃ it ⦄ ⦃ it ⦄ public
   open EpochStructure epochStructure public
-  open Ledger.Dijkstra.Specification.Script cryptoStructure epochStructure Network public
+  open Ledger.Dijkstra.Specification.Script cryptoStructure epochStructure Network it public
   field
 ```
 -->
@@ -128,7 +128,7 @@ record TransactionStructure : Type₁ where
 <!--
 ```agda
   open ScriptStructure scriptStructure public
-  open Ledger.Dijkstra.Specification.PParams cryptoStructure epochStructure Network scriptStructure public
+  open Ledger.Dijkstra.Specification.PParams cryptoStructure epochStructure Network it scriptStructure public
   field
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
@@ -244,7 +244,7 @@ Of particular note in the Dijkstra era are
       inductive
       field
         txBody       : TxBody txLevel
-        txWitnesses  : TxWitnesses txLevel
+        txWitnesses  : TxWitnesses
         txSize       : ℕ
         isValid      : InTopLevel txLevel Bool
         txAuxData    : Maybe AuxiliaryData
@@ -282,7 +282,7 @@ Of particular note in the Dijkstra era are
       requiredSignerHashes = mapPartial isKeyHashObj txGuards
 
 
-    record TxWitnesses (txLevel : TxLevel) : Type where
+    record TxWitnesses : Type where
       inductive
       field
         vKeySigs     : VKey ⇀ Sig
@@ -320,8 +320,8 @@ could be either of them.
     field TxBodyOf : A → TxBody txLevel
   open HasTxBody  ⦃...⦄ public
 
-  record HasTxWitnesses {txLevel} {a} (A : Type a) : Type a where
-    field TxWitnessesOf : A → TxWitnesses txLevel
+  record HasTxWitnesses {a} (A : Type a) : Type a where
+    field TxWitnessesOf : A → TxWitnesses
   open HasTxWitnesses ⦃...⦄ public
 
   record HasRedeemers {a} (A : Type a) : Type a where
@@ -437,7 +437,7 @@ could be either of them.
     HasIsValidFlag-Tx : HasIsValidFlag TopLevelTx
     HasIsValidFlag-Tx .IsValidFlagOf = Tx.isValid
 
-    HasRedeemers-TxWitnesses : HasRedeemers (TxWitnesses txLevel)
+    HasRedeemers-TxWitnesses : HasRedeemers TxWitnesses
     HasRedeemers-TxWitnesses .RedeemersOf = TxWitnesses.txRedeemers
     HasRedeemers-Tx : HasRedeemers (Tx txLevel)
     HasRedeemers-Tx .RedeemersOf = RedeemersOf ∘ TxWitnessesOf
@@ -528,7 +528,7 @@ could be either of them.
     HasCoin-TxOut : HasCoin TxOut
     HasCoin-TxOut .getCoin = coin ∘ proj₁ ∘ proj₂
 
-    HasData-TxWitnesses : HasData (TxWitnesses txLevel)
+    HasData-TxWitnesses : HasData TxWitnesses
     HasData-TxWitnesses .DataOf = TxWitnesses.txData
     HasData-Tx : HasData (Tx txLevel)
     HasData-Tx .DataOf = DataOf ∘ TxWitnessesOf
@@ -538,7 +538,7 @@ could be either of them.
     HasGuards-Tx : HasGuards (Tx txLevel)
     HasGuards-Tx .GuardsOf = GuardsOf ∘ TxBodyOf
 
-    HasScripts-TxWitnesses : HasScripts (TxWitnesses txLevel)
+    HasScripts-TxWitnesses : HasScripts TxWitnesses
     HasScripts-TxWitnesses .ScriptsOf = TxWitnesses.scripts
     HasScripts-Tx : HasScripts (Tx txLevel)
     HasScripts-Tx .ScriptsOf = ScriptsOf ∘ TxWitnessesOf

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -139,11 +139,11 @@ hashScriptIntegrity
   → RedeemerPtr ⇀ (Redeemer × ExUnits)
   → ℙ Datum
   → Maybe ScriptHash
-hashScriptIntegrity pp langs rdrms dats = nothing
---   with rdrms ˢ ≟ ∅ˢ | langs ≟ ∅ˢ | dats ≟ ∅ˢ
--- ...  | yes _        | yes _      | yes _ = nothing
--- ...  | _            | _          | _     =
---     just $ hash (dats , rdrms , mapˢ (getLanguageView pp) langs)
+hashScriptIntegrity pp langs rdrms dats
+  with rdrms ˢ ≟ ∅ˢ | langs ≟ ∅ˢ | dats ≟ ∅ˢ
+...  | yes _        | yes _      | yes _ = nothing
+...  | _            | _          | _     =
+    just $ hash (dats , rdrms , mapˢ (getLanguageView pp) langs)
 ```
 
 ## Required Top-level Guards

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -139,11 +139,11 @@ hashScriptIntegrity
   → RedeemerPtr ⇀ (Redeemer × ExUnits)
   → ℙ Datum
   → Maybe ScriptHash
-hashScriptIntegrity pp langs rdrms dats
-  with rdrms ˢ ≟ ∅ˢ | langs ≟ ∅ˢ | dats ≟ ∅ˢ
-...  | yes _        | yes _      | yes _ = nothing
-...  | _            | _          | _     =
-    just $ hash (dats , rdrms , mapˢ (getLanguageView pp) langs)
+hashScriptIntegrity pp langs rdrms dats = nothing
+--   with rdrms ˢ ≟ ∅ˢ | langs ≟ ∅ˢ | dats ≟ ∅ˢ
+-- ...  | yes _        | yes _      | yes _ = nothing
+-- ...  | _            | _          | _     =
+--     just $ hash (dats , rdrms , mapˢ (getLanguageView pp) langs)
 ```
 
 ## Required Top-level Guards


### PR DESCRIPTION
# Description

This PR adds the `Foreign` hierarchy of modules for the Dijkstra era.

In addition,
- changes `DecEq Network` module parameter from a typeclass instance to an explicit parameter to work around Agda bug.
- it removes the `TxLevel` type parameter from transaction witnesses as it is not necessary
- adds `DecEq` instances for several types (needed for conformance)

~Blocked by #1133.~

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
