### PR TITLE
[Dijkstra] CIP-159-07: Version gating for CIP-159 fields (#1119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### WIP
 
+- Forbid CIP-159 fields (`txDirectDeposits`, `txBalanceIntervals`) in legacy mode via explicit `UTXOW-legacy` premises.
 - Allow partial withdrawals in `PRE-CERT` rule; define `applyWithdrawals` and `_≤ᵐ_` (CIP-159).
 - Extend `TxInfo` with `txDirectDeposits` and `txBalanceIntervals` fields (CIP-159).
 - Remove `allBalanceIntervals` batch-level aggregation helper; balance interval

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -44,41 +44,35 @@ UsesBootstrapAddress utxo tx
     open Tx tx; open TxBody txBody
 
 module _ (tx : TopLevelTx) where
-  open Tx tx
-  open TxBody txBody
-
   module _ (utxo : UTxO) where
     HasInlineDatum : TxOut → Type
     HasInlineDatum txout = Is-just (txOutToDatum txout)
 
     UsesV2Features : Type
-    UsesV2Features = ∃[ o ∈ (range txOuts) ∪ range (utxo ∣ (txIns ∪ referenceInputs)) ] HasInlineDatum o
+    UsesV2Features = ∃[ o ∈ (range (TxOutsOf tx)) ∪ range (utxo ∣ (SpendInputsOf tx ∪ ReferenceInputsOf tx)) ] HasInlineDatum o
 
   data UsesV3Features : Set where
-    hasVotes     : ¬ (Is-[] txGovVotes)     → UsesV3Features
-    hasProposals : ¬ (Is-[] txGovProposals) → UsesV3Features
-    hasDonation  : NonZero txDonation       → UsesV3Features
-    hasTreasure  : Is-just currentTreasury  → UsesV3Features
+    hasVotes     : ¬ (Is-[] (ListOfGovVotesOf tx))      → UsesV3Features
+    hasProposals : ¬ (Is-[] (ListOfGovProposalsOf tx))  → UsesV3Features
+    hasDonation  : NonZero (DonationsOf tx)             → UsesV3Features
+    hasTreasure  : Is-just (CurrentTreasuryOf tx)       → UsesV3Features
 
   data UsesV4Features : Set where
-    hasSubtransactions   : ¬ (Is-[] txSubTransactions)        → UsesV4Features
-    hasGuards            : ¬ (Is-∅ txGuards)                  → UsesV4Features
-    hasDirectDeposits    : ¬ (Is-∅ (dom txDirectDeposits))    → UsesV4Features
-    hasBalanceIntervals  : ¬ (Is-∅ (dom txBalanceIntervals))  → UsesV4Features
+    hasSubtransactions   : ¬ Is-[] (SubTransactionsOf tx)        → UsesV4Features
+    hasGuards            : ¬ Is-∅ (GuardsOf tx)                  → UsesV4Features
+    hasDirectDeposits    : ¬ Is-∅ (dom (DirectDepositsOf tx))    → UsesV4Features
+    hasBalanceIntervals  : ¬ Is-∅ (dom (BalanceIntervalsOf tx))  → UsesV4Features
 
 ```
 
 <!--
 ```agda
 module _ {tx : TopLevelTx} where
-  open Tx tx
-  open TxBody txBody
-
   instance
     Dec-UsesV3Features : UsesV3Features tx ⁇
     Dec-UsesV3Features .dec
-      with ¿ ¬ (Is-[] txGovVotes) ¿ | ¿ ¬ (Is-[] txGovProposals) ¿
-         | ¿ NonZero txDonation   ¿ | ¿ Is-just currentTreasury  ¿
+      with ¿ ¬ Is-[] (ListOfGovVotesOf tx) ¿ | ¿ ¬ Is-[] (ListOfGovProposalsOf tx) ¿
+         | ¿ NonZero (DonationsOf tx)   ¿ | ¿ Is-just (CurrentTreasuryOf tx)  ¿
     ... | yes p | _ | _ | _ = yes (hasVotes p)
     ... | _ | yes p | _ | _ = yes (hasProposals p)
     ... | _ | _ | yes p | _ = yes (hasDonation p)
@@ -88,13 +82,13 @@ module _ {tx : TopLevelTx} where
 
 module _ {tx : TopLevelTx} where
   open Tx tx
-  open TxBody txBody
+  -- open TxBody txBody
 
   instance
     Dec-UsesV4Features : UsesV4Features tx ⁇
     Dec-UsesV4Features .dec
-      with ¿ ¬ (Is-[] txSubTransactions) ¿ | ¿ ¬ (Is-∅ txGuards) ¿
-         | ¿ ¬ (Is-∅ (dom txDirectDeposits)) ¿ | ¿ ¬ (Is-∅ (dom txBalanceIntervals)) ¿
+      with ¿ ¬ Is-[] (SubTransactionsOf tx) ¿ | ¿ ¬ Is-∅ (GuardsOf tx) ¿
+         | ¿ ¬ Is-∅ (dom (DirectDepositsOf tx)) ¿ | ¿ ¬ Is-∅ (dom (BalanceIntervalsOf tx)) ¿
     ... | yes p | _ | _ | _ = yes (hasSubtransactions p)
     ... | _ | yes p | _ | _ = yes (hasGuards p)
     ... | _ | _ | yes p | _ = yes (hasDirectDeposits p)
@@ -106,18 +100,14 @@ module _ {tx : TopLevelTx} where
 -->
 
 CIP-159 fields (`txDirectDeposits`{.AgdaField} and `txBalanceIntervals`{.AgdaField})
-require at least PlutusV4.  When either field is non-empty,
-`UsesV4Features`{.AgdaDatatype} holds and `allowedLanguagesLegacyMode`{.AgdaFunction}
-returns `∅`, making the legacy rule's language premise unsatisfiable.
-This forces such transactions into normal mode (PlutusV4-only), which is precisely
-the CIP-159/CIP-118 design:
+require at least PlutusV4 and are explicitly forbidden in legacy mode via the
+`Is-∅ (dom txDirectDeposits)` and `Is-∅ (dom txBalanceIntervals)` premises in
+`UTXOW-legacy`.  This follows the same pattern as `Is-∅ (GuardsOf txTop)` for guard
+scripts.
 
-> When backward compatibility with older Plutus scripts (v1–v3) is needed, CIP-159
-> fields can appear in sub-transactions, while older scripts run at the top level
-> (the CIP-118 escape hatch).
-
-The version gating here ensures that a top-level transaction with non-empty CIP-159
-fields cannot enter legacy mode.
+When backward compatibility with older Plutus scripts (v1–v3) is needed, CIP-159
+fields can appear in sub-transactions while older scripts run at the top level
+(the CIP-118 escape hatch).
 
 ```agda
 languages :  ℙ P2Script → ℙ Language
@@ -125,9 +115,6 @@ languages p2Scripts = mapˢ language p2Scripts
 
 allowedLanguagesLegacyMode : TopLevelTx → UTxO → ℙ Language
 allowedLanguagesLegacyMode tx utxo =
-  if UsesV4Features tx
-    then ∅
-    else
   if UsesV3Features tx
     then fromList (PlutusV3 ∷ [])
     else
@@ -330,6 +317,11 @@ mode up front rather than deciding both.
 4. `Guards` is the empty set, and, thus, all sub-transaction's `requiredTopLevelGuards`
    are also the empty set.
 
+5. The top-level transaction does not contain direct deposits (`txDirectDeposits` is empty).
+
+6. The top-level transaction does not contain balance interval assertions
+   (`txBalanceIntervals` is empty).
+
 ```agda
   UTXOW-legacy :
     let
@@ -374,7 +366,9 @@ mode up front rather than deciding both.
     in
     ∙ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ [])
     ∙ ¬ (UsesBootstrapAddress (UTxOOf Γ) txTop)
