### PR TITLE
[Dijkstra] CIP-159-04: Update cert rules for partial withdrawals (#1116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### WIP
 
+- Allow partial withdrawals in `PRE-CERT` rule; define `applyWithdrawals` and `_≤ᵐ_` (CIP-159).
 - Extend `TxInfo` with `txDirectDeposits` and `txBalanceIntervals` fields (CIP-159).
 - Remove `allBalanceIntervals` batch-level aggregation helper; balance interval
   assertions will be checked per-(sub)transaction in `UTXO`/`SUBUTXO` rules (see #1117).

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -466,12 +466,9 @@ data _⊢_⇀⦇_,PRE-CERT⦈_ : CertEnv → CertState → ⊤ → CertState →
     in
     ∙ filter isKeyHash wdrlCreds ⊆ dom voteDelegs
     ∙ wdrlCreds ⊆ dom rewards
-    ∙ ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ᵐ lookupᵐ? rewards (stake addr)
+    ∙ ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rewards (stake addr))
       ────────────────────────────────
-      ⟦ e , pp , vs , wdrls , cc ⟧ ⊢
-        ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , ⟦ dReps , ccHotKeys , deposits' ⟧ ⟧
-          ⇀⦇ _ ,PRE-CERT⦈
-        ⟦ ⟦ voteDelegs , stakeDelegs , applyWithdrawals wdrls rewards , deposits ⟧ , stᵖ , ⟦ refreshedDReps , ccHotKeys , deposits' ⟧ ⟧
+      ⟦ e , pp , vs , wdrls , cc ⟧ ⊢ ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , ⟦ dReps , ccHotKeys , deposits' ⟧ ⟧ ⇀⦇ _ ,PRE-CERT⦈ ⟦ ⟦ voteDelegs , stakeDelegs , applyWithdrawals wdrls rewards , deposits ⟧ , stᵖ , ⟦ refreshedDReps , ccHotKeys , deposits' ⟧ ⟧
 ```
 
 **TODO**: Version restriction (deferred).  CIP-159 specifies that partial withdrawals are

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -293,6 +293,32 @@ applyDirectDeposits dd ds = record ds { rewards = RewardsOf ds ∪⁺ dd }
 The `LEDGER`{.AgdaDatatype} rule will call `applyDirectDeposits`{.AgdaFunction} to
 credit direct deposits to account balances as part of processing a transaction batch.
 
+```agda
+applyWithdrawals : Withdrawals → Rewards → Rewards
+applyWithdrawals wdrls rwds =
+  foldl applyOne rwds (setToList (wdrls ˢ))
+  where
+    -- For each withdrawal entry `(addr, amt)`, look up `stake addr` in the acc,
+    -- compute `bal ∸ amt`, create a singleton map with the new balance, and
+    -- merge it with the rest (complement-restricted, to remove the old entry).
+    applyOne : Rewards → RewardAddress × Coin → Rewards
+    applyOne acc (addr , amt) =
+      case lookupᵐ? acc (stake addr) of λ where
+        (just bal) → ❴ stake addr , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ stake addr ❵ ᶜ)
+        nothing    → acc
+        -- `nothing` case is defensive; the PRE-CERT precondition guarantees the
+        -- credential is registered, but handling it makes the function total.
+```
+
+In the Dijkstra era, CIP-159 allows **partial withdrawals**: a transaction may
+withdraw any amount up to the current account balance.
+`applyWithdrawals`{.AgdaFunction} subtracts each withdrawal amount from the
+corresponding account balance.  Full withdrawals remain valid as a special case
+(where the withdrawn amount equals the balance, leaving a zero balance).
+
+The `PRE-CERT`{.AgdaDatatype} rule calls `applyWithdrawals`{.AgdaFunction}
+to process withdrawals as part of certificate processing.
+
 <!--
 ```agda
 instance
