### PR TITLE
CIP-159-08 phantom asset attack prevention (PR target: 1112-master)

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
@@ -709,6 +709,14 @@ allowed to inspect utxo for its inputs.
     foldl (λ acc txSub → acc ∪⁺ DirectDepositsOf txSub)
           (DirectDepositsOf txTop)
           (SubTransactionsOf txTop)
+
+  -- Batch-wide withdrawal aggregation: sums withdrawal amounts for the same reward
+  -- address across the top-level transaction and all sub-transactions.
+  allWithdrawals : TopLevelTx → Withdrawals
+  allWithdrawals txTop =
+    foldl  (λ acc txSub → acc ∪⁺ WithdrawalsOf txSub)
+           (WithdrawalsOf txTop)
+           (SubTransactionsOf txTop)
 ```
 
 

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -308,9 +308,7 @@ collateralCheck pp txTop utxo =
   × isAdaOnly (balance (utxo ∣ CollateralInputsOf txTop))
   × coin (balance (utxo ∣ CollateralInputsOf txTop)) * 100 ≥ (TxFeesOf txTop) * pp .collateralPercentage
   × (CollateralInputsOf txTop) ≢ ∅
-```
 
-```agda
 module _ (depositsChange : DepositsChange) where
 
   open DepositsChange depositsChange
@@ -340,15 +338,6 @@ module _ (depositsChange : DepositsChange) where
   consumedBatch txTop utxo = consumed txTop utxo
                              + ∑ˡ[ stx ← SubTransactionsOf txTop ] (consumedTx stx utxo)
                              + inject depositRefundsSub
-```
-
-Direct deposits represent value that flows from the transaction into account
-addresses.  In the preservation-of-value equation, direct deposits appear on the
-*produced* side: value leaves the UTxO and enters account balances.  The
-`getCoin (DirectDepositsOf tx)` term sums the ADA of all direct deposits in
-the transaction.
-
-```agda
   producedTx : Tx ℓ → Value
   producedTx tx = balance (outs tx)
                   + inject (DonationsOf tx)
@@ -364,6 +353,42 @@ the transaction.
                         + ∑ˡ[ stx ← SubTransactionsOf txTop ] (producedTx stx)
                         + inject newDepositsSub
 ```
+
+## CIP-159 Notes
+
+### Preservation of Value
+
+CIP-159 introduces two new fields to transactions: `directDeposits` and
+`balanceIntervals`.  Direct deposits represent value that flows from the transaction
+into account addresses.
+
+In the preservation-of-value equation, direct deposits appear on the
+*produced* side: value leaves the UTxO and enters account balances.  The
+`getCoin (DirectDepositsOf tx)` term, appearing in the definition of
+`producedTx`{.AgdaFunction}, sums the ADA of all direct deposits in
+the transaction.
+
+### Phantom Asset Prevention
+
+```agda
+NoPhantomWithdrawals : Rewards → TopLevelTx → Type
+NoPhantomWithdrawals preBalances txTop =
+  ∀[ (addr , amt) ∈ allWithdrawals txTop ˢ ]
+    amt ≤ maybe id 0 (lookupᵐ? preBalances (RewardAddress.stake addr))
+```
+
+**The Problem**.  CIP-159 identifies a "phantom asset" attack when nested
+transactions combine direct deposits and withdrawals to the same account within a
+single batch.  If a sub-transaction deposits ADA into an account and a later
+sub-transaction withdraws it, Plutus scripts may be tricked into believing native
+assets were minted.
+
+**The Solution**.  Withdrawals across the entire batch are bounded by the
+**pre-batch** account balances.  The `NoPhantomWithdrawals`{.AgdaFunction} predicate
+checks that the total withdrawal for each reward address (aggregated via
+`allWithdrawals`{.AgdaFunction}) does not exceed the pre-batch balance of the
+corresponding credential.  This mirrors the spend-side safety principle where
+spending inputs must come from the pre-batch UTxO snapshot (`utxo₀`{.AgdaField}).
 
 
 ## The <span class="AgdaDatatype">UTXOS</span> Transition System
@@ -546,6 +571,7 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
     ∙ MaybeNetworkIdOf txTop ~ just NetworkId
     ∙ CurrentTreasuryOf txTop  ~ just (TreasuryOf Γ)
     ∙ dom (DirectDepositsOf txTop) ⊆ dom (AccountBalancesOf Γ)
+    ∙ NoPhantomWithdrawals (AccountBalancesOf Γ) txTop
     ∙ ∀[ (c , interval) ∈ BalanceIntervalsOf txTop ˢ ]
         InBalanceInterval (maybe id 0 (lookupᵐ? (AccountBalancesOf Γ) c)) interval
     ∙ Γ ⊢ _ ⇀⦇ txTop ,UTXOS⦈ _
