### PR TITLE
Remove formal-ledger as a dep. from nix shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
 
             default =
               (mkShell {
-                inputsFrom = builtins.attrValues pkgs';
+                inputsFrom = builtins.attrValues (removeAttrs pkgs' [ "formal-ledger-test" ]);
               }).overrideAttrs
                 (oldAttrs: {
                   buildInputs = oldAttrs.buildInputs ++ [


### PR DESCRIPTION
# Description

This PR fixes an issue introduced by #1175 in which nix shell depends on `formal-ledger` (as a dependency of `formal-ledger-test`)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