@@ -407,12 +433,30 @@ data _⊢_⇀⦇_,CERT⦈_  : CertEnv → CertState → DCert → CertState → 
     ∙ Γ ⊢ stᵍ ⇀⦇ dCert ,GOVCERT⦈ stᵍ'
       ────────────────────────────────
       Γ ⊢ ⟦ stᵈ , stᵖ , stᵍ ⟧ ⇀⦇ dCert ,CERT⦈ ⟦ stᵈ , stᵖ , stᵍ' ⟧
+```
 
+## PRE-CERT Transition Rule
 
--- PRE-CERT Transition Rule --
+### Withdrawal Processing
 
+The `PRE-CERT`{.AgdaDatatype} rule processes withdrawals before certificate
+evaluation.  In the Dijkstra era, CIP-159 extends the withdrawal semantics from an
+"all-or-nothing" model (where the withdrawn amount must equal the full account
+balance) to a "partial withdrawal" model (where any amount up to the full balance
+may be withdrawn).
+
+The precondition checks that each withdrawal targets a registered account and that
+the withdrawal amount does not exceed the account's current balance.  The effect
+subtracts the withdrawal amounts from the corresponding account balances via
+`applyWithdrawals`{.AgdaFunction}.
+
+<!--
+```agda
 open GovVote using (voter)
+```
+-->
 
+```agda
 data _⊢_⇀⦇_,PRE-CERT⦈_ : CertEnv → CertState → ⊤ → CertState → Type where
 
   CERT-pre :
@@ -421,13 +465,24 @@ data _⊢_⇀⦇_,PRE-CERT⦈_ : CertEnv → CertState → ⊤ → CertState →
         wdrlCreds       = mapˢ stake (dom wdrls)
     in
     ∙ filter isKeyHash wdrlCreds ⊆ dom voteDelegs
-    ∙ mapˢ (map₁ stake) (wdrls ˢ) ⊆ rewards ˢ
+    ∙ wdrlCreds ⊆ dom rewards
+    ∙ ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ᵐ lookupᵐ? rewards (stake addr)
       ────────────────────────────────
-      ⟦ e , pp , vs , wdrls , cc ⟧ ⊢ ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , ⟦ dReps , ccHotKeys , deposits' ⟧ ⟧ ⇀⦇ _ ,PRE-CERT⦈ ⟦ ⟦ voteDelegs , stakeDelegs , constMap wdrlCreds 0 ∪ˡ rewards , deposits ⟧ , stᵖ , ⟦ refreshedDReps , ccHotKeys , deposits' ⟧ ⟧
+      ⟦ e , pp , vs , wdrls , cc ⟧ ⊢
+        ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , ⟦ dReps , ccHotKeys , deposits' ⟧ ⟧
+          ⇀⦇ _ ,PRE-CERT⦈
+        ⟦ ⟦ voteDelegs , stakeDelegs , applyWithdrawals wdrls rewards , deposits ⟧ , stᵖ , ⟦ refreshedDReps , ccHotKeys , deposits' ⟧ ⟧
+```
 
+**TODO**: Version restriction (deferred).  CIP-159 specifies that partial withdrawals are
+only permitted in transactions without Plutus v1–v3 scripts (i.e., `legacyMode ≡ false`).
+Enforcing this requires threading `legacyMode` into `CertEnv`, which in turn requires
+changes to the `SUBLEDGER` and `LEDGER` rules.  This restriction will be added in a
+follow-up issue.
 
--- POST-CERT Transition Rule --
+## POST-CERT Transition Rule
 
+```agda
 data _⊢_⇀⦇_,POST-CERT⦈_ : CertEnv → CertState → ⊤ → CertState → Type where
 
   CERT-post :

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -165,16 +165,25 @@ instance
     with computeProof Γ (CertState.gState cs) dCert | completeness _ _ _ _ h
   ... | success _ | refl = refl
 