@@ -560,8 +586,8 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
 <!--
 ```agda
 unquoteDecl UTXO-premises = genPremises UTXO-premises (quote UTXO)
-pattern UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ h
-  = UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , h)
+pattern UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ p₂₁ h
+  = UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , h)
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Utxo/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo/Properties/Computational.lagda.md
@@ -130,30 +130,30 @@ instance
       ... | false | [ refl ]
         with H?
       ... | (no ¬p) = failure "UTXO" -- (genErrors ¬p)
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀)
+      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop
-      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , proj₂ h))
+      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , proj₂ h))
       ... | failure ¬h = failure "UTXOS"
       computeProof | true | [ refl ]
         with H?
       ... | (no ¬p) = failure "UTXO" -- (genErrors ¬p)
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀)
+      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop
-      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , proj₂ h))
+      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , proj₂ h))
       ... | failure ¬h = failure "UTXOS"
 
       completeness : ∀ s₁ → Γ,legacyMode ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁ → map proj₁ computeProof ≡ success s₁
-      completeness s₁ (UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ h)
+      completeness s₁ (UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ p₂₁ h)
         with IsValidFlagOf txTop | inspect IsValidFlagOf txTop
       ... | false | [ refl ]
         with H?
-      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀)))
+      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)))
       ... | yes _
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop | UTXOS.completeness _ _ _ _ h
       ... | success h | refl = refl
-      completeness s₁ (UTXO-⋯ p₀  p₁  p₂  p₃  p₄  p₅  p₆  p₇  p₈  p₉  p₁₀  p₁₁  p₁₂  p₁₃  p₁₄  p₁₅  p₁₆  p₁₇  p₁₈ p₁₉ p₂₀ h) | true | [ refl ]
+      completeness s₁ (UTXO-⋯ p₀  p₁  p₂  p₃  p₄  p₅  p₆  p₇  p₈  p₉  p₁₀  p₁₁  p₁₂  p₁₃  p₁₄  p₁₅  p₁₆  p₁₇  p₁₈ p₁₉ p₂₀ p₂₁ h) | true | [ refl ]
         with H?
-      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀)))
+      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)))
       ... | yes _
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop | UTXOS.completeness _ _ _ _ h
       ... | success h | refl = refl


### PR DESCRIPTION
## Description

Addresses Issue #1120.

**NOTE FOR REVIEWER**.  This PR depends on #1117 (UTxO rules) for the `accountBalances` field in `UTxOEnv`.  It does not depend on #1119 at the code level (no imports from `Utxow`), though #1119 is a logical prerequisite (version gating ensures CIP-159 fields can't appear in legacy mode).

---

### Changes

`src/Ledger/Dijkstra/Specification/Transaction.lagda.md`

+  **New function**. `allWithdrawals : TopLevelTx → Withdrawals` — aggregates withdrawal amounts across the top-level transaction and all sub-transactions using `∪⁺`, mirroring the existing `allDirectDeposits` helper.

`src/Ledger/Dijkstra/Specification/Utxo.lagda.md`

+  **New predicate**.  `NoPhantomWithdrawals : Rewards → TopLevelTx → Type` — for each `(addr, amt)` in the batch-wide aggregated withdrawals, checks that `amt ≤ lookupᵐ? preBalances (stake addr)`.

+  **New `UTXO` premise**.  `NoPhantomWithdrawals (AccountBalancesOf Γ) txTop` added as a conjunct in the UTXO rule.

+  **New documentation**.  Explains the phantom asset attack, the mitigation (pre-batch withdrawal bounds), and the analogy with spend-side safety (`utxo₀` pattern).

`src/Ledger/Dijkstra/Specification/Utxo/Properties/Computational.lagda.md`

+  **Updated `Computational-UTXO`**.  Premise tuple grows from 21+h to 22+h.

---

### Design Notes

+  **Batch-wide check in UTXO, not per-sub-tx in SUBUTXO**.  The phantom asset check inspects all sub-transactions at once via `allWithdrawals`.  `SUBUTXO` only sees one sub-transaction at a time and cannot enforce the batch-wide invariant.

+  **`allWithdrawals` uses `∪⁺` (additive union)**.  If the same reward address appears in multiple sub-transactions, amounts are summed.  This correctly captures the total withdrawal pressure on each account.

+  **Pre-batch balances via `AccountBalancesOf Γ`**.  The check uses the frozen pre-batch snapshot, not the running balance after earlier sub-transactions.  This mirrors the `utxo₀` pattern for spend-side safety.

---

### Acceptance criteria checklist

- [x] `NoPhantomWithdrawals` predicate defined
- [x] `allWithdrawals` batch aggregation helper defined
- [x] New premise added to `UTXO` rule
- [x] Pre-batch account balances correctly used via `AccountBalancesOf Γ`
- [x] Check covers both top-level and sub-transaction withdrawals
- [x] `Computational-UTXO` updated for new premise
- [x] Module compiles with `--safe`

---

## Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
