### PR TITLE
Improve typechecking speed of some slow modules

### DIFF
--- a/src/Ledger/Conway/Specification/Epoch/Properties/ExpiredDReps.lagda.md
+++ b/src/Ledger/Conway/Specification/Epoch/Properties/ExpiredDReps.lagda.md
@@ -440,6 +440,40 @@ record Post-POOLREAP-Update-[_]_≈_ (e : Epoch) (pPRUpd₁ pPRUpd₂ : Post-POO
     dState'' : pPRUpd₁.dState'' ≡ pPRUpd₂.dState''
     acnt''   : pPRUpd₁.acnt'' ≡ pPRUpd₂.acnt''
 
+opaque
+  unfolding Post-POOLREAPUpdate.payout
+
+  Post-POOLREAPUpdate-govActionReturns-cong
+    : ∀ {es₁ es₂ : EnactState} {ls₁ ls₂ : LState}
+        {dSt₁ dSt₂ : DState} {acnt₁ acnt₂ : Acnt}
+        {govUpd₁ govUpd₂ : Governance-Update}
+    → govUpd₁ ≡ govUpd₂
+    → Post-POOLREAPUpdate.govActionReturns es₁ ls₁ dSt₁ acnt₁ govUpd₁
+      ≡ Post-POOLREAPUpdate.govActionReturns es₂ ls₂ dSt₂ acnt₂ govUpd₂
+  Post-POOLREAPUpdate-govActionReturns-cong refl = refl
+
+  Post-POOLREAPUpdate-payout-cong
+    : ∀ {es₁ es₂ : EnactState} {ls₁ ls₂ : LState}
+        {dSt₁ dSt₂ : DState} {acnt₁ acnt₂ : Acnt}
+        {govUpd₁ govUpd₂ : Governance-Update}
+    → es₁ ≡ es₂ → govUpd₁ ≡ govUpd₂
+    → Post-POOLREAPUpdate.payout es₁ ls₁ dSt₁ acnt₁ govUpd₁
+      ≡ Post-POOLREAPUpdate.payout es₂ ls₂ dSt₂ acnt₂ govUpd₂
+  Post-POOLREAPUpdate-payout-cong refl refl = refl
+
+opaque
+  unfolding Post-POOLREAPUpdate.refunds
+  unfolding Post-POOLREAPUpdate.payout
+
+  Post-POOLREAPUpdate-refunds-cong
+    : ∀ {es₁ es₂ : EnactState} {ls₁ ls₂ : LState}
+        {dSt₁ dSt₂ : DState} {acnt₁ acnt₂ : Acnt}
+        {govUpd₁ govUpd₂ : Governance-Update}
+    → es₁ ≡ es₂ → dSt₁ ≡ dSt₂ → govUpd₁ ≡ govUpd₂
+    → Post-POOLREAPUpdate.refunds es₁ ls₁ dSt₁ acnt₁ govUpd₁
+      ≡ Post-POOLREAPUpdate.refunds es₂ ls₂ dSt₂ acnt₂ govUpd₂
+  Post-POOLREAPUpdate-refunds-cong refl refl refl = refl
+
 module Post-POOLREAP-update
   {eSt eSt' : EnactState} {lSt lSt' : LState} {dSt dSt' : DState} {acnt acnt' : Acnt} {govUpd govUpd' : Governance-Update}
   (e : Epoch)
@@ -449,20 +483,14 @@ module Post-POOLREAP-update
   module pPRUpd₁ = Post-POOLREAPUpdate eSt lSt dSt acnt govUpd
   module pPRUpd₂ = Post-POOLREAPUpdate eSt' lSt' dSt' acnt' govUpd'
 
-  opaque
-    unfolding Post-POOLREAPUpdate.payout
+  govActionReturns : pPRUpd₁.govActionReturns ≡ pPRUpd₂.govActionReturns
+  govActionReturns = Post-POOLREAPUpdate-govActionReturns-cong govUpd≡govUpd'
 
-    govActionReturns : pPRUpd₁.govActionReturns ≡ pPRUpd₂.govActionReturns
-    govActionReturns rewrite govUpd≡govUpd' = refl
+  payout : pPRUpd₁.payout ≡ pPRUpd₂.payout
+  payout = Post-POOLREAPUpdate-payout-cong eSt≡eSt' govUpd≡govUpd'
 
-    payout : pPRUpd₁.payout ≡ pPRUpd₂.payout
-    payout rewrite eSt≡eSt' | govActionReturns = refl
-
-  opaque
-    unfolding Post-POOLREAPUpdate.refunds
-
-    refunds : pPRUpd₁.refunds ≡ pPRUpd₂.refunds
-    refunds rewrite payout | dSt≡dSt' = refl
+  refunds : pPRUpd₁.refunds ≡ pPRUpd₂.refunds
+  refunds = Post-POOLREAPUpdate-refunds-cong eSt≡eSt' dSt≡dSt' govUpd≡govUpd'
 
   dState'' : pPRUpd₁.dState'' ≡ pPRUpd₂.dState''
   dState'' rewrite refunds | dSt≡dSt' = refl

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -110,11 +110,11 @@ instance
                        → map proj₁ (computeProof-aux dV3 dLeg dNorm) ≡ success s₁
       completeness-aux (yes (s , p , q)) _ _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _) =
         ⊥-elim (Properties.∉-∅ (V1,V2,V3∩V4⊆∅ (∈-∩ .Equivalence.to (q , (p₀ p)))))
-      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _) =
+      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _) =
         ⊥-elim (¬p p₀)