+
+  -- ⁇-≤ᵐ is intentionally placed here (after Computational-CERT) to avoid
+  -- polluting instance resolution for the DELEG/POOL/GOVCERT proofs above.
+  ⁇-≤ᵐ : {amt : Coin} {mb : Maybe Coin} → (amt ≤ᵐ mb) ⁇
+  ⁇-≤ᵐ .dec = Dec-≤ᵐ
+
   Computational-PRE-CERT : Computational _⊢_⇀⦇_,PRE-CERT⦈_ String
   Computational-PRE-CERT .computeProof ce cs _ =
     case ¿  filterˢ isKeyHash (mapˢ CredentialOf (dom (WithdrawalsOf ce))) ⊆ dom (VoteDelegsOf cs)
-            × mapˢ (map₁ CredentialOf) (WithdrawalsOf ce ˢ) ⊆ (RewardsOf cs) ˢ  ¿
+            × mapˢ CredentialOf (dom (WithdrawalsOf ce)) ⊆ dom (RewardsOf cs)
+            × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ᵐ lookupᵐ? (RewardsOf cs) (CredentialOf addr)  ¿
     of λ where
       (yes p) → success (-, CERT-pre p)
       (no ¬p) → failure (genErrors ¬p)
+
   Computational-PRE-CERT .completeness ce st _ st' (CERT-pre p) rewrite
     dec-yes ¿  filterˢ isKeyHash (mapˢ CredentialOf (dom (WithdrawalsOf ce))) ⊆ dom (VoteDelegsOf st)
-               × mapˢ (map₁ CredentialOf) (WithdrawalsOf ce ˢ) ⊆ (RewardsOf st) ˢ  ¿
+               × mapˢ CredentialOf (dom (WithdrawalsOf ce)) ⊆ dom (RewardsOf st)
+               × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ᵐ lookupᵐ? (RewardsOf st) (CredentialOf addr)  ¿
         p .proj₂ = refl
 
   Computational-POST-CERT : Computational _⊢_⇀⦇_,POST-CERT⦈_ String

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -166,16 +166,11 @@ instance
   ... | success _ | refl = refl
 
 
-  -- ⁇-≤ᵐ is intentionally placed here (after Computational-CERT) to avoid
-  -- polluting instance resolution for the DELEG/POOL/GOVCERT proofs above.
-  ⁇-≤ᵐ : {amt : Coin} {mb : Maybe Coin} → (amt ≤ᵐ mb) ⁇
-  ⁇-≤ᵐ .dec = Dec-≤ᵐ
-
   Computational-PRE-CERT : Computational _⊢_⇀⦇_,PRE-CERT⦈_ String
   Computational-PRE-CERT .computeProof ce cs _ =
     case ¿  filterˢ isKeyHash (mapˢ CredentialOf (dom (WithdrawalsOf ce))) ⊆ dom (VoteDelegsOf cs)
             × mapˢ CredentialOf (dom (WithdrawalsOf ce)) ⊆ dom (RewardsOf cs)
-            × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ᵐ lookupᵐ? (RewardsOf cs) (CredentialOf addr)  ¿
+            × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (CredentialOf addr))  ¿
     of λ where
       (yes p) → success (-, CERT-pre p)
       (no ¬p) → failure (genErrors ¬p)
@@ -183,7 +178,7 @@ instance
   Computational-PRE-CERT .completeness ce st _ st' (CERT-pre p) rewrite
     dec-yes ¿  filterˢ isKeyHash (mapˢ CredentialOf (dom (WithdrawalsOf ce))) ⊆ dom (VoteDelegsOf st)
                × mapˢ CredentialOf (dom (WithdrawalsOf ce)) ⊆ dom (RewardsOf st)
-               × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ᵐ lookupᵐ? (RewardsOf st) (CredentialOf addr)  ¿
+               × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ maybe id 0 (lookupᵐ? (RewardsOf st) (CredentialOf addr))  ¿
         p .proj₂ = refl
 
   Computational-POST-CERT : Computational _⊢_⇀⦇_,POST-CERT⦈_ String

--- a/src/Ledger/Prelude.lagda.md
+++ b/src/Ledger/Prelude.lagda.md
@@ -3,15 +3,17 @@ source_branch: master
 source_path: src/Ledger/Prelude.lagda.md
 ---
 