-    ∙ Is-∅ (GuardsOf txTop)
+    ∙ Is-∅ (GuardsOf txTop)                      -- (4)
+    ∙ Is-∅ (dom txDirectDeposits)                -- (5)
+    ∙ Is-∅ (dom txBalanceIntervals)              -- (6)
     ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (3)
     ∙ ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes (TxIdOf txTop)) σ
     ∙ ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided txVldt s
@@ -394,7 +388,7 @@ unquoteDecl UTXOW-normal-premises = genPremises UTXOW-normal-premises (quote UTX
 unquoteDecl UTXOW-legacy-premises = genPremises UTXOW-legacy-premises (quote UTXOW-legacy)
 unquoteDecl SUBUTXOW-premises = genPremises SUBUTXOW-premises (quote SUBUTXOW)
 pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , h)
-pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)
+pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , h)
 pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , h)
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -61,8 +61,11 @@ module _ (tx : TopLevelTx) where
     hasTreasure  : Is-just currentTreasury  → UsesV3Features
 
   data UsesV4Features : Set where
-    hasSubtransactions  : ¬ (Is-[] txSubTransactions) → UsesV4Features
-    hasGuards           : ¬ (Is-∅ txGuards)           → UsesV4Features
+    hasSubtransactions   : ¬ (Is-[] txSubTransactions)        → UsesV4Features
+    hasGuards            : ¬ (Is-∅ txGuards)                  → UsesV4Features
+    hasDirectDeposits    : ¬ (Is-∅ (dom txDirectDeposits))    → UsesV4Features
+    hasBalanceIntervals  : ¬ (Is-∅ (dom txBalanceIntervals))  → UsesV4Features
+
 ```
 
 <!--
@@ -91,12 +94,30 @@ module _ {tx : TopLevelTx} where
     Dec-UsesV4Features : UsesV4Features tx ⁇
     Dec-UsesV4Features .dec
       with ¿ ¬ (Is-[] txSubTransactions) ¿ | ¿ ¬ (Is-∅ txGuards) ¿
-    ... | yes p | _ = yes (hasSubtransactions p)
-    ... | _ | yes p = yes (hasGuards p)
-    ... | no p₁ | no p₂
-      = no λ { (hasSubtransactions x) → p₁ x ; (hasGuards x) → p₂ x}
+         | ¿ ¬ (Is-∅ (dom txDirectDeposits)) ¿ | ¿ ¬ (Is-∅ (dom txBalanceIntervals)) ¿
+    ... | yes p | _ | _ | _ = yes (hasSubtransactions p)
+    ... | _ | yes p | _ | _ = yes (hasGuards p)
+    ... | _ | _ | yes p | _ = yes (hasDirectDeposits p)
+    ... | _ | _ | _ | yes p = yes (hasBalanceIntervals p)
+    ... | no p₁ | no p₂ | no p₃ | no p₄
+      = no λ { (hasSubtransactions x) → p₁ x ; (hasGuards x) → p₂ x
+             ; (hasDirectDeposits x) → p₃ x ; (hasBalanceIntervals x) → p₄ x }
 ```
 -->
