### PR TITLE
[Dijkstra] CIP-159-06: Extend TxInfo and script validation (#1118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### WIP
 
+- Extend `TxInfo` with `txDirectDeposits` and `txBalanceIntervals` fields (CIP-159).
 - Remove `allBalanceIntervals` batch-level aggregation helper; balance interval
   assertions will be checked per-(sub)transaction in `UTXO`/`SUBUTXO` rules (see #1117).
 - Add `TxBody.txDirectDeposits` and `TxBody.txBalanceIntervals` fields (CIP-159).

--- a/src/Ledger/Dijkstra/Specification/Script/ScriptPurpose.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/ScriptPurpose.lagda.md
@@ -68,7 +68,8 @@ mutual
 The `txDirectDeposits`{.AgdaField} and `txBalanceIntervals`{.AgdaField} fields
 expose the CIP-159 transaction fields to Plutus scripts via the script context.
 CIP-159 specifies that the Plutus script context is "pre-emptively upgraded" to
-include these fields from the start, even though only ADA direct deposits are
-supported in Dijkstra.  This ensures scripts written for Dijkstra do not need
-recompilation when multi-asset support is added in a future era.
+include these fields from the start.  In Dijkstra, direct deposits are
+currently ADA-only, so the pre-emptive upgrade here is about the *presence* of
+these fields in the script context rather than guaranteeing that the concrete
+direct-deposit representation is already the final multi-asset one.
 

--- a/src/Ledger/Dijkstra/Specification/Script/ScriptPurpose.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/ScriptPurpose.lagda.md
@@ -72,8 +72,3 @@ include these fields from the start, even though only ADA direct deposits are
 supported in Dijkstra.  This ensures scripts written for Dijkstra do not need
 recompilation when multi-asset support is added in a future era.
 
-CIP-159 does **not** introduce new `ScriptPurpose`{.AgdaDatatype} values for
-direct deposits or balance intervals.  Direct deposits do not require a witness
-from the receiving credential (mirroring how UTxOs can be sent to a script
-address without executing the spending script).  Balance intervals are Phase-1
-validity conditions that do not trigger script execution.

--- a/src/Ledger/Dijkstra/Specification/Script/ScriptPurpose.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/ScriptPurpose.lagda.md
@@ -46,20 +46,34 @@ mutual
   record TxInfo : Type where
     inductive
     field
-      realizedInputs : UTxO
-      txOuts         : Ix ⇀ TxOut
-      txFee          : Maybe Fees
-      mint           : Value
-      txCerts        : List DCert
-      txWithdrawals  : Withdrawals
-      txVldt         : Maybe Slot × Maybe Slot
-      vkKey          : ℙ KeyHash     -- native/phase-1/timelock signers
-      txGuards       : ℙ Credential  -- CIP-0112/0118 guards (required by tx body)
-      txData         : ℙ Datum
-      txId           : TxId
-      txInfoSubTxs   : Maybe (List SubTxInfo)
+      realizedInputs      : UTxO
+      txOuts              : Ix ⇀ TxOut
+      txFee               : Maybe Fees
+      mint                : Value
+      txCerts             : List DCert
+      txWithdrawals       : Withdrawals
+      txVldt              : Maybe Slot × Maybe Slot
+      vkKey               : ℙ KeyHash     -- native/phase-1/timelock signers
+      txGuards            : ℙ Credential  -- CIP-0112/0118 guards (required by tx body)
+      txData              : ℙ Datum
+      txId                : TxId
+      txInfoSubTxs        : Maybe (List SubTxInfo)
+      txDirectDeposits    : DirectDeposits
+      txBalanceIntervals  : AccountBalanceIntervals
 
   SubTxInfo : Type
   SubTxInfo = TxInfo
-
 ```
+
+The `txDirectDeposits`{.AgdaField} and `txBalanceIntervals`{.AgdaField} fields
+expose the CIP-159 transaction fields to Plutus scripts via the script context.
+CIP-159 specifies that the Plutus script context is "pre-emptively upgraded" to
+include these fields from the start, even though only ADA direct deposits are
+supported in Dijkstra.  This ensures scripts written for Dijkstra do not need
+recompilation when multi-asset support is added in a future era.
+
+CIP-159 does **not** introduce new `ScriptPurpose`{.AgdaDatatype} values for
+direct deposits or balance intervals.  Direct deposits do not require a witness
+from the receiving credential (mirroring how UTxOs can be sent to a script
+address without executing the spending script).  Balance intervals are Phase-1
+validity conditions that do not trigger script execution.

--- a/src/Ledger/Dijkstra/Specification/Script/Validation.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/Validation.lagda.md
@@ -154,12 +154,13 @@ credsNeeded utxo tx =
     collateralInputs {TxLevelSub} tx = ∅
 ```
 
-**CIP-159 and `credsNeeded`**.  CIP-159 does not introduce new `ScriptPurpose` values
-for direct deposits or balance intervals, so `credsNeeded` requires no changes.
-Direct deposits do not require a witness from the receiving credential.  Balance
-intervals are Phase-1 validity conditions that do not trigger script execution.  The
-existing `Reward` case already handles partial withdrawals; it generates a `Reward`
-script purpose for each entry in `txWithdrawals`, regardless of whether the
+**CIP-159 and `credsNeeded`**.
+CIP-159 does not introduce new `ScriptPurpose`{.AgdaDatatype} values for direct
+deposits or balance intervals, so `credsNeeded`{.AgdaFunction} requires no changes.
+Direct deposits do not require a witness from the receiving credential.
+Balance intervals are Phase-1 validity conditions that do not trigger script execution.
+The existing `Reward` case already handles partial withdrawals; it generates a
+`Reward` script purpose for each entry in `txWithdrawals`, regardless of whether the
 withdrawal is full or partial.
 
 <!--

--- a/src/Ledger/Dijkstra/Specification/Script/Validation.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/Validation.lagda.md
@@ -74,33 +74,37 @@ getDatumSpend tx utxo₀ allData txin
 txInfo : (ℓ : TxLevel) → UTxO → Tx ℓ → TxInfo
 
 txInfo TxLevelTop utxo tx =
-  record  { realizedInputs  = utxo ∣ (SpendInputsOf tx)
-          ; txOuts          = TxOutsOf tx
-          ; txFee           = FeesOf? tx
-          ; mint            = MintedValueOf tx
-          ; txCerts         = DCertsOf tx
-          ; txWithdrawals   = WithdrawalsOf tx
-          ; txVldt          = ValidIntervalOf tx
-          ; vkKey           = RequiredSignerHashesOf tx
-          ; txGuards        = GuardsOf tx
-          ; txData          = DataOf tx
-          ; txId            = TxIdOf tx
-          ; txInfoSubTxs    = nothing
+  record  { realizedInputs      = utxo ∣ (SpendInputsOf tx)
+          ; txOuts              = TxOutsOf tx
+          ; txFee               = FeesOf? tx
+          ; mint                = MintedValueOf tx
+          ; txCerts             = DCertsOf tx
+          ; txWithdrawals       = WithdrawalsOf tx
+          ; txVldt              = ValidIntervalOf tx
+          ; vkKey               = RequiredSignerHashesOf tx
+          ; txGuards            = GuardsOf tx
+          ; txData              = DataOf tx
+          ; txId                = TxIdOf tx
+          ; txInfoSubTxs        = nothing
+          ; txDirectDeposits    = DirectDepositsOf tx
+          ; txBalanceIntervals  = BalanceIntervalsOf tx
           }
 
 txInfo TxLevelSub utxo tx =
-  record  { realizedInputs  = utxo ∣ (TxBody.txIns txBody)
-          ; txOuts          = TxBody.txOuts txBody
-          ; txFee           = nothing
-          ; mint            = TxBody.mint txBody
-          ; txCerts         = TxBody.txCerts txBody
-          ; txWithdrawals   = TxBody.txWithdrawals txBody
-          ; txVldt          = TxBody.txVldt txBody
-          ; vkKey           = TxBody.requiredSignerHashes txBody
-          ; txGuards        = TxBody.txGuards txBody
-          ; txData          = DataOf tx
-          ; txId            = TxBody.txId txBody
-          ; txInfoSubTxs    = nothing
+  record  { realizedInputs      = utxo ∣ (TxBody.txIns txBody)
+          ; txOuts              = TxBody.txOuts txBody
+          ; txFee               = nothing
+          ; mint                = TxBody.mint txBody
+          ; txCerts             = TxBody.txCerts txBody
+          ; txWithdrawals       = TxBody.txWithdrawals txBody
+          ; txVldt              = TxBody.txVldt txBody
+          ; vkKey               = TxBody.requiredSignerHashes txBody
+          ; txGuards            = TxBody.txGuards txBody
+          ; txData              = DataOf tx
+          ; txId                = TxBody.txId txBody
+          ; txInfoSubTxs        = nothing
+          ; txDirectDeposits    = DirectDepositsOf tx
+          ; txBalanceIntervals  = BalanceIntervalsOf tx
           } where open Tx tx
 
 txInfoForPurpose : {ℓ : TxLevel} → UTxO → Tx ℓ → ScriptPurpose → TxInfo
@@ -149,6 +153,14 @@ credsNeeded utxo tx =
     collateralInputs {TxLevelTop} tx = CollateralInputsOf tx
     collateralInputs {TxLevelSub} tx = ∅
 ```
+
+**CIP-159 and `credsNeeded`**.  CIP-159 does not introduce new `ScriptPurpose` values
+for direct deposits or balance intervals, so `credsNeeded` requires no changes.
+Direct deposits do not require a witness from the receiving credential.  Balance
+intervals are Phase-1 validity conditions that do not trigger script execution.  The
+existing `Reward` case already handles partial withdrawals; it generates a `Reward`
+script purpose for each entry in `txWithdrawals`, regardless of whether the
+withdrawal is full or partial.
 
 <!--
 ```agda

--- a/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
@@ -170,7 +170,7 @@ record TransactionStructure : Type₁ where
   open GovernanceActions hiding (Vote; yes; no; abstain) public
 
   open import Ledger.Dijkstra.Specification.Certs govStructure
-  open import Ledger.Dijkstra.Specification.Account govStructure
+  open import Ledger.Dijkstra.Specification.Account govStructure public
 ```
 -->
 ```agda


### PR DESCRIPTION
## Description

This PR closes Issue #1118.

Extends the Plutus script context (`TxInfo`) with two new CIP-159 transaction fields (`txDirectDeposits` and `txBalanceIntervals`) and documents that the `credsNeeded` function requires no changes for CIP-159, as specified in [CIP-159](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0159).

---

### Changes

`src/Ledger/Dijkstra/Specification/Script/ScriptPurpose.lagda.md`:

+  **New `TxInfo` fields**.  
   + `txDirectDeposits : DirectDeposits`
   + `txBalanceIntervals : AccountBalanceIntervals`

+  **New documentation**.  Explains that the Plutus script context is "pre-emptively upgraded" to include both fields from the start (even though only ADA direct deposits are supported in Dijkstra), so scripts written for Dijkstra do not need recompilation when multi-asset support is added. Documents that CIP-159 does not introduce new `ScriptPurpose` values.

`src/Ledger/Dijkstra/Specification/Script/Validation.lagda.md`:

+  **Updated `txInfo` construction**.  Both the `TxLevelTop` and `TxLevelSub` cases now populate the two new fields using `DirectDepositsOf` and `BalanceIntervalsOf` type class accessors.

+  **New documentation**.  Documents that `credsNeeded` requires no changes for CIP-159: direct deposits do not require a witness from the receiving credential, balance intervals are Phase-1 validity conditions, and the existing `Reward` case already handles partial withdrawals.

---

### Design

**`txInfoForPurpose` unchanged**.  The Guard-case override `record base { txInfoSubTxs = just subInfos }` continues to work correctly — the new fields flow through from the `base` call to `txInfo`.

**`credsNeeded` unchanged**.  CIP-159 explicitly states it does not introduce new `ScriptPurpose` values.  Direct deposits, balance intervals, and partial withdrawals (via the existing `Reward` case) all require zero changes to `credsNeeded`.

---

### Acceptance Criteria

- [x] `TxInfo` extended with `txDirectDeposits` field
- [x] `TxInfo` extended with `txBalanceIntervals` field
- [x] `txInfo` construction functions populate the new fields
- [x] `credsNeeded` confirmed to not need changes for CIP-159 (documented)
- [x] Module compiles with `--safe`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