-## Ledger prelude
-
-This module re-exports modules relating to STS, set theory and other miscellaneous
-things used to write the ledger rules. If something is used in more than two Ledger.*
-modules, it should probably go here.
-
-<!--
 ```agda
 {-# OPTIONS --safe #-}
+
+--------------------------------------------------------------------------------
+-- Ledger prelude
+--
+-- Re-exports modules relating to STS, set theory and other
+-- miscellaneous things used to write the ledger rules. If something
+-- is used in more than two Ledger.* modules, it should probably go
+-- here.
+--------------------------------------------------------------------------------
 
 module Ledger.Prelude where
 
@@ -48,10 +50,7 @@ import Data.Integer as ℤ
 open import Data.Integer using (0ℤ) public
 import Data.Rational as ℚ
 open import Data.Rational using (ℚ)
-```
--->
 
-```agda
 dec-de-morgan : ∀{P Q : Type} → ⦃ P ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
 dec-de-morgan ⦃ ⁇ no ¬p ⦄ ¬pq = inj₁ ¬p
 dec-de-morgan ⦃ ⁇ yes p ⦄ ¬pq = inj₂ λ q → ¬pq (p , q)
@@ -99,17 +98,4 @@ Is-∅ X = Is-[] (setToList X)
 
 concatMapˡ : {A B : Type} → (A → ℙ B) → List A → ℙ B
 concatMapˡ f as = proj₁ $ unions (fromList (map f as))
-
-_≤ᵐ_ : Coin → Maybe Coin → Type
-amt ≤ᵐ just bal  = amt ≤ bal
-amt ≤ᵐ nothing   = ⊥
 ```
-
-<!--
-```agda
-instance
-  Dec-≤ᵐ : {amt : Coin} {mb : Maybe Coin} → Dec (amt ≤ᵐ mb)
-  Dec-≤ᵐ {amt} {just n} = amt ≤? n
-  Dec-≤ᵐ {mb = nothing} = no λ ()
-```
--->

--- a/src/Ledger/Prelude.lagda.md
+++ b/src/Ledger/Prelude.lagda.md
@@ -3,17 +3,15 @@ source_branch: master
 source_path: src/Ledger/Prelude.lagda.md
 ---
 
+## Ledger prelude
+
+This module re-exports modules relating to STS, set theory and other miscellaneous
+things used to write the ledger rules. If something is used in more than two Ledger.*
+modules, it should probably go here.
+
+<!--
 ```agda
 {-# OPTIONS --safe #-}
-
---------------------------------------------------------------------------------
--- Ledger prelude
---
--- Re-exports modules relating to STS, set theory and other
--- miscellaneous things used to write the ledger rules. If something
--- is used in more than two Ledger.* modules, it should probably go
--- here.
---------------------------------------------------------------------------------
 
 module Ledger.Prelude where
 
@@ -50,7 +48,10 @@ import Data.Integer as ℤ
 open import Data.Integer using (0ℤ) public
 import Data.Rational as ℚ
 open import Data.Rational using (ℚ)
+```
+-->
 
+```agda
 dec-de-morgan : ∀{P Q : Type} → ⦃ P ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
 dec-de-morgan ⦃ ⁇ no ¬p ⦄ ¬pq = inj₁ ¬p
 dec-de-morgan ⦃ ⁇ yes p ⦄ ¬pq = inj₂ λ q → ¬pq (p , q)
@@ -98,4 +99,17 @@ Is-∅ X = Is-[] (setToList X)
 
 concatMapˡ : {A B : Type} → (A → ℙ B) → List A → ℙ B
 concatMapˡ f as = proj₁ $ unions (fromList (map f as))
+
+_≤ᵐ_ : Coin → Maybe Coin → Type
+amt ≤ᵐ just bal  = amt ≤ bal
+amt ≤ᵐ nothing   = ⊥
 ```