+
+CIP-159 fields (`txDirectDeposits`{.AgdaField} and `txBalanceIntervals`{.AgdaField})
+require at least PlutusV4.  When either field is non-empty,
+`UsesV4Features`{.AgdaDatatype} holds and `allowedLanguagesLegacyMode`{.AgdaFunction}
+returns `∅`, making the legacy rule's language premise unsatisfiable.
+This forces such transactions into normal mode (PlutusV4-only), which is precisely
+the CIP-159/CIP-118 design:
+
+> When backward compatibility with older Plutus scripts (v1–v3) is needed, CIP-159
+> fields can appear in sub-transactions, while older scripts run at the top level
+> (the CIP-118 escape hatch).
+
+The version gating here ensures that a top-level transaction with non-empty CIP-159
+fields cannot enter legacy mode.
 
 ```agda
 languages :  ℙ P2Script → ℙ Language
@@ -104,6 +125,9 @@ languages p2Scripts = mapˢ language p2Scripts
 
 allowedLanguagesLegacyMode : TopLevelTx → UTxO → ℙ Language
 allowedLanguagesLegacyMode tx utxo =
+  if UsesV4Features tx
+    then ∅
+    else
   if UsesV3Features tx
     then fromList (PlutusV3 ∷ [])
     else

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -85,8 +85,8 @@ instance
         with ¿ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿
       ... | yes p with H?-legacy
       ... | no ¬p = failure "UTXOW"
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀) =
-        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)))
+      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂) =
+        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , h)))
             (UTXO.computeProof (Γ , true) s₀ txTop)
       computeProof | no ¬p with H?-normal
       ... | no ¬p = failure "UTXOW"
@@ -102,11 +102,11 @@ instance
       ... | no ¬p = ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉))
       ... | yes _ with UTXO.computeProof (Γ , false) s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
-      completeness s₁ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h)
+      completeness s₁ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ h)
         with ¿ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿
       ... | no ¬p  = ⊥-elim (¬p p₀)
       ... | yes p with H?-legacy
-      ... | no ¬p = ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀))
+      ... | no ¬p = ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂))
       ... | yes _ with UTXO.computeProof (Γ , true) s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
 ```