-      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ _) =
-        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀))
-      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ h)
+      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂))
+      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
         with UTXO.computeProof (Γ , true) s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
       completeness-aux (no _) _ (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ _) =

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -38,18 +38,26 @@ instance
 
       module SUBUTXO = Computational Computational-SUBUTXO
 
-      computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁))
-      computeProof with H?
-      ... | no ¬p = failure "SUBUTXOW"
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉) =
+      computeProof-aux : Dec H → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁))
+      computeProof-aux (no ¬p) = failure "SUBUTXOW"
+      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉)) =
           map (map₂′ (λ h → SUBUTXOW {txSub = txSub} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , h)))
               (SUBUTXO.computeProof Γ s₀ txSub)
 
-      completeness : ∀ s₁ → Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁ → map proj₁ computeProof ≡ success s₁
-      completeness s₁ (SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ h) with H?
-      ... | no ¬p = ⊥-elim $ ¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉))
-      ... | yes _ with SUBUTXO.computeProof Γ s₀ txSub | SUBUTXO.completeness _ _ _ _ h
+      computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁))
+      computeProof = computeProof-aux H?
+
+      completeness-aux : (d : Dec H) (s₁ : UTxOState)
+                       → Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁
+                       → map proj₁ (computeProof-aux d) ≡ success s₁
+      completeness-aux (no ¬p) _ (SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ h) =
+        ⊥-elim $ ¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉)
+      completeness-aux (yes _) _ (SUBUTXOW-⋯ _ _ _ _ _ _ _ _ _ _ h)
+        with SUBUTXO.computeProof Γ s₀ txSub | SUBUTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
+
+      completeness : ∀ s₁ → Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁ → map proj₁ computeProof ≡ success s₁
+      completeness = completeness-aux H?
 
   Computational-UTXOW : Computational _⊢_⇀⦇_,UTXOW⦈_ String
   Computational-UTXOW = record {go} where
@@ -80,33 +88,41 @@ instance
 
       module UTXO = Computational Computational-UTXO
 
-      computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
-      computeProof
-        with ¿ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿
-      ... | yes p with H?-legacy
-      ... | no ¬p = failure "UTXOW"
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂) =
+      DecV3 = Dec (∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []))
+
+      computeProof-aux : DecV3 → Dec H-legacy → Dec H-normal
+                       → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
+      computeProof-aux (yes _) (no _) _ = failure "UTXOW"
+      computeProof-aux (yes _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂)) _ =
         map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , h)))
             (UTXO.computeProof (Γ , true) s₀ txTop)
-      computeProof | no ¬p with H?-normal
-      ... | no ¬p = failure "UTXOW"
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉) =
+      computeProof-aux (no _) _ (no _) = failure "UTXOW"
+      computeProof-aux (no _) _ (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉)) =
         map (map₂′ (λ h → UTXOW-normal {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , h)))
             (UTXO.computeProof (Γ , false) s₀ txTop)
 