+
+<!--
+```agda
+instance
+  Dec-≤ᵐ : {amt : Coin} {mb : Maybe Coin} → Dec (amt ≤ᵐ mb)
+  Dec-≤ᵐ {amt} {just n} = amt ≤? n
+  Dec-≤ᵐ {mb = nothing} = no λ ()
+```
+-->


### PR DESCRIPTION
## Description

This PR closes Issue #1116.

**Reviewer Note**.  This PR branches off of #1125 (Issue #1115), so it targets that branch to make reviewing the diffs easier.

This PR updates the `PRE-CERT` rule to support partial withdrawals as specified by
[CIP-159](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0159); specifically, handling of withdrawals changes from an "all-or-nothing" model (the withdrawn amount must equal the full account balance) to a "partial withdrawal" model (any amount up to the current balance may be withdrawn).

### Changes

`src/Ledger/Dijkstra/Specification/Certs.lagda.md`:

+  **New function**.  `applyWithdrawals : Withdrawals → Rewards → Rewards` — fold-based pointwise subtraction; For each `(addr, amt)` in the withdrawal map, looks up `stake addr` in rewards, computes `bal ∸ amt`, and replaces the entry via a singleton `∪ˡ` with complement restriction; credentials not in the withdrawal map are unaffected.

+  **Updated `PRE-CERT` preconditions**.  
   1.  `filter isKeyHash wdrlCreds ⊆ dom voteDelegs` (unchanged).
   2.  `wdrlCreds ⊆ dom rewards` — all withdrawal credentials are registered.
   3.  `∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rewards (stake addr))` — each withdrawal amount ≤ current balance.

       In case `stake addr` is not in the domain of the `rewards` map, then `maybe id 0 (lookupᵐ? rewards (stake addr))` is 0, in which case the predicate fails if `amt` is nonzero and succeeds otherwise.

       Note this means a withdraw of 0 will not cause the predicate to fail, even if the staking credential of `addr` is not in the domain of `rewards`.

+  **Updated `PRE-CERT` effect**.
   +  Old: `constMap wdrlCreds 0 ∪ˡ rewards` — zeroes out withdrawn credentials.
   +  New: `applyWithdrawals wdrls rewards` — subtracts withdrawal amounts pointwise.

+  **New documentation**.  Explains the partial withdrawal semantics, documents that full withdrawals remain valid as a special case (`amt ≡ bal` gives `bal ∸ amt = 0`), and notes the deferred version restriction.


`src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md`:

+  **Updated `Computational-PRE-CERT`**.  Both `computeProof` and `completeness` use the new three-premise `¿ ... ¿` expression.

---

### Design Considerations

+  **Fold-based `applyWithdrawals`**.  Iterates over withdrawal entries, using `lookupᵐ?` + `∸` + singleton `∪ˡ` with complement restriction for each entry; avoids needing a `mapKeys stake wdrls` conversion (which fails because `stake : RewardAddress → Credential` drops the `net` field and isn't injective).

+  **`DELEG-dereg` unchanged**.  The `(c , 0) ∈ rwds` precondition is preserved; CIP-159 does not change deregistration rules; users must withdraw all funds before deregistering, which is now possible via one or more partial withdrawals.

+  **`legacyMode` version restriction deferred**.  CIP-159 specifies partial withdrawals are only permitted without V1–V3 scripts; eEnforcing this requires adding `legacyMode : Bool` to `CertEnv` and threading it through `SUBLEDGER`/`LEDGER`, which requires UTXOW interface changes; deferred to a follow-up issue; #1119 already gates CIP-159 *fields* in legacy mode; the remaining gap (partial withdrawals in legacy mode without CIP-159 fields) is a refinement.

## Acceptance criteria checklist

- [x] `PRE-CERT` allows partial withdrawals (amount ≤ balance)
- [x] `PRE-CERT` correctly subtracts partial withdrawal amounts
- [x] Existing full-withdrawal semantics remain valid (special case)
- [x] Module compiles with `--safe`


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