### PR DESCRIPTION
## Description

This PR closes Issue #1119.

Extends the `UsesV4Features` predicate to detect CIP-159 transaction fields and adds explicit premises to `UTXOW-legacy` forbidding them in legacy mode, as required by [CIP-159](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0159).

### Changes

`src/Ledger/Dijkstra/Specification/Utxow.lagda.md`:

+  **Extended `UsesV4Features`**.  Two new constructors:
   + `hasDirectDeposits : ¬ (Is-∅ (dom txDirectDeposits)) → UsesV4Features`
   + `hasBalanceIntervals : ¬ (Is-∅ (dom txBalanceIntervals)) → UsesV4Features`

+  **New `UTXOW-legacy` premises**.  Two new premises forbid CIP-159 fields in legacy mode:
   + `Is-∅ (dom txDirectDeposits)`
   + `Is-∅ (dom txBalanceIntervals)`

   These follow the same pattern as the existing `Is-∅ (GuardsOf txTop)` premise for guard scripts.

+  **Updated `Dec-UsesV4Features`**.  The decidability instance now handles four constructors (was two), following the same pattern as `Dec-UsesV3Features`.

+  **New documentation**.  Explains the CIP-159/CIP-118 interaction: when backward compatibility with older Plutus scripts (v1–v3) is needed, CIP-159 fields can appear in sub-transactions while older scripts run at the top level (the CIP-118 escape hatch).

`src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md`:

+  **Updated `Computational-UTXOW`**.  The legacy premise tuple grows from 11 to 13 elements (plus the UTXO step).  Both `computeProof` and `completeness` are updated for the new arity.

### Design

+  **Explicit premises for CIP-159 field gating.**  `UTXOW-legacy` now includes `Is-∅ (dom txDirectDeposits)` and `Is-∅ (dom txBalanceIntervals)` as direct premises, following the same pattern as `Is-∅ (GuardsOf txTop)` for guard scripts.  This is clearer than routing through `allowedLanguagesLegacyMode`, which is intended for selecting among V1–V3 versions *within* legacy mode, not for gating entry into legacy mode.

+  **`allowedLanguagesLegacyMode` unchanged from master.**  This function checks transaction features against legacy Plutus versions (V1–V3) and is only called when legacy mode is already determined.  CIP-159 field gating is orthogonal and handled by the new premises.

+  **`Is-∅ (dom ...)` for map emptiness**.  Since `txDirectDeposits` and `txBalanceIntervals` are maps (`Credential ⇀ Coin` and `Credential ⇀ BalanceInterval`), we check emptiness via `Is-∅ (dom ...)` rather than a direct map equality.  `dom` yields `ℙ Credential`, for which `Is-∅` is decidable.

+  **`UTXOW-Normal-Premises` unchanged**.  Normal mode already enforces `languageV4Only` (all scripts must be PlutusV4), so CIP-159 fields are automatically permitted.

+  **`SUBUTXOW-Premises` unchanged**.  Sub-transactions already enforce `languageV4Only`; CIP-159 envisions direct deposits being placed in sub-transactions (the CIP-118 escape hatch), and the existing constraint is sufficient.

### Deferred Issue

**Partial withdrawal version restriction → #1116.**  CIP-159 states partial withdrawals are only permitted in transactions without V1–V3 scripts.  Enforcing this requires adding `legacyMode` to `CertEnv` and conditioning `PRE-CERT` on it — changes that belong with the certificate rule overhaul, which we'll tackle in a separate PR (addressing Issue #1116).

## Acceptance criteria checklist

- [x] `UsesV4Features` extended with `hasDirectDeposits` and `hasBalanceIntervals`
- [x] CIP-159 fields forbidden in legacy mode via explicit `UTXOW-legacy` premises
- [x] `UTXOW-Normal-Premises` confirmed: no changes needed (V4 enforcement sufficient)
- [x] `SUBUTXOW-Premises` confirmed: no changes needed (V4 enforcement sufficient)
- [ ] ~Partial withdrawal version restriction~ deferred to #1116
- [x] `Dec-UsesV4Features` updated for new constructors
- [x] `Computational-UTXOW` updated for new legacy premise arity
- [x] Module compiles with `--safe`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
