### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,6 @@
     let
       systems = [
         "x86_64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
     in


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] ~~Any semantic changes to the specifications are documented in `CHANGELOG.md`~~
- [x] ~~Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)~~
- [x] Self-reviewed the diff