+      computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
+      computeProof = computeProof-aux ¿ _ ¿ H?-legacy H?-normal
+
+      completeness-aux : (dV3 : DecV3) (dLeg : Dec H-legacy) (dNorm : Dec H-normal)
+                         (s₁ : UTxOState)
+                       → Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁
+                       → map proj₁ (computeProof-aux dV3 dLeg dNorm) ≡ success s₁
+      completeness-aux (yes (s , p , q)) _ _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _) =
+        ⊥-elim (Properties.∉-∅ (V1,V2,V3∩V4⊆∅ (∈-∩ .Equivalence.to (q , (p₀ p)))))
+      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _) =
+        ⊥-elim (¬p p₀)
+      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀))
+      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ h)
+        with UTXO.computeProof (Γ , true) s₀ txTop | UTXO.completeness _ _ _ _ h
+      ... | success _ | refl = refl
+      completeness-aux (no _) _ (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉))
+      completeness-aux (no _) _ (yes _) _ (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ h)
+        with UTXO.computeProof (Γ , false) s₀ txTop | UTXO.completeness _ _ _ _ h
+      ... | success _ | refl = refl
+
       completeness : ∀ s₁ → Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁ → map proj₁ computeProof ≡ success s₁
-      completeness s₁ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ h) 
-        with ¿ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿
-      ... | yes (s , p , q) = ⊥-elim (Properties.∉-∅ (V1,V2,V3∩V4⊆∅ (∈-∩ .Equivalence.to (q , (p₀ p)))))
-      ... | no ¬p  with H?-normal
-      ... | no ¬p = ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉))
-      ... | yes _ with UTXO.computeProof (Γ , false) s₀ txTop | UTXO.completeness _ _ _ _ h
-      ... | success _ | refl = refl
-      completeness s₁ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ h)
-        with ¿ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿
-      ... | no ¬p  = ⊥-elim (¬p p₀)
-      ... | yes p with H?-legacy
-      ... | no ¬p = ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂))
-      ... | yes _ with UTXO.computeProof (Γ , true) s₀ txTop | UTXO.completeness _ _ _ _ h
-      ... | success _ | refl = refl
+      completeness = completeness-aux ¿ _ ¿ H?-legacy H?-normal
 ```


### PR DESCRIPTION
# Description

I've recently written a claude skill for finding performance issues, and after some smaller wins I tried it here for a real challenge. I've put the two modules it improved into separate commits.

Here are the profiling results I get on my machine:
Before:
```
Total                                                                               165,357ms 
Miscellaneous                                                                        27,416ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.completeness       48,499ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.computeProof       34,370ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.computeProof       28,357ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.completeness       26,406ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.V1,V2,V3∩V4⊆∅         215ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational.Computational-UTXOW         69ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational.Computational-SUBUTXOW      22ms 
```
After:
```
Total                                                                               36,353ms 
Miscellaneous                                                                        7,731ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.completeness-aux  11,208ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.completeness-aux   9,899ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.computeProof-aux   6,201ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.computeProof-aux     818ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.V1,V2,V3∩V4⊆∅        231ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational.Computational-UTXOW        76ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.completeness          65ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.computeProof          36ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.completeness          36ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational.Computational-SUBUTXOW     28ms 
Ledger.Dijkstra.Specification.Utxow.Properties.Computational._.go.DecV3                 18ms 
```
Before:
```
Total                                                                                                 118,148ms 
Miscellaneous                                                                                          39,867ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.Post-POOLREAP-update.refunds                 30,378ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.Post-POOLREAP-update.payout                  12,653ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.POOLREAP.cong                                12,041ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.EPOCH.cong                                    4,449ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.EPOCH._.R.es                                  3,037ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.AcceptedConds-≈.acceptConds-→                 2,233ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.RATIFY.cong                                   1,593ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.EPOCH._.R.fut≡fut'                            1,351ms 
...
```
After:
```
Total                                                                                               46,911ms 
Miscellaneous                                                                                        8,827ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.Post-POOLREAPUpdate-refunds-cong          13,734ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.POOLREAP.cong                             11,661ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.EPOCH.cong                                 4,189ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.EPOCH._.R.es                               2,950ms 
Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps.EPOCH._.R.fut≡fut'                         1,972ms 
...
```

In total, this is an improvement of 129s in `Ledger.Dijkstra.Specification.Utxow.Properties.Computational` and 71s in `Ledger.Conway.Specification.Epoch.Properties.ExpiredDReps`. The downside is that the code is a bit longer & maybe more difficult to understand. Note that I haven't tried to find minimal code changes that preserve the performance characteristics, so it's possible that there are smaller diffs with the same benefit.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
