### PR TITLE
[Dijkstra] (DEPRECATED) CIP-159-11a: Prove Certs preservation of value (#1185)

### DIFF
--- a/src/Ledger/Conway/Conformance/Properties.lagda.md
+++ b/src/Ledger/Conway/Conformance/Properties.lagda.md
@@ -124,8 +124,6 @@ module _ (s : ChainState) where
   -- Transaction properties
 
   module _ {slot} {tx} (let txb = body tx) (valid : validTxIn₂ s slot tx)
-    (indexedSum-∪⁺-hom : ∀ {A V : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq V ⦄ ⦃ mon : CommutativeMonoid 0ℓ 0ℓ V ⦄
-      → (d₁ d₂ : A ⇀ V) → indexedSumᵛ' id (d₁ ∪⁺ d₂) ≡ indexedSumᵛ' id d₁ ◇ indexedSumᵛ' id d₂)
     (indexedSum-⊆ : ∀ {A : Type} ⦃ _ : DecEq A ⦄ (d d' : A ⇀ ℕ) → d ˢ ⊆ d' ˢ
       → indexedSumᵛ' id d ≤ indexedSumᵛ' id d') -- technically we could use an ordered monoid instead of ℕ
     where

--- a/src/Ledger/Conway/Specification/Certs/Properties/PoV.lagda.md
+++ b/src/Ledger/Conway/Specification/Certs/Properties/PoV.lagda.md
@@ -46,19 +46,12 @@ private variable
 instance
   _ = +-0-monoid
 
-module Certs-PoV  ( indexedSumᵛ'-∪' :  {A : Type} ⦃ _ : DecEq A ⦄ (m m' : A ⇀ Coin)
-                              → disjoint (dom m) (dom m')
-                              → getCoin (m ∪ˡ m') ≡ getCoin m + getCoin m' )
-    -- TODO: prove some or all of the following assumptions, used in roof of `CERTBASE-pov`.
-    ( sumConstZero'    :  {A : Type} ⦃ _ : DecEq A ⦄ {X : ℙ A} → getCoin (constMap X 0) ≡ 0 )
-    ( res-decomp'      :  {A : Type} ⦃ _ : DecEq A ⦄ (m m' : A ⇀ Coin)
-                         → (m ∪ˡ m')ˢ ≡ᵉ (m ∪ˡ (m' ∣ dom (m ˢ) ᶜ))ˢ )
-    ( getCoin-cong'    :  {A : Type} ⦃ _ : DecEq A ⦄ (s : A ⇀ Coin) (s' : ℙ (A × Coin)) → s ˢ ≡ᵉ s'
-                         → indexedSum' proj₂ (s ˢ) ≡ indexedSum' proj₂ s' )
-    ( ≡ᵉ-getCoinˢ'     :  {A A' : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq A' ⦄ (s : ℙ (A × Coin)) {f : A → A'}
-                         → InjectiveOn (dom s) f → getCoin (mapˢ (map₁ f) s) ≡ getCoin s )
+module Certs-PoV
+    -- TODO: prove the following assumption, used in roof of `CERTBASE-pov`.
+    ( ≡ᵉ-getCoinˢ' :  {A A' : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq A' ⦄ (s : ℙ (A × Coin)) {f : A → A'}
+                      → InjectiveOn (dom s) f → getCoin (mapˢ (map₁ f) s) ≡ getCoin s )
     where
-    open Certs-Pov-lemmas indexedSumᵛ'-∪' sumConstZero' res-decomp' getCoin-cong' ≡ᵉ-getCoinˢ'
+    open Certs-Pov-lemmas ≡ᵉ-getCoinˢ'
 ```
 -->
 

--- a/src/Ledger/Conway/Specification/Certs/Properties/PoVLemmas.lagda.md
+++ b/src/Ledger/Conway/Specification/Certs/Properties/PoVLemmas.lagda.md
@@ -40,35 +40,12 @@ private variable
 instance
   _ = +-0-monoid
 
-getCoin-singleton : ⦃ _ : DecEq A ⦄ {(a , c) : A × Coin} → indexedSumᵛ' id ❴ (a , c) ❵ ≡ c
-getCoin-singleton = indexedSum-singleton' {M = Coin} (finiteness _)
-
-∪ˡsingleton∈dom :  ⦃ _ : DecEq A ⦄ (m : A ⇀ Coin) {(a , c) : A × Coin}
-                → a ∈ dom m → getCoin (m ∪ˡ ❴ (a , c) ❵ᵐ) ≡ getCoin m
-∪ˡsingleton∈dom m {(a , c)} a∈dom = ≡ᵉ-getCoin (m ∪ˡ ❴ (a , c) ❵) m (singleton-∈-∪ˡ {m = m} a∈dom)
-
 module _  ( indexedSumᵛ'-∪ :  {A : Type} ⦃ _ : DecEq A ⦄ (m m' : A ⇀ Coin)
                               → disjoint (dom m) (dom m')
                               → getCoin (m ∪ˡ m') ≡ getCoin m + getCoin m' )
   where
   open ≡-Reasoning
   open Equivalence
-
-  ∪ˡsingleton∉dom :  ⦃ _ : DecEq A ⦄ (m : A ⇀ Coin) {(a , c) : A × Coin}
-                   → a ∉ dom m → getCoin (m ∪ˡ ❴ (a , c) ❵ᵐ) ≡ getCoin m + c
-  ∪ˡsingleton∉dom m {(a , c)} a∉dom = begin
-    getCoin (m ∪ˡ ❴ a , c ❵ᵐ)
-      ≡⟨ indexedSumᵛ'-∪ m ❴ a , c ❵ᵐ
-         ( λ x y → a∉dom (subst (_∈ dom m) (from ∈-dom-singleton-pair y) x) ) ⟩
-    getCoin m + getCoin ❴ a , c ❵ᵐ
-      ≡⟨ cong (getCoin m +_) getCoin-singleton ⟩
-    getCoin m + c
-      ∎
-
-  ∪ˡsingleton0≡ : ⦃ _ : DecEq A ⦄ → (m : A ⇀ Coin) {a : A} → getCoin (m ∪ˡ ❴ (a , 0) ❵ᵐ) ≡ getCoin m
-  ∪ˡsingleton0≡ m {a} with a ∈? dom m
-  ... | yes a∈dom = ∪ˡsingleton∈dom m a∈dom
-  ... | no a∉dom = trans (∪ˡsingleton∉dom m a∉dom) (+-identityʳ (getCoin m))
 ```
 -->
 

--- a/src/Ledger/Conway/Specification/Certs/Properties/PoVLemmas.lagda.md
+++ b/src/Ledger/Conway/Specification/Certs/Properties/PoVLemmas.lagda.md
@@ -23,7 +23,7 @@ open import Axiom.Set.Properties th
 open import Algebra using (CommutativeMonoid)
 open import Data.Maybe.Properties
 open import Data.Nat.Properties using (+-0-monoid; +-0-commutativeMonoid; +-identityʳ; +-identityˡ)
-open import Relation.Binary using (IsEquivalence)
+import Relation.Binary as Eq using (IsEquivalence)
 open import Relation.Nullary.Decidable
 open import Tactic.ReduceDec
 
@@ -40,12 +40,7 @@ private variable
 instance
   _ = +-0-monoid
 
-module _  ( indexedSumᵛ'-∪ :  {A : Type} ⦃ _ : DecEq A ⦄ (m m' : A ⇀ Coin)
-                              → disjoint (dom m) (dom m')
-                              → getCoin (m ∪ˡ m') ≡ getCoin m + getCoin m' )
-  where
-  open ≡-Reasoning
-  open Equivalence
+open ≡-Reasoning
 ```
 -->
 
@@ -60,61 +55,55 @@ some `dcert`{.AgdaBound} : `DCert`{.AgdaDatatype}. Then,
 *Formally*.
 
 ```agda
-  CERT-pov : {Γ : CertEnv} {s s'  : CertState}
-    → Γ ⊢ s ⇀⦇ dCert ,CERT⦈ s'
-    → getCoin s ≡ getCoin s'
+CERT-pov : {Γ : CertEnv} {s s'  : CertState}
+  → Γ ⊢ s ⇀⦇ dCert ,CERT⦈ s' → getCoin s ≡ getCoin s'
 ```
 
 *Proof*.  (Click the "Show more Agda" button to reveal the proof.)
 
 <!--
 ```agda
-  CERT-pov (CERT-deleg (DELEG-delegate {rwds = rwds} _)) = sym (∪ˡsingleton0≡ rwds)
-  CERT-pov (CERT-deleg (DELEG-reg {rwds = rwds} _)) = sym (∪ˡsingleton0≡ rwds)
-  CERT-pov {s = ⟦ _ , stᵖ , stᵍ ⟧ᶜˢ}{⟦ _ , stᵖ' , stᵍ' ⟧ᶜˢ}
-    (CERT-deleg (DELEG-dereg {c = c} {rwds} {vDelegs = vDelegs}{sDelegs} x)) = begin
-    getCoin ⟦ ⟦ vDelegs , sDelegs , rwds ⟧ , stᵖ , stᵍ ⟧
-      ≡˘⟨ ≡ᵉ-getCoin rwds-∪ˡ-decomp rwds
-          ( ≡ᵉ.trans rwds-∪ˡ-∪ (≡ᵉ.trans ∪-sym (res-ex-∪ Dec-∈-singleton)) ) ⟩
-    getCoin rwds-∪ˡ-decomp
-      ≡⟨ ≡ᵉ-getCoin rwds-∪ˡ-decomp ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ) rwds-∪ˡ≡sing-∪ˡ  ⟩
-    getCoin ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ )
-      ≡⟨ ∪ˡsingleton0≡ (rwds ∣ ❴ c ❵ ᶜ) ⟩
-    getCoin ⟦ ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ ⟧ , stᵖ' , stᵍ' ⟧
-      ∎
-    where
-    module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
-    rwds-∪ˡ-decomp = (rwds ∣ ❴ c ❵ ᶜ) ∪ˡ (rwds ∣ ❴ c ❵ )
+CERT-pov (CERT-deleg (DELEG-delegate {rwds = rwds} _)) = sym (∪ˡsingleton0≡ rwds)
+CERT-pov (CERT-deleg (DELEG-reg {rwds = rwds} _)) = sym (∪ˡsingleton0≡ rwds)
+CERT-pov {s = ⟦ _ , stᵖ , stᵍ ⟧ᶜˢ}{⟦ _ , stᵖ' , stᵍ' ⟧ᶜˢ}
+  (CERT-deleg (DELEG-dereg {c = c} {rwds} {vDelegs = vDelegs}{sDelegs} x)) = begin
+  getCoin ⟦ ⟦ vDelegs , sDelegs , rwds ⟧ , stᵖ , stᵍ ⟧
+    ≡˘⟨ ≡ᵉ-getCoin rwds-∪ˡ-decomp rwds
+        ( ≡ᵉ.trans rwds-∪ˡ-∪ (≡ᵉ.trans ∪-sym (res-ex-∪ Dec-∈-singleton)) ) ⟩
+  getCoin rwds-∪ˡ-decomp
+    ≡⟨ ≡ᵉ-getCoin rwds-∪ˡ-decomp ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ) rwds-∪ˡ≡sing-∪ˡ  ⟩
+  getCoin ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ )
+    ≡⟨ ∪ˡsingleton0≡ (rwds ∣ ❴ c ❵ ᶜ) ⟩
+  getCoin ⟦ ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ ⟧ , stᵖ' , stᵍ' ⟧
+    ∎
+  where
+  module ≡ᵉ = Eq.IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+  rwds-∪ˡ-decomp = (rwds ∣ ❴ c ❵ ᶜ) ∪ˡ (rwds ∣ ❴ c ❵ )
 
-    rwds-∪ˡ-∪ : rwds-∪ˡ-decomp ˢ ≡ᵉ (rwds ∣ ❴ c ❵ ᶜ)ˢ ∪ (rwds ∣ ❴ c ❵)ˢ
-    rwds-∪ˡ-∪ = disjoint-∪ˡ-∪ (disjoint-sym res-ex-disjoint)
+  rwds-∪ˡ-∪ : rwds-∪ˡ-decomp ˢ ≡ᵉ (rwds ∣ ❴ c ❵ ᶜ)ˢ ∪ (rwds ∣ ❴ c ❵)ˢ
+  rwds-∪ˡ-∪ = disjoint-∪ˡ-∪ (disjoint-sym res-ex-disjoint)
 
-    disj : disjoint (dom ((rwds ∣ ❴ c ❵ˢ ᶜ) ˢ)) (dom (❴ c , 0 ❵ᵐ ˢ))
-    disj {a} a∈res a∈dom  = res-comp-dom a∈res (dom-single→single a∈dom)
+  disj : disjoint (dom ((rwds ∣ ❴ c ❵ˢ ᶜ) ˢ)) (dom (❴ c , 0 ❵ᵐ ˢ))
+  disj {a} a∈res a∈dom  = res-comp-dom a∈res (dom-single→single a∈dom)
 
-    rwds-∪ˡ≡sing-∪ˡ : rwds-∪ˡ-decomp ˢ ≡ᵉ ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ )ˢ
-    rwds-∪ˡ≡sing-∪ˡ = ≡ᵉ.trans rwds-∪ˡ-∪
-                              ( ≡ᵉ.trans (∪-cong ≡ᵉ.refl (res-singleton'{m = rwds} x))
-                                         (≡ᵉ.sym $ disjoint-∪ˡ-∪ disj) )
-  CERT-pov (CERT-pool x) = refl
-  CERT-pov (CERT-vdel x) = refl
+  rwds-∪ˡ≡sing-∪ˡ : rwds-∪ˡ-decomp ˢ ≡ᵉ ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ )ˢ
+  rwds-∪ˡ≡sing-∪ˡ = ≡ᵉ.trans rwds-∪ˡ-∪
+                            ( ≡ᵉ.trans (∪-cong ≡ᵉ.refl (res-singleton'{m = rwds} x))
+                                       (≡ᵉ.sym $ disjoint-∪ˡ-∪ disj) )
+CERT-pov (CERT-pool x) = refl
+CERT-pov (CERT-vdel x) = refl
 
-  injOn : (wdls : Withdrawals)
-          → ∀[ a ∈ dom (wdls ˢ) ] NetworkIdOf a ≡ NetworkId
-          → InjectiveOn (dom (wdls ˢ)) RewardAddress.stake
-  injOn _ h {record { stake = stakex }} {record { stake = stakey }} x∈ y∈ refl =
-    cong (λ u → record { net = u ; stake = stakex }) (trans (h x∈) (sym (h y∈)))
+injOn : (wdls : Withdrawals)
+        → ∀[ a ∈ dom (wdls ˢ) ] NetworkIdOf a ≡ NetworkId
+        → InjectiveOn (dom (wdls ˢ)) RewardAddress.stake
+injOn _ h {record { stake = stakex }} {record { stake = stakey }} x∈ y∈ refl =
+  cong (λ u → record { net = u ; stake = stakex }) (trans (h x∈) (sym (h y∈)))
 
-  module Certs-Pov-lemmas
-    -- TODO: prove some or all of the following assumptions, used in roof of `CERTBASE-pov`.
-    ( sumConstZero    :  {A : Type} ⦃ _ : DecEq A ⦄ {X : ℙ A} → getCoin (constMap X 0) ≡ 0 )
-    ( res-decomp      :  {A : Type} ⦃ _ : DecEq A ⦄ (m m' : A ⇀ Coin)
-                         → (m ∪ˡ m')ˢ ≡ᵉ (m ∪ˡ (m' ∣ dom (m ˢ) ᶜ))ˢ )
-    ( getCoin-cong    :  {A : Type} ⦃ _ : DecEq A ⦄ (s : A ⇀ Coin) (s' : ℙ (A × Coin)) → s ˢ ≡ᵉ s'
-                         → indexedSum' proj₂ (s ˢ) ≡ indexedSum' proj₂ s' )
-    ( ≡ᵉ-getCoinˢ     :  {A A' : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq A' ⦄ (s : ℙ (A × Coin)) {f : A → A'}
-                         → InjectiveOn (dom s) f → getCoin (mapˢ (map₁ f) s) ≡ getCoin s )
-    where
+module Certs-Pov-lemmas
+  -- TODO: prove the following assumption, used in roof of `CERTBASE-pov`.
+  ( ≡ᵉ-getCoinˢ :  {A A' : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq A' ⦄ (s : ℙ (A × Coin)) {f : A → A'}
+                   → InjectiveOn (dom s) f → getCoin (mapˢ (map₁ f) s) ≡ getCoin s )
+  where
 ```
 -->
 
@@ -152,7 +141,7 @@ value of the withdrawals in `Γ`{.AgdaBound}.  In other terms,
       let
         open DState (dState cs )
         open DState (dState cs') renaming (rewards to rewards')
-        module ≡ᵉ       = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+        module ≡ᵉ       = Eq.IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
         wdrlsCC         = mapˢ (map₁ RewardAddress.stake) (wdrls ˢ)
         zeroMap         = constMap (mapˢ RewardAddress.stake (dom wdrls)) 0
         rwds-∪ˡ-decomp  = (rewards ∣ dom wdrlsCC ᶜ) ∪ˡ (rewards ∣ dom wdrlsCC)

--- a/src/Ledger/Conway/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Conway/Specification/Ledger/Properties/PoV.lagda.md
@@ -38,15 +38,9 @@ instance
 
 module _
   (tx : Tx) (let open Tx tx; open TxBody body)
-  ( indexedSumᵛ'-∪  :  {A : Type} ⦃ _ : DecEq A ⦄ (m m' : A ⇀ Coin)
-                       → disjoint (dom m) (dom m') → getCoin (m ∪ˡ m') ≡ getCoin m + getCoin m' )
-  ( sumConstZero    :  {A : Type} ⦃ _ : DecEq A ⦄ {X : ℙ A} → getCoin (constMap X 0) ≡ 0 )
-  ( res-decomp      :  {A : Type} ⦃ _ : DecEq A ⦄ (m m' : A ⇀ Coin)
-                       → (m ∪ˡ m')ˢ ≡ᵉ (m ∪ˡ (m' ∣ dom (m ˢ) ᶜ))ˢ )
-  ( getCoin-cong    :  {A : Type} ⦃ _ : DecEq A ⦄ (s : A ⇀ Coin) (s' : ℙ (A × Coin)) → s ˢ ≡ᵉ s'
-                       → indexedSum' proj₂ (s ˢ) ≡ indexedSum' proj₂ s' )
-  ( ≡ᵉ-getCoinˢ     :  {A A' : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq A' ⦄ (s : ℙ (A × Coin)) {f : A → A'}
-                       → InjectiveOn (dom s) f → getCoin (mapˢ (map₁ f) s) ≡ getCoin s )
+  -- TODO: prove the following assumption, used in roof of `CERTBASE-pov`.
+  ( ≡ᵉ-getCoinˢ :  {A A' : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq A' ⦄ (s : ℙ (A × Coin)) {f : A → A'}
+                   → InjectiveOn (dom s) f → getCoin (mapˢ (map₁ f) s) ≡ getCoin s )
   where
 
   pattern UTXO-induction r = UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ r _ _ _
@@ -84,8 +78,8 @@ then the coin values of `s`{.AgdaBound} and `s'`{.AgdaBound} are equal, that is,
       open LState s' renaming (utxoSt to utxoSt'; govSt to govSt'; certState to certState')
       open CertState certState'
       open ≡-Reasoning
-      open Certs-PoV indexedSumᵛ'-∪ sumConstZero res-decomp  getCoin-cong ≡ᵉ-getCoinˢ
-      zeroMap    = constMap (mapˢ RewardAddress.stake (dom txWithdrawals)) 0
+      open Certs-PoV ≡ᵉ-getCoinˢ
+      zeroMap = constMap (mapˢ RewardAddress.stake (dom txWithdrawals)) 0
     in
     begin
       getCoin utxoSt + getCoin certState

--- a/src/Ledger/Conway/Specification/Utxo/Properties/GenMinSpend.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo/Properties/GenMinSpend.lagda.md
@@ -51,9 +51,6 @@ coin∅ = begin
   0 ∎
   where open Prelude.≡-Reasoning
 
-getCoin-singleton : ((dp , c) : DepositPurpose × Coin) → indexedSumᵛ' id ❴ (dp , c) ❵ ≡ c
-getCoin-singleton _ = indexedSum-singleton' {A = DepositPurpose × Coin} {f = proj₂} (finiteness _)
-
 module _ -- ASSUMPTION --
          (gc-hom : (d₁ d₂ : Deposits) → getCoin (d₁ ∪⁺ d₂) ≡ getCoin d₁ + getCoin d₂)
   where
@@ -63,7 +60,7 @@ module _ -- ASSUMPTION --
     getCoin (deps ∪⁺ ❴ (dp , c) ❵)
       ≡⟨ gc-hom deps ❴ (dp , c) ❵ ⟩
     getCoin deps + getCoin{A = Deposits} ❴ (dp , c) ❵
-      ≡⟨ cong (getCoin deps +_) (getCoin-singleton (dp , c)) ⟩
+      ≡⟨ cong (getCoin deps +_) getCoin-singleton ⟩
     getCoin deps + c
       ∎
     where open Prelude.≡-Reasoning

--- a/src/Ledger/Dijkstra/Specification/Account.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Account.lagda.md
@@ -33,6 +33,14 @@ DirectDeposits : Type
 DirectDeposits = RewardAddress ⇀ Coin
 ```
 
+<!--
+```agda
+record HasDirectDeposits {a} (A : Type a) : Type a where
+  field DirectDepositsOf : A → DirectDeposits
+open HasDirectDeposits ⦃...⦄ public
+```
+-->
+
 ## Balance Intervals {#sec:balance-intervals}
 
 [CIP 159][] allows a transaction to assert that an account's balance falls within a

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -104,14 +104,14 @@ record PState : Type where
   field
     pools     : Pools
     fPools    : Pools
-    retiring  : KeyHash ⇀ Epoch
+    retiring  : Retiring
     deposits  : KeyHash ⇀ Coin
 
 record GState : Type where
   constructor ⟦_,_,_⟧ᵛ
   field
     dreps      : DReps
-    ccHotKeys  : Credential ⇀ Maybe Credential
+    ccHotKeys  : CCHotKeys
     deposits   : Credential ⇀ Coin
 
 record CertState : Type where
@@ -318,6 +318,17 @@ credit each transaction's direct deposits to its account balances after certific
 processing.  See *Direct Deposit Application (CIP-159)* below for details.
 
 ```agda
+-- For each withdrawal entry `(addr, amt)`, look up `stake addr` in the acc,
+-- compute `bal ∸ amt`, create a singleton map with the new balance, and
+-- merge it with the rest (complement-restricted, to remove the old entry).
+-- applyOne : Rewards → RewardAddress × Coin → Rewards
+-- applyOne acc (addr , amt) =
+--  case lookupᵐ? acc (stake addr) of λ where
+--    (just bal) → ❴ stake addr , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ stake addr ❵ ᶜ)
+--    nothing    → acc
+--    -- `nothing` case is defensive; the PRE-CERT precondition guarantees the
+--    -- credential is registered, but handling it makes the function total.
+
 applyWithdrawals : Withdrawals → Rewards → Rewards
 applyWithdrawals = applyToRewards _∸_
 ```

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -321,17 +321,6 @@ credit each transaction's direct deposits to its account balances after certific
 processing.  See *Direct Deposit Application (CIP-159)* below for details.
 
 ```agda
--- For each withdrawal entry `(addr, amt)`, look up `stake addr` in the acc,
--- compute `bal ∸ amt`, create a singleton map with the new balance, and
--- merge it with the rest (complement-restricted, to remove the old entry).
--- applyOne : Rewards → RewardAddress × Coin → Rewards
--- applyOne acc (addr , amt) =
---  case lookupᵐ? acc (stake addr) of λ where
---    (just bal) → ❴ stake addr , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ stake addr ❵ ᶜ)
---    nothing    → acc
---    -- `nothing` case is defensive; the PRE-CERT precondition guarantees the
---    -- credential is registered, but handling it makes the function total.
-
 applyWithdrawals : Withdrawals → Rewards → Rewards
 applyWithdrawals = applyToRewards _∸_
 ```

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -181,6 +181,9 @@ instance
   HasWithdrawals-CertEnv : HasWithdrawals CertEnv
   HasWithdrawals-CertEnv .WithdrawalsOf = CertEnv.wdrls
 
+  HasDirectDeposits-CertEnv : HasDirectDeposits CertEnv
+  HasDirectDeposits-CertEnv .DirectDepositsOf = CertEnv.directDeposits
+
   HasVoteDelegs-DState : HasVoteDelegs DState
   HasVoteDelegs-DState .VoteDelegsOf = DState.voteDelegs
 

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties.lagda.md
@@ -13,5 +13,8 @@ module Ledger.Dijkstra.Specification.Certs.Properties where
 -->
 
 ```agda
+open import Ledger.Dijkstra.Specification.Certs.Properties.ApplyWithdrawalsPoV
 open import Ledger.Dijkstra.Specification.Certs.Properties.Computational
+open import Ledger.Dijkstra.Specification.Certs.Properties.PoV
+open import Ledger.Dijkstra.Specification.Certs.Properties.PoVLemmas
 ```

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
@@ -41,7 +41,8 @@ open import Ledger.Dijkstra.Specification.Gov.Base using (GovStructure)
 module Ledger.Dijkstra.Specification.Certs.Properties.ApplyWithdrawalsPoV
   (gs : GovStructure) (open GovStructure gs) where
 
-open import Ledger.Dijkstra.Specification.Certs gs
+open import Ledger.Dijkstra.Specification.Account gs using (DirectDeposits; BalanceInterval)
+open import Ledger.Dijkstra.Specification.Certs gs hiding (applyOne)
 open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
 open import Ledger.Prelude
 open import Axiom.Set.Properties th
@@ -70,6 +71,45 @@ instance
 
 The following auxiliary properties are needed.
 
+### Bridge: `getCoin` of a singleton-overwriting union
+
+After CIP-159 PR #1197, `applyToRewards` writes via `❴ k , v ❵ ∪ˡ acc` (no
+complement restriction on `acc`).  Left-bias of `∪ˡ` makes this extensionally
+equal to the older `❴ k , v ❵ ∪ˡ (acc ∣ ❴ k ❵ ᶜ)` form; the lemma below states
+the corresponding `getCoin` equation, which the two `applyOne` proofs use to
+land on a uniform RHS.
+
+```agda
+getCoin-∪ˡ-overwrite : (acc : Rewards) (c : Credential) (v : Coin)
+  → getCoin (❴ c , v ❵ ∪ˡ acc) ≡ v + getCoin (acc ∣ ❴ c ❵ ᶜ)
+```
+
+<!--
+```agda
+getCoin-∪ˡ-overwrite acc c v =
+  begin
+    getCoin (❴ c , v ❵ ∪ˡ acc)
+      ≡⟨ ≡ᵉ-getCoin (❴ c , v ❵ ∪ˡ acc) (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ))
+                    bridge ⟩
+    getCoin (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ))
+      ≡⟨ indexedSumᵛ'-∪ ❴ c , v ❵ᵐ (acc ∣ ❴ c ❵ ᶜ) disj ⟩
+    getCoin ❴ c , v ❵ᵐ + getCoin (acc ∣ ❴ c ❵ ᶜ)
+      ≡⟨ cong (_+ getCoin (acc ∣ ❴ c ❵ ᶜ)) getCoin-singleton ⟩
+    v + getCoin (acc ∣ ❴ c ❵ ᶜ)
+      ∎
+  where
+  open ≡-Reasoning
+  open Equivalence
+  module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+  -- `∪ˡ` is `_∪ (_ ∣ dom _ ᶜ)`, and `filterᵐ` is idempotent, so dropping
+  -- the inner `∣ ❴ c ❵ ᶜ` on the right operand doesn't change the result.
+  bridge : (❴ c , v ❵ ∪ˡ acc) ˢ ≡ᵉ (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) ˢ
+  bridge = res-decomp ❴ c , v ❵ᵐ acc
+  disj : disjoint (dom ❴ c , v ❵ᵐ) (dom (acc ∣ ❴ c ❵ ᶜ))
+  disj x y = res-comp-dom y (dom-single→single x)
+```
+-->
+
 ### Single-step Lemma: `applyOne` decreases `getCoin` by `amt`
 
 When `stake addr ∈ dom acc` and `amt ≤ bal` (where `bal` is the current balance),
@@ -80,7 +120,7 @@ applyOne-pov :
   (acc : Rewards) (addr : RewardAddress) (amt bal : Coin)
   → lookupᵐ? acc (stake addr) ≡ just bal
   → amt ≤ bal
-  → getCoin acc ≡ getCoin (❴ stake addr , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ stake addr ❵ ᶜ)) + amt
+  → getCoin acc ≡ getCoin (❴ stake addr , bal ∸ amt ❵ ∪ˡ acc) + amt
 ```
 
 <!--
@@ -101,10 +141,8 @@ applyOne-pov acc addr amt bal lookup-eq amt≤bal =
       ≡⟨ trans (sym (+-assoc (getCoin (acc ∣ ❴ c ❵ ᶜ)) (bal ∸ amt) amt))
                (cong (_+ amt) (+-comm (getCoin (acc ∣ ❴ c ❵ ᶜ)) (bal ∸ amt))) ⟩
     (bal ∸ amt) + getCoin (acc ∣ ❴ c ❵ ᶜ) + amt
-      ≡˘⟨ cong (_+ amt)
-            (trans (indexedSumᵛ'-∪ ❴ c , bal ∸ amt ❵ᵐ (acc ∣ ❴ c ❵ ᶜ) disj-doms)
-                   (cong (_+ getCoin (acc ∣ ❴ c ❵ ᶜ)) getCoin-singleton)) ⟩
-    getCoin (❴ c , bal ∸ amt ❵ᵐ ∪ˡ (acc ∣ ❴ c ❵ˢ ᶜ)) + amt
+      ≡˘⟨ cong (_+ amt) (getCoin-∪ˡ-overwrite acc c (bal ∸ amt)) ⟩
+    getCoin (❴ c , bal ∸ amt ❵ ∪ˡ acc) + amt
       ∎
   where
   module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
@@ -128,11 +166,7 @@ applyOne-pov acc addr amt bal lookup-eq amt≤bal =
     trans (getCoin-cong (acc ∣ ❴ c ❵) ❴ (c , bal) ❵ (res-singleton' {m = acc} c∈acc))
           getCoin-singleton
 
-  c∉dom-compl : c ∉ dom ((acc ∣ ❴ c ❵ ᶜ) ˢ)
-  c∉dom-compl c∈ = res-comp-dom c∈ (to ∈-singleton refl)
-
-  disj-doms : disjoint (dom ❴ c , bal ∸ amt ❵ᵐ) (dom (acc ∣ ❴ c ❵ ᶜ))
-  disj-doms x y = c∉dom-compl (subst (_∈ dom (acc ∣ ❴ c ❵ ᶜ)) (from ∈-dom-singleton-pair x) y)
+  -- `c∉dom-compl` and `disj-doms` removed: the bridge lemma encapsulates them.
 ```
 -->
 
@@ -164,13 +198,13 @@ applyOne-pov acc addr amt bal lookup-eq amt≤bal =
 <!--
 ```agda
 -- applyOne preserves balance for other credentials.
-module ApplyWithdrawals-PoV
+module ApplyToRewards-PoV
   -- ASSUMPTIONS --
 
   -- TODO: ask that these be proved in the `agda-sets` library.
 
   -- 1. For any credential `c'` other than `c`, lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c'
-  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+  ( ∪ˡ-res-lookup-preserve : (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
       → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
     -- It's hard because the `agda-sets` API requires instance resolution for
     -- `lookupᵐ?`, but the semantic content is clear (lookup in a left-biased union
@@ -179,16 +213,27 @@ module ApplyWithdrawals-PoV
     -- resolution is painful library plumbing.
 
    -- 2. getCoin representation.
-  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+  ( sum-map-proj₂≡getCoin : (m : RewardAddress ⇀ Coin) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
    -- 3. no duplicate credentials.
-  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+  ( setToList-Unique : (m : RewardAddress ⇀ Coin) → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
   where
+
+  -- Local convenience matching the inline fold body of `applyToRewards`.
+  -- Definitionally equal to the lambda inside `applyToRewards f`, so
+  -- `foldl applyOne acc xs ≡ foldl (applyToRewards-lambda f) acc xs` is `refl`.
+  applyOne : (Coin → Coin → Coin) → Rewards → RewardAddress × Coin → Rewards
+  applyOne f acc (addr , amt) =
+    maybe (λ bal → ❴ stake addr , f bal amt ❵ ∪ˡ acc) acc (lookupᵐ? acc (stake addr))
 ```
 -->
 
 
-## Main Theorem
+## Main Theorems
+
+### `applyWithdrawals-pov`
 
 This is the form needed by `PRE-CERT-pov`.
 
@@ -278,7 +323,7 @@ This is the form needed by `PRE-CERT-pov`.
       where
       c   = stake addr
       acc' : Rewards
-      acc' = ❴ c , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)
+      acc' = ❴ c , bal ∸ amt ❵ ∪ˡ acc
 
       amt≤bal : amt ≤ bal
       amt≤bal = subst (amt ≤_) (cong (maybe id 0) eq) (h (here refl) .proj₂)
@@ -303,5 +348,126 @@ This is the form needed by `PRE-CERT-pov`.
 ```
 -->
 
+### `applyDirectDeposits-pov`
 
+The CIP-159 `POST-CERT` rule applies direct deposits via `applyDirectDeposits dd rwds`,
+*increasing* the rewards balance by exactly the sum of the deposit amounts.  This
+lemma is the symmetric counterpart to `applyWithdrawals-pov`; both are instances
+of the common `applyToRewards` fold.
+
+The fold induction `foldl-applyOne-pov-add` is the additive analogue of
+`foldl-applyOne-pov`; its single-step ingredient `applyOne-pov-add` follows
+directly from `getCoin-∪ˡ-overwrite`.
+
+```agda
+  applyOne-pov-add : (acc : Rewards) (addr : RewardAddress) (amt bal : Coin)
+    → lookupᵐ? acc (stake addr) ≡ just bal
+    → getCoin (❴ stake addr , bal + amt ❵ ∪ˡ acc) ≡ getCoin acc + amt
+```
+
+<!--
+```agda
+  applyOne-pov-add acc addr amt bal lookup-eq =
+    let c = stake addr in
+    begin
+      getCoin (❴ c , bal + amt ❵ ∪ˡ acc)
+        ≡⟨ getCoin-∪ˡ-overwrite acc c (bal + amt) ⟩
+      (bal + amt) + getCoin (acc ∣ ❴ c ❵ ᶜ)
+        ≡⟨ +-comm (bal + amt) (getCoin (acc ∣ ❴ c ❵ ᶜ)) ⟩
+      getCoin (acc ∣ ❴ c ❵ ᶜ) + (bal + amt)
+        ≡˘⟨ +-assoc (getCoin (acc ∣ ❴ c ❵ ᶜ)) bal amt ⟩
+      getCoin (acc ∣ ❴ c ❵ ᶜ) + bal + amt
+        ≡˘⟨ cong (_+ amt) (split-by-lookup acc c bal lookup-eq) ⟩
+      getCoin acc + amt
+        ∎
+    where
+    open ≡-Reasoning
+    -- Same decomposition `acc ≡ (acc ∣ ❴ c ❵ ᶜ) ∪ˡ (acc ∣ ❴ c ❵)` used in
+    -- `applyOne-pov`; factor it out if both proofs are kept in this module.
+    split-by-lookup : (acc : Rewards) (c : Credential) (bal : Coin)
+      → lookupᵐ? acc c ≡ just bal
+      → getCoin acc ≡ getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
+    split-by-lookup acc c bal lookup-eq = {!!}
+      -- Same proof as the first three steps of `applyOne-pov`; factor it out.
+```
+-->
+
+```agda
+  foldl-applyOne-pov-add : (acc : Rewards) (entries : List (RewardAddress × Coin))
+    → (∀ {addr amt} → (addr , amt) ∈ˡ entries → stake addr ∈ dom acc)
+    → Unique (map (stake ∘ proj₁) entries)
+    → getCoin (foldl (applyOne _+_) acc entries) ≡ getCoin acc + sum (map proj₂ entries)
+```
+
+<!--
+```agda
+  foldl-applyOne-pov-add acc [] _ _ =
+    sym (+-identityʳ (indexedSumᵛ' id acc))
+  foldl-applyOne-pov-add acc ((addr , amt) ∷ xs) h (c∉xs :: uniq-xs)
+    with lookupᵐ? acc (stake addr) in eq
+  -- Defensive `nothing` case ruled out by the membership precondition.
+  ... | nothing = ⊥-elim (case lookup-just (h (here refl)) of λ where
+                            (_ , p) → case trans (sym eq) p of λ ())
+    where
+    -- A small helper: membership in domain implies `lookupᵐ?` is `just`.
+    lookup-just : ∀ {a} → a ∈ dom acc → Σ Coin λ v → lookupᵐ? acc a ≡ just v
+    lookup-just = {!!}  -- standard agda-sets bridge; provable from `dom∈`.
+  ... | just bal = begin
+      getCoin (foldl (applyOne _+_) acc' xs)
+        ≡⟨ foldl-applyOne-pov-add acc' xs h' uniq-xs ⟩
+      getCoin acc' + sum (map proj₂ xs)
+        ≡⟨ cong (_+ sum (map proj₂ xs)) (applyOne-pov-add acc addr amt bal eq) ⟩
+      (getCoin acc + amt) + sum (map proj₂ xs)
+        ≡⟨ +-assoc (getCoin acc) amt (sum (map proj₂ xs)) ⟩
+      getCoin acc + (amt + sum (map proj₂ xs))
+        ∎
+    where
+    open ≡-Reasoning
+    c = stake addr
+    acc' = ❴ c , bal + amt ❵ ∪ˡ acc
+    -- `h'` is the same invariant-transfer argument as in `foldl-applyOne-pov`,
+    -- but with no `amt ≤ maybe id 0 (lookupᵐ? _ _)` bound to thread —
+    -- only domain membership has to be preserved.  Use the bridge lemma
+    -- to convert `acc' = ❴ c , bal + amt ❵ ∪ˡ acc` into the equivalent
+    -- `❴ c , bal + amt ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)` form, then reuse
+    -- `∪ˡ-res-dom-preserve` from `Certs/Properties/ApplyWithdrawalsPoV`.
+    h' : ∀ {addr' amt'} → (addr' , amt') ∈ˡ xs → stake addr' ∈ dom acc'
+    h' = {!!}  -- mechanical mirror of the original `h'`; see comment above.
+```
+-->
+
+
+
+```agda
+  applyDirectDeposits-pov : (dd : DirectDeposits) (rwds : Rewards)
+    → mapˢ stake (dom dd) ⊆ dom rwds
+    → ∀[ a ∈ dom dd ] NetworkIdOf a ≡ NetworkId
+    → getCoin (applyDirectDeposits dd rwds) ≡ getCoin rwds + getCoin dd
+```
+
+<!--
+```agda
+  applyDirectDeposits-pov dd rwds creds∈ netIds =
+    begin
+      getCoin (applyDirectDeposits dd rwds)
+        ≡⟨ refl ⟩  -- by definition of `applyDirectDeposits = applyToRewards _+_`
+      getCoin (foldl (applyOne _+_) rwds (setToList (dd ˢ)))
+        ≡⟨ sym (foldl-applyOne-pov-add rwds (setToList (dd ˢ)) inv
+                                       (setToList-Unique dd netIds)) ⟩
+      getCoin rwds + sum (map proj₂ (setToList (dd ˢ)))
+        ≡⟨ cong (getCoin rwds +_) (sum-map-proj₂≡getCoin dd) ⟩
+      getCoin rwds + getCoin dd
+        ∎
+    where
+    open ≡-Reasoning
+    open Equivalence
+    inv : ∀ {addr amt} → (addr , amt) ∈ˡ setToList (dd ˢ) → stake addr ∈ dom rwds
+    inv {addr} {amt} mem =
+      let addr-amt∈dd : (addr , amt) ∈ dd ˢ
+          addr-amt∈dd = setToList-∈ mem
+          c∈dom-dd : stake addr ∈ mapˢ stake (dom dd)
+          c∈dom-dd = to ∈-map (addr , refl , to dom∈ (amt , addr-amt∈dd))
+      in  creds∈ c∈dom-dd
+```
+-->
 

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
@@ -101,10 +101,25 @@ getCoin-∪ˡ-overwrite acc c v =
   open ≡-Reasoning
   open Equivalence
   module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
-  -- `∪ˡ` is `_∪ (_ ∣ dom _ ᶜ)`, and `filterᵐ` is idempotent, so dropping
-  -- the inner `∣ ❴ c ❵ ᶜ` on the right operand doesn't change the result.
+  -- `res-decomp ❴ c , v ❵ᵐ acc` proves
+  --     (❴ c , v ❵ᵐ ∪ˡ acc) ˢ ≡ᵉ (❴ c , v ❵ᵐ ∪ˡ (acc ∣ dom (❴ c , v ❵ᵐ ˢ) ᶜ)) ˢ
+  -- but the bridge wants `❴ c ❵ ᶜ` on the right (a set-singleton built via
+  -- the `listing` axiom of `Theory`), not `dom (❴ c , v ❵ᵐ ˢ) ᶜ` (built via
+  -- `mapˢ`, i.e. the `replacement` axiom).  The two restriction sets are
+  -- extensionally equal by `dom-single≡single`, so we chain `res-decomp`
+  -- with an `∪ˡ`-cong step on the right operand to translate the
+  -- restriction set.  ('Listing vs. replacement' is exactly what Agda's
+  -- MismatchedProjectionsError flagged in the previous formulation.)
+
+  -- `_≡ᵐ_` on `Map A B` is defined as `_≡ᵉ_` on the underlying relations
+  -- (`Map.agda`: `(x , _) ≡ᵐ (y , _) = x ≡ᵉ y`), so `res-comp-cong`
+  -- (from `Axiom.Set.Rel`) lifts straight to the Map level.
+  restrict-cong' : (❴ c , v ❵ᵐ ∪ˡ (acc ∣ dom (❴ c , v ❵ᵐ ˢ) ᶜ)) ˢ ≡ᵉ (❴ c , v ❵ᵐ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) ˢ
+  restrict-cong' = ∪ˡ-cong (≡ᵉ.refl {x = ❴ c , v ❵ᵐ ˢ}) (res-comp-cong dom-single≡single)
+
   bridge : (❴ c , v ❵ ∪ˡ acc) ˢ ≡ᵉ (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) ˢ
-  bridge = res-decomp ❴ c , v ❵ᵐ acc
+  bridge = ≡ᵉ.trans (res-decomp ❴ c , v ❵ᵐ acc) restrict-cong'
+
   disj : disjoint (dom ❴ c , v ❵ᵐ) (dom (acc ∣ ❴ c ❵ ᶜ))
   disj x y = res-comp-dom y (dom-single→single x)
 ```
@@ -250,8 +265,8 @@ This is the form needed by `PRE-CERT-pov`.
     begin
       getCoin rwds
         ≡⟨ foldl-applyOne-pov rwds (setToList (wdrls ˢ)) inv (setToList-Unique wdrls) ⟩
-      getCoin (foldl applyOne rwds (setToList (wdrls ˢ))) + sum (map proj₂ (setToList (wdrls ˢ)))
-        ≡⟨ cong (getCoin (foldl applyOne rwds (setToList (wdrls ˢ))) +_) (sum-map-proj₂≡getCoin wdrls) ⟩
+      getCoin (foldl (applyOne _∸_) rwds (setToList (wdrls ˢ))) + sum (map proj₂ (setToList (wdrls ˢ)))
+        ≡⟨ cong (getCoin (foldl (applyOne _∸_) rwds (setToList (wdrls ˢ))) +_) (sum-map-proj₂≡getCoin wdrls) ⟩
       getCoin (applyWithdrawals wdrls rwds) + getCoin wdrls
         ∎
     where
@@ -292,7 +307,8 @@ This is the form needed by `PRE-CERT-pov`.
       → (∀ {addr amt} → (addr , amt) ∈ˡ entries
       → stake addr ∈ dom acc × amt ≤ maybe id 0 (lookupᵐ? acc (stake addr)))
       → Unique (map (stake ∘ proj₁) entries) -- needed for invariant preservation
-      → getCoin acc ≡ getCoin (foldl applyOne acc entries) + sum (map proj₂ entries)
+      → getCoin acc ≡ getCoin (foldl (applyOne _∸_) acc entries) + sum (map proj₂ entries)
+
 
     foldl-applyOne-pov acc [] _ _ = sym (+-identityʳ (indexedSumᵛ' id acc))
 
@@ -304,7 +320,7 @@ This is the form needed by `PRE-CERT-pov`.
       let amt≤0 = subst (amt ≤_) (cong (maybe id 0) eq) (h (here refl) .proj₂)
           amt≡0 = n≤0⇒n≡0 amt≤0
       in -- amt ≤ maybe id 0 nothing = amt ≤ 0
-      subst (λ a → getCoin acc ≡ getCoin (foldl applyOne acc xs) + (a + sum (map proj₂ xs)))
+      subst (λ a → getCoin acc ≡ getCoin (foldl (applyOne _∸_) acc xs) + (a + sum (map proj₂ xs)))
             (sym amt≡0)
             (foldl-applyOne-pov acc xs (λ mem → h (there mem)) uniq-xs)
 
@@ -314,11 +330,11 @@ This is the form needed by `PRE-CERT-pov`.
           ≡⟨ applyOne-pov acc addr amt bal eq amt≤bal ⟩
         getCoin acc' + amt
           ≡⟨ cong (_+ amt) (foldl-applyOne-pov acc' xs h' uniq-xs) ⟩
-        (getCoin (foldl applyOne acc' xs) + sum (map proj₂ xs)) + amt
-          ≡⟨ +-assoc (getCoin (foldl applyOne acc' xs)) (sum (map proj₂ xs)) amt ⟩
-        getCoin (foldl applyOne acc' xs) + (sum (map proj₂ xs) + amt)
-          ≡⟨ cong (getCoin (foldl applyOne acc' xs) +_) (+-comm (sum (map proj₂ xs)) amt) ⟩
-        getCoin (foldl applyOne acc' xs) + (amt + sum (map proj₂ xs))
+        (getCoin (foldl (applyOne _∸_) acc' xs) + sum (map proj₂ xs)) + amt
+          ≡⟨ +-assoc (getCoin (foldl (applyOne _∸_) acc' xs)) (sum (map proj₂ xs)) amt ⟩
+        getCoin (foldl (applyOne _∸_) acc' xs) + (sum (map proj₂ xs) + amt)
+          ≡⟨ cong (getCoin (foldl (applyOne _∸_) acc' xs) +_) (+-comm (sum (map proj₂ xs)) amt) ⟩
+        getCoin (foldl (applyOne _∸_) acc' xs) + (amt + sum (map proj₂ xs))
           ∎
       where
       c   = stake addr

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
@@ -42,7 +42,7 @@ module Ledger.Dijkstra.Specification.Certs.Properties.ApplyWithdrawalsPoV
   (gs : GovStructure) (open GovStructure gs) where
 
 open import Ledger.Dijkstra.Specification.Account gs using (DirectDeposits; BalanceInterval)
-open import Ledger.Dijkstra.Specification.Certs gs hiding (applyOne)
+open import Ledger.Dijkstra.Specification.Certs gs
 open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
 open import Ledger.Prelude
 open import Axiom.Set.Properties th

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
@@ -1,0 +1,307 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+---
+
+# `applyWithdrawals` Preservation of Value {#sec:apply-withdrawals-pov}
+
+This module proves that `applyWithdrawals` decreases the total rewards balance
+by exactly the sum of the withdrawal amounts.  This is the key new lemma
+for the Dijkstra (CIP-159) CERTS preservation-of-value proof.
+
+## Proof Strategy
+
+`applyWithdrawals` is defined as a `foldl` over the list representation of the
+withdrawal map.  The proof proceeds by induction on this list, with a single-step
+lemma showing that each `applyOne` step decreases `getCoin` by exactly the
+withdrawal amount.
+
+The single-step argument decomposes the accumulator map `acc` into:
+`acc ≡ᵉ (acc ∣ ❴ c ❵ ᶜ) ∪ˡ (acc ∣ ❴ c ❵)`
+where `c = stake addr`.  When `lookupᵐ? acc c ≡ just bal` and `amt ≤ bal`:
+`getCoin acc = getCoin (acc ∣ ❴ c ❵ ᶜ) + bal`, by decomposition;
+`getCoin (applyOne acc (addr , amt))` = `getCoin (❴ c , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ))`
+= `(bal ∸ amt) + getCoin (acc ∣ ❴ c ❵ ᶜ)`, by disjoint union.
+
+So the decrease is `bal - (bal ∸ amt) = amt` (since `amt ≤ bal`).
+
+For the fold induction, the invariant is maintained because:
+- Each credential is targeted at most once (by injectivity of `stake` on `dom wdrls`,
+  which follows from the `NetworkId` constraint).
+- `applyOne` preserves domain membership (it replaces entries, never removes them).
+- Therefore, remaining entries still have their credentials registered and their
+  amounts bounded by the (unchanged) balances.
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Gov.Base using (GovStructure)
+
+module Ledger.Dijkstra.Specification.Certs.Properties.ApplyWithdrawalsPoV
+  (gs : GovStructure) (open GovStructure gs) where
+
+open import Ledger.Dijkstra.Specification.Certs gs
+open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
+open import Ledger.Prelude
+open import Axiom.Set.Properties th
+open import Data.Nat.Properties
+  using ( +-0-monoid; +-identityʳ; +-identityˡ; +-comm; +-assoc
+        ; m∸n+n≡m )
+open import Data.Maybe.Properties using (just-injective)
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique) renaming (_∷_ to _::_)
+open import Data.List.Relation.Unary.Any using (Any)
+open import Data.List.Membership.Propositional.Properties using (∈-map⁺)
+import Data.List.Relation.Unary.All as All
+open import Relation.Binary using (IsEquivalence)
+open import Data.Nat.Properties using (n≤0⇒n≡0)
+open RewardAddress
+open Any
+
+private variable
+  A : Type
+
+instance
+  _ = +-0-monoid
+```
+-->
+
+## Supporting lemmas
+
+The following auxiliary properties are needed.
+
+### Single-step Lemma: `applyOne` decreases `getCoin` by `amt`
+
+When `stake addr ∈ dom acc` and `amt ≤ bal` (where `bal` is the current balance),
+applying a single withdrawal decreases the total by exactly `amt`.
+
+```agda
+applyOne-pov :
+  (acc : Rewards) (addr : RewardAddress) (amt bal : Coin)
+  → lookupᵐ? acc (stake addr) ≡ just bal
+  → amt ≤ bal
+  → getCoin acc ≡ getCoin (❴ stake addr , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ stake addr ❵ ᶜ)) + amt
+```
+
+<!--
+```agda
+applyOne-pov acc addr amt bal lookup-eq amt≤bal =
+  begin
+    getCoin acc
+      ≡˘⟨ ≡ᵉ-getCoin decomp acc
+      ( ≡ᵉ.trans (disjoint-∪ˡ-∪ (disjoint-sym res-ex-disjoint))
+                 ( ≡ᵉ.trans ∪-sym (res-ex-∪ Dec-∈-singleton)) ) ⟩
+    getCoin decomp
+      ≡⟨ indexedSumᵛ'-∪ (acc ∣ ❴ c ❵ ᶜ) (acc ∣ ❴ c ❵) (disjoint-sym res-ex-disjoint) ⟩
+    getCoin (acc ∣ ❴ c ❵ ᶜ) + getCoin (acc ∣ ❴ c ❵)
+      ≡⟨ cong (getCoin (acc ∣ ❴ c ❵ ᶜ) +_) acc∣c≡bal ⟩
+    getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
+      ≡⟨ cong (getCoin (acc ∣ ❴ c ❵ ᶜ) +_) (sym (m∸n+n≡m amt≤bal)) ⟩
+    getCoin (acc ∣ ❴ c ❵ ᶜ) + (bal ∸ amt + amt)
+      ≡⟨ trans (sym (+-assoc (getCoin (acc ∣ ❴ c ❵ ᶜ)) (bal ∸ amt) amt))
+               (cong (_+ amt) (+-comm (getCoin (acc ∣ ❴ c ❵ ᶜ)) (bal ∸ amt))) ⟩
+    (bal ∸ amt) + getCoin (acc ∣ ❴ c ❵ ᶜ) + amt
+      ≡˘⟨ cong (_+ amt)
+            (trans (indexedSumᵛ'-∪ ❴ c , bal ∸ amt ❵ᵐ (acc ∣ ❴ c ❵ ᶜ) disj-doms)
+                   (cong (_+ getCoin (acc ∣ ❴ c ❵ ᶜ)) getCoin-singleton)) ⟩
+    getCoin (❴ c , bal ∸ amt ❵ᵐ ∪ˡ (acc ∣ ❴ c ❵ˢ ᶜ)) + amt
+      ∎
+  where
+  module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+  open ≡-Reasoning
+  open Equivalence
+
+  c : Credential
+  c = stake addr
+
+  decomp : Credential ⇀ Coin
+  decomp = (acc ∣ ❴ c ❵ ᶜ) ∪ˡ (acc ∣ ❴ c ❵)
+
+  c∈acc : (c , bal) ∈ acc ˢ
+  c∈acc with c ∈? dom (acc ˢ)
+  ... | yes c∈dom =
+    subst (λ v → (c , v) ∈ acc ˢ) (just-injective lookup-eq) (lookupᵐ-∈ acc c c∈dom)
+  ... | no c∉dom = case lookup-eq of λ ()
+
+  acc∣c≡bal : getCoin (acc ∣ ❴ c ❵) ≡ bal
+  acc∣c≡bal =
+    trans (getCoin-cong (acc ∣ ❴ c ❵) ❴ (c , bal) ❵ (res-singleton' {m = acc} c∈acc))
+          getCoin-singleton
+
+  c∉dom-compl : c ∉ dom ((acc ∣ ❴ c ❵ ᶜ) ˢ)
+  c∉dom-compl c∈ = res-comp-dom c∈ (to ∈-singleton refl)
+
+  disj-doms : disjoint (dom ❴ c , bal ∸ amt ❵ᵐ) (dom (acc ∣ ❴ c ❵ ᶜ))
+  disj-doms x y = c∉dom-compl (subst (_∈ dom (acc ∣ ❴ c ❵ ᶜ)) (from ∈-dom-singleton-pair x) y)
+```
+-->
+
+
+### Domain Membership Preservation Lemma
+
+```agda
+∪ˡ-res-dom-preserve :
+    ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+    → c' ∈ dom m → c' ≢ c
+    → c' ∈ dom (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ))
+```
+
+<!--
+```agda
+∪ˡ-res-dom-preserve m c v c' c'∈dom c'≢c = dom∪ˡʳ {m = ❴ c , v ❵} {m' = m ∣ ❴ c ❵ ᶜ} c'∈resᶜ
+    where
+    open Equivalence
+    c'∉❴c❵ : c' ∉ ❴ c ❵
+    c'∉❴c❵ = c'≢c ∘ from ∈-singleton
+
+    c'∈resᶜ : c' ∈ dom ((m ∣ ❴ c ❵ ᶜ) ˢ)
+    c'∈resᶜ = let (v' , c'v'∈m) = from dom∈ c'∈dom
+              in  to dom∈ (v' , to ∈-filter (c'∉❴c❵ , c'v'∈m))
+```
+-->
+
+
+<!--
+```agda
+-- applyOne preserves balance for other credentials.
+module ApplyWithdrawals-PoV
+  -- ASSUMPTIONS --
+
+  -- TODO: ask that these be proved in the `agda-sets` library.
+
+  -- 1. For any credential `c'` other than `c`, lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c'
+  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+    -- It's hard because the `agda-sets` API requires instance resolution for
+    -- `lookupᵐ?`, but the semantic content is clear (lookup in a left-biased union
+    -- for a key not in the left map equals lookup in the right map, and complement
+    -- restriction doesn't affect keys ≢ c); threading it through the `⁇` instance
+    -- resolution is painful library plumbing.
+
+   -- 2. getCoin representation.
+  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+   -- 3. no duplicate credentials.
+  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+  where
+```
+-->
+
+
+## Main Theorem
+
+This is the form needed by `PRE-CERT-pov`.
+
+```agda
+  applyWithdrawals-pov : (wdrls : Withdrawals) (rwds : Rewards)
+    → mapˢ stake (dom wdrls) ⊆ dom rwds
+    → ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rwds (stake addr))
+    → getCoin rwds ≡ getCoin (applyWithdrawals wdrls rwds) + getCoin wdrls
+```
+
+<!--
+```agda
+  applyWithdrawals-pov wdrls rwds creds∈ amts≤ =
+    begin
+      getCoin rwds
+        ≡⟨ foldl-applyOne-pov rwds (setToList (wdrls ˢ)) inv (setToList-Unique wdrls) ⟩
+      getCoin (foldl applyOne rwds (setToList (wdrls ˢ))) + sum (map proj₂ (setToList (wdrls ˢ)))
+        ≡⟨ cong (getCoin (foldl applyOne rwds (setToList (wdrls ˢ))) +_) (sum-map-proj₂≡getCoin wdrls) ⟩
+      getCoin (applyWithdrawals wdrls rwds) + getCoin wdrls
+        ∎
+    where
+    open ≡-Reasoning
+    open Equivalence
+
+    inv : ∀ {addr amt} → (addr , amt) ∈ˡ setToList (wdrls ˢ)
+      → stake addr ∈ dom rwds × amt ≤ maybe id 0 (lookupᵐ? rwds (stake addr))
+    inv {addr} {amt} mem =
+      let addr-amt∈wdrls : (addr , amt) ∈ wdrls ˢ
+          addr-amt∈wdrls = setToList-∈ mem  -- setToList is id in List-Model
+
+          c∈dom-wdrls : stake addr ∈ mapˢ stake (dom wdrls)
+          c∈dom-wdrls = to ∈-map (addr , refl , to dom∈ (amt , addr-amt∈wdrls))
+
+      in  creds∈ c∈dom-wdrls , amts≤ addr-amt∈wdrls
+
+    -- MAIN SUPPORTING LEMMA --
+    -- Fold invariant: fold over the full list
+    -- The fold invariant tracks three properties through the induction.
+    -- 1. All remaining withdrawal credentials are in the current accumulator's domain.
+    -- 2. All remaining withdrawal amounts are bounded by the current balances.
+    -- 3. Each credential appears at most once in the remaining list (NoDup on credentials).
+
+    -- After processing some prefix of withdrawals, the remaining suffix still
+    -- has all its credentials registered in the accumulator, with amounts bounded
+    -- by current (possibly reduced) balances.
+    --
+    -- The Unique condition ensures each credential is targeted at most once,
+    -- which is critical: applyOne replaces (not removes) the entry, so other
+    -- credentials' balances are unchanged, but the same credential's balance
+    -- IS reduced.  Unique guarantees we never revisit a reduced balance.
+    --
+    -- Unique on (mapˢ (stake ∘ proj₁) entries) follows from injectivity of
+    -- `stake` on `dom wdrls`, which follows from the NetworkId constraint.
+
+    foldl-applyOne-pov : (acc : Rewards) (entries : List (RewardAddress × Coin))
+      → (∀ {addr amt} → (addr , amt) ∈ˡ entries
+      → stake addr ∈ dom acc × amt ≤ maybe id 0 (lookupᵐ? acc (stake addr)))
+      → Unique (map (stake ∘ proj₁) entries) -- needed for invariant preservation
+      → getCoin acc ≡ getCoin (foldl applyOne acc entries) + sum (map proj₂ entries)
+
+    foldl-applyOne-pov acc [] _ _ = sym (+-identityʳ (indexedSumᵛ' id acc))
+
+    foldl-applyOne-pov acc ((addr , amt) ∷ xs) h (c∉xs :: uniq-xs)
+      with lookupᵐ? acc (stake addr) in eq
+
+    -- Nothing case: applyOne is a no-op, amt must be 0.
+    ... | nothing =
+      let amt≤0 = subst (amt ≤_) (cong (maybe id 0) eq) (h (here refl) .proj₂)
+          amt≡0 = n≤0⇒n≡0 amt≤0
+      in -- amt ≤ maybe id 0 nothing = amt ≤ 0
+      subst (λ a → getCoin acc ≡ getCoin (foldl applyOne acc xs) + (a + sum (map proj₂ xs)))
+            (sym amt≡0)
+            (foldl-applyOne-pov acc xs (λ mem → h (there mem)) uniq-xs)
+
+    -- Just case: the main inductive step.
+    ... | just bal = begin
+        getCoin acc
+          ≡⟨ applyOne-pov acc addr amt bal eq amt≤bal ⟩
+        getCoin acc' + amt
+          ≡⟨ cong (_+ amt) (foldl-applyOne-pov acc' xs h' uniq-xs) ⟩
+        (getCoin (foldl applyOne acc' xs) + sum (map proj₂ xs)) + amt
+          ≡⟨ +-assoc (getCoin (foldl applyOne acc' xs)) (sum (map proj₂ xs)) amt ⟩
+        getCoin (foldl applyOne acc' xs) + (sum (map proj₂ xs) + amt)
+          ≡⟨ cong (getCoin (foldl applyOne acc' xs) +_) (+-comm (sum (map proj₂ xs)) amt) ⟩
+        getCoin (foldl applyOne acc' xs) + (amt + sum (map proj₂ xs))
+          ∎
+      where
+      c   = stake addr
+      acc' : Rewards
+      acc' = ❴ c , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)
+
+      amt≤bal : amt ≤ bal
+      amt≤bal = subst (amt ≤_) (cong (maybe id 0) eq) (h (here refl) .proj₂)
+
+      -- Invariant transfer: the precondition holds for (acc', xs).
+      -- For each (addr', amt') ∈ˡ xs:
+      --   - From Unique, stake addr' ≢ c
+      --   - dom-preserve: stake addr' ∈ dom acc → stake addr' ∈ dom acc'
+      --   - balance-preserve: lookupᵐ? acc' (stake addr') ≡ lookupᵐ? acc (stake addr')
+      h' : ∀ {addr' amt'} → (addr' , amt') ∈ˡ xs
+         → stake addr' ∈ dom acc'
+           × amt' ≤ maybe id 0 (lookupᵐ? acc' (stake addr'))
+      h' {addr'} {amt'} mem =
+        let (c'∈dom , amt'≤) = h (there mem)
+            c'≢c : stake addr' ≢ c
+            c'≢c = ≢-sym (All.lookup c∉xs (∈-map⁺ (stake ∘ proj₁) mem))
+            dom' : stake addr' ∈ dom acc'
+            dom' = ∪ˡ-res-dom-preserve acc c (bal ∸ amt) (stake addr') c'∈dom c'≢c
+            bal' : lookupᵐ? acc' (stake addr') ≡ lookupᵐ? acc (stake addr')
+            bal' = ∪ˡ-res-lookup-preserve acc c (bal ∸ amt) (stake addr') c'≢c
+        in  dom' , subst (amt' ≤_) (cong (maybe id 0) (sym bal')) amt'≤
+```
+-->
+
+
+

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
@@ -58,6 +58,7 @@ open import Relation.Binary using (IsEquivalence)
 open import Data.Nat.Properties using (n≤0⇒n≡0)
 open RewardAddress
 open Any
+open ≡-Reasoning
 
 private variable
   A : Type
@@ -98,7 +99,6 @@ getCoin-∪ˡ-overwrite acc c v =
     v + getCoin (acc ∣ ❴ c ❵ ᶜ)
       ∎
   where
-  open ≡-Reasoning
   open Equivalence
   module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
   -- `res-decomp ❴ c , v ❵ᵐ acc` proves
@@ -115,7 +115,10 @@ getCoin-∪ˡ-overwrite acc c v =
   -- (`Map.agda`: `(x , _) ≡ᵐ (y , _) = x ≡ᵉ y`), so `res-comp-cong`
   -- (from `Axiom.Set.Rel`) lifts straight to the Map level.
   restrict-cong' : (❴ c , v ❵ᵐ ∪ˡ (acc ∣ dom (❴ c , v ❵ᵐ ˢ) ᶜ)) ˢ ≡ᵉ (❴ c , v ❵ᵐ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) ˢ
-  restrict-cong' = ∪ˡ-cong (≡ᵉ.refl {x = ❴ c , v ❵ᵐ ˢ}) (res-comp-cong dom-single≡single)
+  restrict-cong' =
+    ∪ˡ-cong {m = ❴ c , v ❵ᵐ} {m' = (acc ∣ dom (❴ c , v ❵ᵐ ˢ) ᶜ)}{m'' = ❴ c , v ❵ᵐ} {m''' = (acc ∣ ❴ c ❵ ᶜ)}
+      (≡ᵉ.refl {x = ❴ c , v ❵ᵐ ˢ}) (res-comp-cong dom-single≡single)
+--  ∪ˡ-cong : ∀ {m m' m'' m''' : Map A B} → m ≡ᵐ m'' → m' ≡ᵐ m''' → (m ∪ˡ m') ≡ᵐ (m'' ∪ˡ m''')
 
   bridge : (❴ c , v ❵ ∪ˡ acc) ˢ ≡ᵉ (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) ˢ
   bridge = ≡ᵉ.trans (res-decomp ❴ c , v ❵ᵐ acc) restrict-cong'
@@ -124,6 +127,52 @@ getCoin-∪ˡ-overwrite acc c v =
   disj x y = res-comp-dom y (dom-single→single x)
 ```
 -->
+
+### `split-by-lookup`: decompose `getCoin acc` along a known lookup result
+
+When `lookupᵐ? acc c ≡ just bal`, we can split `getCoin acc` into the
+contribution of `c` (which is `bal`) plus the contribution of everything
+else (`acc ∣ ❴ c ❵ ᶜ`).  This is the prefix shared by both `applyOne-pov`
+and `applyOne-pov-add`; factoring it out avoids duplicating the proof.
+
+```agda
+split-by-lookup : (acc : Rewards) (c : Credential) (bal : Coin)
+  → lookupᵐ? acc c ≡ just bal
+  → getCoin acc ≡ getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
+```
+
+<!--
+```agda
+split-by-lookup acc c bal lookup-eq =
+  begin
+    getCoin acc
+      ≡˘⟨ ≡ᵉ-getCoin decomp acc
+            ( ≡ᵉ.trans (disjoint-∪ˡ-∪ (disjoint-sym res-ex-disjoint))
+                       ( ≡ᵉ.trans ∪-sym (res-ex-∪ Dec-∈-singleton)) ) ⟩
+    getCoin decomp
+      ≡⟨ indexedSumᵛ'-∪ (acc ∣ ❴ c ❵ ᶜ) (acc ∣ ❴ c ❵) (disjoint-sym res-ex-disjoint) ⟩
+    getCoin (acc ∣ ❴ c ❵ ᶜ) + getCoin (acc ∣ ❴ c ❵)
+      ≡⟨ cong (getCoin (acc ∣ ❴ c ❵ ᶜ) +_) acc∣c≡bal ⟩
+    getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
+      ∎
+  where
+  module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+  open Equivalence
+  decomp : Credential ⇀ Coin
+  decomp = (acc ∣ ❴ c ❵ ᶜ) ∪ˡ (acc ∣ ❴ c ❵)
+  c∈acc : (c , bal) ∈ acc ˢ
+  c∈acc with c ∈? dom (acc ˢ)
+  ... | yes c∈dom =
+    subst (λ v → (c , v) ∈ acc ˢ) (just-injective lookup-eq) (lookupᵐ-∈ acc c c∈dom)
+  ... | no c∉dom = case lookup-eq of λ ()
+  acc∣c≡bal : getCoin (acc ∣ ❴ c ❵) ≡ bal
+  acc∣c≡bal =
+    trans (getCoin-cong (acc ∣ ❴ c ❵) ❴ (c , bal) ❵ (res-singleton' {m = acc} c∈acc))
+          getCoin-singleton
+```
+-->
+
+
 
 ### Single-step Lemma: `applyOne` decreases `getCoin` by `amt`
 
@@ -140,16 +189,10 @@ applyOne-pov :
 
 <!--
 ```agda
-applyOne-pov acc addr amt bal lookup-eq amt≤bal =
+applyOne-pov acc addr amt bal lookup-eq amt≤bal = let c = stake addr in
   begin
     getCoin acc
-      ≡˘⟨ ≡ᵉ-getCoin decomp acc
-      ( ≡ᵉ.trans (disjoint-∪ˡ-∪ (disjoint-sym res-ex-disjoint))
-                 ( ≡ᵉ.trans ∪-sym (res-ex-∪ Dec-∈-singleton)) ) ⟩
-    getCoin decomp
-      ≡⟨ indexedSumᵛ'-∪ (acc ∣ ❴ c ❵ ᶜ) (acc ∣ ❴ c ❵) (disjoint-sym res-ex-disjoint) ⟩
-    getCoin (acc ∣ ❴ c ❵ ᶜ) + getCoin (acc ∣ ❴ c ❵)
-      ≡⟨ cong (getCoin (acc ∣ ❴ c ❵ ᶜ) +_) acc∣c≡bal ⟩
+      ≡⟨ split-by-lookup acc c bal lookup-eq ⟩
     getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
       ≡⟨ cong (getCoin (acc ∣ ❴ c ❵ ᶜ) +_) (sym (m∸n+n≡m amt≤bal)) ⟩
     getCoin (acc ∣ ❴ c ❵ ᶜ) + (bal ∸ amt + amt)
@@ -159,29 +202,6 @@ applyOne-pov acc addr amt bal lookup-eq amt≤bal =
       ≡˘⟨ cong (_+ amt) (getCoin-∪ˡ-overwrite acc c (bal ∸ amt)) ⟩
     getCoin (❴ c , bal ∸ amt ❵ ∪ˡ acc) + amt
       ∎
-  where
-  module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
-  open ≡-Reasoning
-  open Equivalence
-
-  c : Credential
-  c = stake addr
-
-  decomp : Credential ⇀ Coin
-  decomp = (acc ∣ ❴ c ❵ ᶜ) ∪ˡ (acc ∣ ❴ c ❵)
-
-  c∈acc : (c , bal) ∈ acc ˢ
-  c∈acc with c ∈? dom (acc ˢ)
-  ... | yes c∈dom =
-    subst (λ v → (c , v) ∈ acc ˢ) (just-injective lookup-eq) (lookupᵐ-∈ acc c c∈dom)
-  ... | no c∉dom = case lookup-eq of λ ()
-
-  acc∣c≡bal : getCoin (acc ∣ ❴ c ❵) ≡ bal
-  acc∣c≡bal =
-    trans (getCoin-cong (acc ∣ ❴ c ❵) ❴ (c , bal) ❵ (res-singleton' {m = acc} c∈acc))
-          getCoin-singleton
-
-  -- `c∉dom-compl` and `disj-doms` removed: the bridge lemma encapsulates them.
 ```
 -->
 
@@ -218,9 +238,9 @@ module ApplyToRewards-PoV
 
   -- TODO: ask that these be proved in the `agda-sets` library.
 
-  -- 1. For any credential `c'` other than `c`, lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c'
-  ( ∪ˡ-res-lookup-preserve : (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
-      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+  -- 1. For any credential `c'` other than `c`, lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c'
+  ( ∪ˡ-lookup-preserve : (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
     -- It's hard because the `agda-sets` API requires instance resolution for
     -- `lookupᵐ?`, but the semantic content is clear (lookup in a left-biased union
     -- for a key not in the left map equals lookup in the right map, and complement
@@ -255,22 +275,22 @@ This is the form needed by `PRE-CERT-pov`.
 ```agda
   applyWithdrawals-pov : (wdrls : Withdrawals) (rwds : Rewards)
     → mapˢ stake (dom wdrls) ⊆ dom rwds
+    → ∀[ a ∈ dom wdrls ] NetworkIdOf a ≡ NetworkId
     → ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rwds (stake addr))
     → getCoin rwds ≡ getCoin (applyWithdrawals wdrls rwds) + getCoin wdrls
 ```
 
 <!--
 ```agda
-  applyWithdrawals-pov wdrls rwds creds∈ amts≤ =
+  applyWithdrawals-pov wdrls rwds creds∈ netIds amts≤ =
     begin
       getCoin rwds
-        ≡⟨ foldl-applyOne-pov rwds (setToList (wdrls ˢ)) inv (setToList-Unique wdrls) ⟩
+        ≡⟨ foldl-applyOne-pov rwds (setToList (wdrls ˢ)) inv (setToList-Unique wdrls netIds) ⟩
       getCoin (foldl (applyOne _∸_) rwds (setToList (wdrls ˢ))) + sum (map proj₂ (setToList (wdrls ˢ)))
         ≡⟨ cong (getCoin (foldl (applyOne _∸_) rwds (setToList (wdrls ˢ))) +_) (sum-map-proj₂≡getCoin wdrls) ⟩
       getCoin (applyWithdrawals wdrls rwds) + getCoin wdrls
         ∎
     where
-    open ≡-Reasoning
     open Equivalence
 
     inv : ∀ {addr amt} → (addr , amt) ∈ˡ setToList (wdrls ˢ)
@@ -357,9 +377,9 @@ This is the form needed by `PRE-CERT-pov`.
             c'≢c : stake addr' ≢ c
             c'≢c = ≢-sym (All.lookup c∉xs (∈-map⁺ (stake ∘ proj₁) mem))
             dom' : stake addr' ∈ dom acc'
-            dom' = ∪ˡ-res-dom-preserve acc c (bal ∸ amt) (stake addr') c'∈dom c'≢c
+            dom' = dom∪ˡʳ {m = ❴ c , bal ∸ amt ❵} {m' = acc} c'∈dom
             bal' : lookupᵐ? acc' (stake addr') ≡ lookupᵐ? acc (stake addr')
-            bal' = ∪ˡ-res-lookup-preserve acc c (bal ∸ amt) (stake addr') c'≢c
+            bal' = ∪ˡ-lookup-preserve acc c (bal ∸ amt) (stake addr') c'≢c
         in  dom' , subst (amt' ≤_) (cong (maybe id 0) (sym bal')) amt'≤
 ```
 -->
@@ -396,15 +416,6 @@ directly from `getCoin-∪ˡ-overwrite`.
         ≡˘⟨ cong (_+ amt) (split-by-lookup acc c bal lookup-eq) ⟩
       getCoin acc + amt
         ∎
-    where
-    open ≡-Reasoning
-    -- Same decomposition `acc ≡ (acc ∣ ❴ c ❵ ᶜ) ∪ˡ (acc ∣ ❴ c ❵)` used in
-    -- `applyOne-pov`; factor it out if both proofs are kept in this module.
-    split-by-lookup : (acc : Rewards) (c : Credential) (bal : Coin)
-      → lookupᵐ? acc c ≡ just bal
-      → getCoin acc ≡ getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
-    split-by-lookup acc c bal lookup-eq = {!!}
-      -- Same proof as the first three steps of `applyOne-pov`; factor it out.
 ```
 -->
 
@@ -421,13 +432,6 @@ directly from `getCoin-∪ˡ-overwrite`.
     sym (+-identityʳ (indexedSumᵛ' id acc))
   foldl-applyOne-pov-add acc ((addr , amt) ∷ xs) h (c∉xs :: uniq-xs)
     with lookupᵐ? acc (stake addr) in eq
-  -- Defensive `nothing` case ruled out by the membership precondition.
-  ... | nothing = ⊥-elim (case lookup-just (h (here refl)) of λ where
-                            (_ , p) → case trans (sym eq) p of λ ())
-    where
-    -- A small helper: membership in domain implies `lookupᵐ?` is `just`.
-    lookup-just : ∀ {a} → a ∈ dom acc → Σ Coin λ v → lookupᵐ? acc a ≡ just v
-    lookup-just = {!!}  -- standard agda-sets bridge; provable from `dom∈`.
   ... | just bal = begin
       getCoin (foldl (applyOne _+_) acc' xs)
         ≡⟨ foldl-applyOne-pov-add acc' xs h' uniq-xs ⟩
@@ -438,17 +442,20 @@ directly from `getCoin-∪ˡ-overwrite`.
       getCoin acc + (amt + sum (map proj₂ xs))
         ∎
     where
-    open ≡-Reasoning
     c = stake addr
     acc' = ❴ c , bal + amt ❵ ∪ˡ acc
     -- `h'` is the same invariant-transfer argument as in `foldl-applyOne-pov`,
-    -- but with no `amt ≤ maybe id 0 (lookupᵐ? _ _)` bound to thread —
-    -- only domain membership has to be preserved.  Use the bridge lemma
-    -- to convert `acc' = ❴ c , bal + amt ❵ ∪ˡ acc` into the equivalent
-    -- `❴ c , bal + amt ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)` form, then reuse
-    -- `∪ˡ-res-dom-preserve` from `Certs/Properties/ApplyWithdrawalsPoV`.
+    -- but with no `amt ≤ maybe id 0 (lookupᵐ? _ _)` bound to thread — only
+    -- domain membership has to be preserved.
+    -- Since `acc' = ❴ c , bal + amt ❵ ∪ˡ acc` (no complement restriction),
+    -- we use `dom∪ˡʳ` directly; membership in `dom acc` lifts to membership
+    -- in `dom acc'` without needing the `c'≢c` witness.
     h' : ∀ {addr' amt'} → (addr' , amt') ∈ˡ xs → stake addr' ∈ dom acc'
-    h' = {!!}  -- mechanical mirror of the original `h'`; see comment above.
+    h' mem = dom∪ˡʳ {m = ❴ c , bal + amt ❵} {m' = acc} (h (there mem))
+  -- Defensive `nothing` case ruled out by the membership precondition.
+  ... | nothing with (stake addr ∈? dom (acc ˢ))
+  ... | yes c∈ = case eq of λ ()
+  ... | no a∉ = ⊥-elim (a∉ (h (here refl)))
 ```
 -->
 
@@ -468,14 +475,13 @@ directly from `getCoin-∪ˡ-overwrite`.
       getCoin (applyDirectDeposits dd rwds)
         ≡⟨ refl ⟩  -- by definition of `applyDirectDeposits = applyToRewards _+_`
       getCoin (foldl (applyOne _+_) rwds (setToList (dd ˢ)))
-        ≡⟨ sym (foldl-applyOne-pov-add rwds (setToList (dd ˢ)) inv
-                                       (setToList-Unique dd netIds)) ⟩
+        ≡⟨ foldl-applyOne-pov-add rwds (setToList (dd ˢ)) inv
+                                       (setToList-Unique dd netIds) ⟩
       getCoin rwds + sum (map proj₂ (setToList (dd ˢ)))
         ≡⟨ cong (getCoin rwds +_) (sum-map-proj₂≡getCoin dd) ⟩
       getCoin rwds + getCoin dd
         ∎
     where
-    open ≡-Reasoning
     open Equivalence
     inv : ∀ {addr amt} → (addr , amt) ∈ˡ setToList (dd ˢ) → stake addr ∈ dom rwds
     inv {addr} {amt} mem =

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
@@ -1,0 +1,60 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
+---
+
+# CERTS: Preservation of Value {#sec:certs-pov}
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Gov.Base using (GovStructure)
+
+module Ledger.Dijkstra.Specification.Certs.Properties.PoV
+  (gs : GovStructure) (open GovStructure gs) where
+
+open import Ledger.Prelude
+
+open import Ledger.Dijkstra.Specification.Certs gs
+open import Ledger.Dijkstra.Specification.Certs.Properties.PoVLemmas gs
+open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
+open import Ledger.Prelude
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
+open import Data.Nat.Properties using (+-0-monoid)
+
+open CertState
+open RewardAddress
+
+private variable
+  l : List DCert
+
+instance
+  _ = +-0-monoid
+
+module Certs-PoV
+  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+
+  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+  where
+    open Certs-Pov-lemmas ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+```
+-->
+
+## Theorem: The `CERTS` rule preserves value {#thm:CERTS-PoV}
+
+```agda
+    CERTS-pov : {Γ : CertEnv} {s₁ sₙ : CertState}
+      → ∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId
+      → Γ ⊢ s₁ ⇀⦇ l ,CERTS⦈ sₙ
+      → getCoin s₁ ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)
+```
+
+```agda
+    CERTS-pov {Γ = Γ} validNetId (run (pre-cert , certs)) =
+      trans  (PRE-CERT-pov validNetId pre-cert)
+             (cong (_+ getCoin (WithdrawalsOf Γ)) (sts-pov certs))
+```

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
@@ -37,16 +37,13 @@ module Certs-PoV
   ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
       → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
 
-  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+  ( sum-map-proj₂≡getCoin : ∀ (m : RewardAddress ⇀ Coin) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
-  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
-
-  -- New CIP-159 assumption (forwarded to Certs-Pov-lemmas): see PoVLemmas.
-  ( indexedSumᵛ'-∪⁺ : ∀ (m m' : Rewards) → getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m' )
+  ( setToList-Unique : ∀ (m : RewardAddress ⇀ Coin) → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
 
   where
   open Certs-Pov-lemmas ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
-                        indexedSumᵛ'-∪⁺
 ```
 -->
 
@@ -66,6 +63,8 @@ Equivalently, the *increase* in rewards balance from `s₁`{.AgdaBound} to
 ```agda
   CERTS-pov : {Γ : CertEnv} {s₁ sₙ : CertState}
     → ∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId
+    → ∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId
+    → mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s₁))
     → Γ ⊢ s₁ ⇀⦇ l ,CERTS⦈ sₙ
     → getCoin s₁ + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)
 ```
@@ -77,11 +76,11 @@ plus an arithmetic shuffle to interleave the two accounting terms.
 
 <!--
 ```agda
-  CERTS-pov {Γ = Γ} {s₁} {sₙ} validNetId (run {s' = s'} (pre-cert , certs)) =
+  CERTS-pov {Γ = Γ} {s₁} {sₙ} validNetIdW validNetIdDD creds∈ (run {s' = s'} (pre-cert , certs)) =
     begin
       getCoin s₁ + cdd        ≡⟨ cong (_+ cdd) (PRE-CERT-pov validNetId pre-cert) ⟩
       getCoin s' + cwd + cdd  ≡⟨ swap-right _ (cwd) (cdd) ⟩
-      getCoin s' + cdd + cwd  ≡⟨ cong (_+ cwd) (sts-pov certs) ⟩
+      getCoin s' + cdd + cwd  ≡⟨ cong (_+ cwd) (sts-pov creds∈' validNetIdDD certs) ⟩
       getCoin sₙ + cwd ∎
     where
     open ≡-Reasoning
@@ -94,5 +93,7 @@ plus an arithmetic shuffle to interleave the two accounting terms.
       trans  (+-assoc a b c)
              (trans  (cong (a +_) (+-comm b c))
                      (sym (+-assoc a c b)))
+    creds∈' : mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s'))
+    creds∈' = {!!}  -- preserve-dom across PRE-CERT
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
@@ -16,12 +16,13 @@ module Ledger.Dijkstra.Specification.Certs.Properties.PoV
 
 open import Ledger.Prelude
 
+open import Ledger.Dijkstra.Specification.Account gs
 open import Ledger.Dijkstra.Specification.Certs gs
 open import Ledger.Dijkstra.Specification.Certs.Properties.PoVLemmas gs
 open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
 open import Ledger.Prelude
 open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
-open import Data.Nat.Properties using (+-0-monoid)
+open import Data.Nat.Properties using (+-0-monoid; +-comm; +-assoc)
 
 open CertState
 open RewardAddress
@@ -39,22 +40,59 @@ module Certs-PoV
   ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
   ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
+  -- New CIP-159 assumption (forwarded to Certs-Pov-lemmas): see PoVLemmas.
+  ( indexedSumᵛ'-∪⁺ : ∀ (m m' : Rewards) → getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m' )
+
   where
-    open Certs-Pov-lemmas ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+  open Certs-Pov-lemmas ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+                        indexedSumᵛ'-∪⁺
 ```
 -->
 
 ## Theorem: The `CERTS` rule preserves value {#thm:CERTS-PoV}
 
-```agda
-    CERTS-pov : {Γ : CertEnv} {s₁ sₙ : CertState}
-      → ∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId
-      → Γ ⊢ s₁ ⇀⦇ l ,CERTS⦈ sₙ
-      → getCoin s₁ ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)
-```
+In Dijkstra, the `CERTS`{.AgdaDatatype} rule processes withdrawals (via
+`PRE-CERT`{.AgdaDatatype}) and direct deposits (via `POST-CERT`{.AgdaDatatype})
+in addition to the certificate steps.  Withdrawals reduce the rewards balance;
+direct deposits increase it; the preservation-of-value equation is a symmetric
+"consumed equals produced" statement:
+
+`getCoin s₁ + getCoin (CertEnv.directDeposits Γ) ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)`.
+
+Equivalently, the *increase* in rewards balance from `s₁`{.AgdaBound} to
+`sₙ`{.AgdaBound} equals `directDeposits − withdrawals`.
 
 ```agda
-    CERTS-pov {Γ = Γ} validNetId (run (pre-cert , certs)) =
-      trans  (PRE-CERT-pov validNetId pre-cert)
-             (cong (_+ getCoin (WithdrawalsOf Γ)) (sts-pov certs))
+  CERTS-pov : {Γ : CertEnv} {s₁ sₙ : CertState}
+    → ∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId
+    → Γ ⊢ s₁ ⇀⦇ l ,CERTS⦈ sₙ
+    → getCoin s₁ + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)
 ```
+
+The proof composes `PRE-CERT-pov`{.AgdaFunction} (which gives
+`getCoin s₁ ≡ getCoin s' + getCoin (WithdrawalsOf Γ)`) with `sts-pov`{.AgdaFunction}
+(which gives `getCoin s' + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ`),
+plus an arithmetic shuffle to interleave the two accounting terms.
+
+<!--
+```agda
+  CERTS-pov {Γ = Γ} {s₁} {sₙ} validNetId (run {s' = s'} (pre-cert , certs)) =
+    begin
+      getCoin s₁ + cdd        ≡⟨ cong (_+ cdd) (PRE-CERT-pov validNetId pre-cert) ⟩
+      getCoin s' + cwd + cdd  ≡⟨ swap-right _ (cwd) (cdd) ⟩
+      getCoin s' + cdd + cwd  ≡⟨ cong (_+ cwd) (sts-pov certs) ⟩
+      getCoin sₙ + cwd ∎
+    where
+    open ≡-Reasoning
+    cdd cwd : Coin
+    cdd = getCoin (DirectDepositsOf Γ)
+    cwd = getCoin (WithdrawalsOf Γ)
+
+    swap-right : ∀ a b c → (a + b) + c ≡ (a + c) + b
+    swap-right a b c =
+      trans  (+-assoc a b c)
+             (trans  (cong (a +_) (+-comm b c))
+                     (sym (+-assoc a c b)))
+```
+-->

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
@@ -34,8 +34,8 @@ instance
   _ = +-0-monoid
 
 module Certs-PoV
-  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
-      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+  ( ∪ˡ-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
 
   ( sum-map-proj₂≡getCoin : ∀ (m : RewardAddress ⇀ Coin) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
@@ -43,7 +43,7 @@ module Certs-PoV
       → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
 
   where
-  open Certs-Pov-lemmas ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+  open Certs-Pov-lemmas ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
 ```
 -->
 
@@ -64,7 +64,6 @@ Equivalently, the *increase* in rewards balance from `s₁`{.AgdaBound} to
   CERTS-pov : {Γ : CertEnv} {s₁ sₙ : CertState}
     → ∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId
     → ∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId
-    → mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s₁))
     → Γ ⊢ s₁ ⇀⦇ l ,CERTS⦈ sₙ
     → getCoin s₁ + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)
 ```
@@ -76,11 +75,11 @@ plus an arithmetic shuffle to interleave the two accounting terms.
 
 <!--
 ```agda
-  CERTS-pov {Γ = Γ} {s₁} {sₙ} validNetIdW validNetIdDD creds∈ (run {s' = s'} (pre-cert , certs)) =
+  CERTS-pov {Γ = Γ} {s₁} {sₙ} validNetIdW validNetIdDD (run {s' = s'} (pre-cert , certs)) =
     begin
-      getCoin s₁ + cdd        ≡⟨ cong (_+ cdd) (PRE-CERT-pov validNetId pre-cert) ⟩
+      getCoin s₁ + cdd        ≡⟨ cong (_+ cdd) (PRE-CERT-pov validNetIdW pre-cert) ⟩
       getCoin s' + cwd + cdd  ≡⟨ swap-right _ (cwd) (cdd) ⟩
-      getCoin s' + cdd + cwd  ≡⟨ cong (_+ cwd) (sts-pov creds∈' validNetIdDD certs) ⟩
+      getCoin s' + cdd + cwd  ≡⟨ cong (_+ cwd) (sts-pov validNetIdDD certs) ⟩
       getCoin sₙ + cwd ∎
     where
     open ≡-Reasoning
@@ -93,7 +92,5 @@ plus an arithmetic shuffle to interleave the two accounting terms.
       trans  (+-assoc a b c)
              (trans  (cong (a +_) (+-comm b c))
                      (sym (+-assoc a c b)))
-    creds∈' : mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s'))
-    creds∈' = {!!}  -- preserve-dom across PRE-CERT
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
@@ -124,16 +124,12 @@ module Certs-Pov-lemmas
   ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
       → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
 
-  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+  ( sum-map-proj₂≡getCoin : ∀ (m : RewardAddress ⇀ Coin) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
-  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
-
-  -- New CIP-159 assumption: getCoin distributes over ∪⁺.
-  -- `∪⁺` adds values of shared keys, so `getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m'`
-  -- holds unconditionally.  TODO: Prove this in Ledger.Prelude or agda-sets.
-  ( indexedSumᵛ'-∪⁺ : ∀ (m m' : Rewards) → getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m' )
+  ( setToList-Unique : ∀ (m : RewardAddress ⇀ Coin) → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
   where
-    open ApplyWithdrawals-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+    open ApplyToRewards-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
 ```
 -->
 
@@ -145,14 +141,16 @@ becomes "pre-balance plus direct deposits equals post-balance":
 
 ```agda
     POST-CERT-pov : {Γ : CertEnv} {s s' : CertState}
+      → mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s))
+      → ∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId
       → Γ ⊢ s ⇀⦇ _ ,POST-CERT⦈ s'
       → getCoin s + getCoin (DirectDepositsOf Γ) ≡ getCoin s'
 ```
 
 <!--
 ```agda
-    POST-CERT-pov (CERT-post {dd = dd} {rewards = rewards} _) =
-      sym (indexedSumᵛ'-∪⁺ rewards dd)
+    POST-CERT-pov {Γ} {s} creds∈ netIds (CERT-post {dd = dd} {rewards = rewards} _) =
+      applyDirectDeposits-pov dd rewards creds∈ netIds
 ```
 -->
 
@@ -165,6 +163,8 @@ final `POST-CERT`{.AgdaDatatype} step adds `getCoin (DirectDepositsOf Γ)`.
 
 ```agda
     sts-pov : {Γ : CertEnv} {s₁ sₙ : CertState} {sigs : List DCert}
+      → mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s₁))
+      → ∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId
       → RunTraceAndThen _⊢_⇀⦇_,CERT⦈_ _⊢_⇀⦇_,POST-CERT⦈_ Γ s₁ sigs sₙ
       → getCoin s₁ + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ
 ```

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
@@ -121,15 +121,15 @@ injOn _ h {record { stake = stakex }} {record { stake = stakey }} x∈ y∈ refl
   cong (λ u → record { net = u ; stake = stakex }) (trans (h x∈) (sym (h y∈)))
 
 module Certs-Pov-lemmas
-  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
-      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+  ( ∪ˡ-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m ) c' ≡ lookupᵐ? m c' )
 
   ( sum-map-proj₂≡getCoin : ∀ (m : RewardAddress ⇀ Coin) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
   ( setToList-Unique : ∀ (m : RewardAddress ⇀ Coin) → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
       → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
   where
-    open ApplyToRewards-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+    open ApplyToRewards-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
 ```
 -->
 
@@ -141,7 +141,6 @@ becomes "pre-balance plus direct deposits equals post-balance":
 
 ```agda
     POST-CERT-pov : {Γ : CertEnv} {s s' : CertState}
-      → mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s))
       → ∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId
       → Γ ⊢ s ⇀⦇ _ ,POST-CERT⦈ s'
       → getCoin s + getCoin (DirectDepositsOf Γ) ≡ getCoin s'
@@ -149,8 +148,13 @@ becomes "pre-balance plus direct deposits equals post-balance":
 
 <!--
 ```agda
-    POST-CERT-pov {Γ} {s} creds∈ netIds (CERT-post {dd = dd} {rewards = rewards} _) =
-      applyDirectDeposits-pov dd rewards creds∈ netIds
+    -- `CERT-post`'s own premise `creds∈ : mapˢ stake (dom dd) ⊆ dom rewards`
+    -- is exactly what `applyDirectDeposits-pov` needs.  We extract it from
+    -- the step rather than threading it from outside, because CERTs *do*
+    -- generally change `dom rewards` (e.g. `DELEG-dereg`), so the premise
+    -- can't be propagated from the pre-CERT* state.
+    POST-CERT-pov netIds (CERT-post {dd = dd} {rewards = rewards} creds∈) =
+      sym (applyDirectDeposits-pov dd rewards creds∈ netIds)
 ```
 -->
 
@@ -163,7 +167,6 @@ final `POST-CERT`{.AgdaDatatype} step adds `getCoin (DirectDepositsOf Γ)`.
 
 ```agda
     sts-pov : {Γ : CertEnv} {s₁ sₙ : CertState} {sigs : List DCert}
-      → mapˢ stake (dom (DirectDepositsOf Γ)) ⊆ dom (RewardsOf (DStateOf s₁))
       → ∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId
       → RunTraceAndThen _⊢_⇀⦇_,CERT⦈_ _⊢_⇀⦇_,POST-CERT⦈_ Γ s₁ sigs sₙ
       → getCoin s₁ + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ
@@ -171,9 +174,15 @@ final `POST-CERT`{.AgdaDatatype} step adds `getCoin (DirectDepositsOf Γ)`.
 
 <!--
 ```agda
-    sts-pov (run-[] x) = POST-CERT-pov x
-    sts-pov {Γ = Γ} (run-∷ x xs) =
-      trans (cong (_+ getCoin (DirectDepositsOf Γ)) (CERT-pov x)) (sts-pov xs)
+    sts-pov nid (run-[] x) = POST-CERT-pov nid x
+    sts-pov {Γ} {s₁} {sₙ} nid (run-∷ {s' = s'} x xs) =
+      begin
+      rewardsBalance (dState s₁) + getCoin (DirectDepositsOf Γ)
+      ≡⟨ cong (_+ getCoin (DirectDepositsOf Γ)) (CERT-pov x) ⟩
+      rewardsBalance (dState s') + getCoin (DirectDepositsOf Γ)
+        ≡⟨ sts-pov nid xs ⟩
+      rewardsBalance (dState sₙ)
+      ∎
 ```
 -->
 
@@ -194,6 +203,6 @@ Conway's `constMap`/`res-decomp`/`sumConstZero` chain.
 ```agda
     PRE-CERT-pov {Γ = Γ} {s = cs} validNetId
       (CERT-pre {wdrls = wdrls} (_ , wdrlCreds⊆rwds , wdrlBounded)) =
-        applyWithdrawals-pov wdrls (RewardsOf (dState cs)) wdrlCreds⊆rwds wdrlBounded
+        applyWithdrawals-pov wdrls (RewardsOf (dState cs)) wdrlCreds⊆rwds validNetId wdrlBounded
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
@@ -8,11 +8,17 @@ source_path: src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.
 
 ## Key Differences from Conway
 
-+  **`PRE-CERT`**: Conway uses `constMap wdrlCreds 0 ∪ˡ rewards` (zeroing).
++  **`PRE-CERT`**.  Conway uses `constMap wdrlCreds 0 ∪ˡ rewards` (zeroing).
    Dijkstra (CIP-159) uses `applyWithdrawals wdrls rewards` (subtraction).
    The PoV equation still holds; the proof structure differs.
-+  **`CERT` / `DELEG`**: Same value-relevant structure as Conway.
-+  **No `CERT-vdel`**: Dijkstra has `CERT-deleg`, `CERT-pool`, `CERT-gov` only.
++  **`POST-CERT`**.  Conway only filters `voteDelegs` and preserves `getCoin`.
+   Dijkstra (CIP-159) additionally applies `rewards ∪⁺ directDeposits`, increasing
+   the value by `getCoin (DirectDepositsOf Γ)`.  The PoV equation
+   therefore changes: `POST-CERT-pov` and `sts-pov` now relate the pre- and
+   post-state by the direct-deposit total, and `CERTS-pov` becomes a symmetric
+   "consumed ≡ produced" equation balancing withdrawals against direct deposits.
++  **`CERT` / `DELEG`**.  Same value-relevant structure as Conway.
++  **No `CERT-vdel`**.  Dijkstra has `CERT-deleg`, `CERT-pool`, `CERT-gov` only.
 
 <!--
 ```agda
@@ -23,6 +29,7 @@ open import Ledger.Dijkstra.Specification.Gov.Base using (GovStructure)
 module Ledger.Dijkstra.Specification.Certs.Properties.PoVLemmas
   (gs : GovStructure) (open GovStructure gs) where
 
+open import Ledger.Dijkstra.Specification.Account gs
 open import Ledger.Dijkstra.Specification.Certs gs
 open import Ledger.Dijkstra.Specification.Certs.Properties.ApplyWithdrawalsPoV gs
 open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
@@ -56,6 +63,8 @@ CERT-pov : {Γ : CertEnv} {s s' : CertState}
   → Γ ⊢ s ⇀⦇ dCert ,CERT⦈ s' → getCoin s ≡ getCoin s'
 ```
 
+(The `CERT` rule is unchanged in Dijkstra, so this lemma matches the Conway version.)
+
 <!--
 ```agda
 CERT-pov (CERT-deleg (DELEG-delegate {rwds = rwds} _)) = sym (∪ˡsingleton0≡ rwds)
@@ -88,26 +97,20 @@ CERT-pov (CERT-gov _) = refl
 ```
 -->
 
-## POST-CERT-pov and sts-pov
+## CIP-159 PoV lemmas (parameterized)
 
-```agda
-POST-CERT-pov : {Γ : CertEnv} {s s' : CertState}
-  → Γ ⊢ s ⇀⦇ _ ,POST-CERT⦈ s' → getCoin s ≡ getCoin s'
+The `POST-CERT-pov`, `sts-pov`, and `PRE-CERT-pov` proofs all live inside the
+parameterized `Certs-Pov-lemmas`{.AgdaModule} sub-module.
 
-POST-CERT-pov CERT-post = refl
-
-sts-pov : {Γ : CertEnv} {s₁ sₙ : CertState} {sigs : List DCert}
-  → RunTraceAndThen _⊢_⇀⦇_,CERT⦈_ _⊢_⇀⦇_,POST-CERT⦈_ Γ s₁ sigs sₙ
-  → getCoin s₁ ≡ getCoin sₙ
-sts-pov (run-[] x) = POST-CERT-pov x
-sts-pov (run-∷ x xs) = trans (CERT-pov x) (sts-pov xs)
-```
-
-## PRE-CERT-pov (CIP-159: partial withdrawals)
-
-The key new assumption `applyWithdrawals-pov` states that applying withdrawals
-decreases `rewardsBalance` by exactly the total withdrawn amount.  This replaces
-Conway's `constMap`/`res-decomp`/`sumConstZero` chain.
++  `PRE-CERT-pov`{.AgdaFunction} relies on `applyWithdrawals-pov`{.AgdaFunction}
+   from `Certs.Properties.ApplyWithdrawalsPoV`{.AgdaModule}, which itself takes
+   three module parameters bridging gaps in the `agda-sets` API.
++  `POST-CERT-pov`{.AgdaFunction} relies on a fourth parameter
+   `indexedSumᵛ'-∪⁺`{.AgdaFunction} stating that `getCoin` distributes over
+   `∪⁺`{.AgdaFunction} (union with addition).  This is the natural analogue of
+   the existing Conway `indexedSumᵛ'-∪`{.AgdaFunction} lemma for `∪ˡ`{.AgdaFunction}
+   on disjoint domains, but for `∪⁺`{.AgdaFunction} the equation holds
+   *unconditionally* — values at shared keys are added rather than dropped.
 
 <!--
 ```agda
@@ -124,10 +127,61 @@ module Certs-Pov-lemmas
   ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
   ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
+  -- New CIP-159 assumption: getCoin distributes over ∪⁺.
+  -- `∪⁺` adds values of shared keys, so `getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m'`
+  -- holds unconditionally.  TODO: Prove this in Ledger.Prelude or agda-sets.
+  ( indexedSumᵛ'-∪⁺ : ∀ (m m' : Rewards) → getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m' )
   where
     open ApplyWithdrawals-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
 ```
 -->
+
+### POST-CERT-pov (CIP-159: direct deposits)
+
+The `POST-CERT`{.AgdaDatatype} rule applies direct deposits via `rewards ∪⁺ dd`,
+*increasing* the rewards balance by `getCoin dd`.  The PoV equation therefore
+becomes "pre-balance plus direct deposits equals post-balance":
+
+```agda
+    POST-CERT-pov : {Γ : CertEnv} {s s' : CertState}
+      → Γ ⊢ s ⇀⦇ _ ,POST-CERT⦈ s'
+      → getCoin s + getCoin (DirectDepositsOf Γ) ≡ getCoin s'
+```
+
+<!--
+```agda
+    POST-CERT-pov (CERT-post {dd = dd} {rewards = rewards} _) =
+      sym (indexedSumᵛ'-∪⁺ rewards dd)
+```
+-->
+
+### sts-pov
+
+A trace of `CERT`{.AgdaDatatype} steps followed by `POST-CERT`{.AgdaDatatype}
+increases the rewards balance by exactly the direct-deposit total: each
+`CERT`{.AgdaDatatype} step preserves value (by `CERT-pov`{.AgdaFunction}), and the
+final `POST-CERT`{.AgdaDatatype} step adds `getCoin (DirectDepositsOf Γ)`.
+
+```agda
+    sts-pov : {Γ : CertEnv} {s₁ sₙ : CertState} {sigs : List DCert}
+      → RunTraceAndThen _⊢_⇀⦇_,CERT⦈_ _⊢_⇀⦇_,POST-CERT⦈_ Γ s₁ sigs sₙ
+      → getCoin s₁ + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ
+```
+
+<!--
+```agda
+    sts-pov (run-[] x) = POST-CERT-pov x
+    sts-pov {Γ = Γ} (run-∷ x xs) =
+      trans (cong (_+ getCoin (DirectDepositsOf Γ)) (CERT-pov x)) (sts-pov xs)
+```
+-->
+
+### PRE-CERT-pov (CIP-159: partial withdrawals)
+
+The key new assumption `applyWithdrawals-pov` states that applying withdrawals
+decreases `rewardsBalance` by exactly the total withdrawn amount.  This replaces
+Conway's `constMap`/`res-decomp`/`sumConstZero` chain.
 
 ```agda
     PRE-CERT-pov : {Γ : CertEnv} {s s' : CertState}

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
@@ -1,0 +1,145 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Certs/Properties/PoVLemmas.lagda.md
+---
+
+
+# CERTS: Preservation of Value Lemmas {#sec:certs-pov-lemmas}
+
+## Key Differences from Conway
+
++  **`PRE-CERT`**: Conway uses `constMap wdrlCreds 0 ∪ˡ rewards` (zeroing).
+   Dijkstra (CIP-159) uses `applyWithdrawals wdrls rewards` (subtraction).
+   The PoV equation still holds; the proof structure differs.
++  **`CERT` / `DELEG`**: Same value-relevant structure as Conway.
++  **No `CERT-vdel`**: Dijkstra has `CERT-deleg`, `CERT-pool`, `CERT-gov` only.
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Gov.Base using (GovStructure)
+
+module Ledger.Dijkstra.Specification.Certs.Properties.PoVLemmas
+  (gs : GovStructure) (open GovStructure gs) where
+
+open import Ledger.Dijkstra.Specification.Certs gs
+open import Ledger.Dijkstra.Specification.Certs.Properties.ApplyWithdrawalsPoV gs
+open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
+open import Ledger.Prelude
+
+open import Axiom.Set.Properties th
+
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
+open import Data.Nat.Properties using (+-0-monoid; +-identityʳ)
+open import Relation.Binary using (IsEquivalence)
+
+open RewardAddress
+open Computational ⦃...⦄
+open CertState
+
+private variable
+  dCert : DCert
+  A A' : Type
+
+instance
+  _ = +-0-monoid
+
+open ≡-Reasoning
+```
+-->
+
+## CERT-pov: Each certificate step preserves value
+
+```agda
+CERT-pov : {Γ : CertEnv} {s s' : CertState}
+  → Γ ⊢ s ⇀⦇ dCert ,CERT⦈ s' → getCoin s ≡ getCoin s'
+```
+
+<!--
+```agda
+CERT-pov (CERT-deleg (DELEG-delegate {rwds = rwds} _)) = sym (∪ˡsingleton0≡ rwds)
+CERT-pov {s = ⟦ _ , stᵖ , stᵍ ⟧ᶜˢ} {⟦ _ , stᵖ' , stᵍ' ⟧ᶜˢ}
+    (CERT-deleg (DELEG-dereg {c = c} {rwds} {vDelegs = vDelegs} {sDelegs} x)) = begin
+    getCoin ⟦ ⟦ vDelegs , sDelegs , rwds , DepositsOf stᵍ ⟧ , stᵖ , stᵍ ⟧
+      ≡˘⟨ ≡ᵉ-getCoin rwds-∪ˡ-decomp rwds
+          ( ≡ᵉ.trans rwds-∪ˡ-∪
+            (≡ᵉ.trans ∪-sym (res-ex-∪ Dec-∈-singleton)) ) ⟩
+    getCoin rwds-∪ˡ-decomp
+      ≡⟨ ≡ᵉ-getCoin rwds-∪ˡ-decomp
+           ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ) rwds-∪ˡ≡sing-∪ˡ ⟩
+    getCoin ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ)
+      ≡⟨ ∪ˡsingleton0≡ (rwds ∣ ❴ c ❵ ᶜ) ⟩
+    getCoin ⟦ ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ , DepositsOf stᵍ ⟧ , stᵖ' , stᵍ' ⟧
+      ∎
+    where
+    module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+    rwds-∪ˡ-decomp = (rwds ∣ ❴ c ❵ ᶜ) ∪ˡ (rwds ∣ ❴ c ❵)
+    rwds-∪ˡ-∪ : rwds-∪ˡ-decomp ˢ ≡ᵉ (rwds ∣ ❴ c ❵ ᶜ)ˢ ∪ (rwds ∣ ❴ c ❵)ˢ
+    rwds-∪ˡ-∪ = disjoint-∪ˡ-∪ (disjoint-sym res-ex-disjoint)
+    disj : disjoint (dom ((rwds ∣ ❴ c ❵ˢ ᶜ) ˢ)) (dom (❴ c , 0 ❵ᵐ ˢ))
+    disj {a} a∈res a∈dom = res-comp-dom a∈res (dom-single→single a∈dom)
+    rwds-∪ˡ≡sing-∪ˡ : rwds-∪ˡ-decomp ˢ ≡ᵉ ((rwds ∣ ❴ c ❵ ᶜ) ∪ˡ ❴ (c , 0) ❵ᵐ)ˢ
+    rwds-∪ˡ≡sing-∪ˡ = ≡ᵉ.trans rwds-∪ˡ-∪
+                        ( ≡ᵉ.trans (∪-cong ≡ᵉ.refl (res-singleton'{m = rwds} (x .proj₁)))
+                                   (≡ᵉ.sym $ disjoint-∪ˡ-∪ disj) )
+CERT-pov (CERT-pool _) = refl
+CERT-pov (CERT-gov _) = refl
+```
+-->
+
+## POST-CERT-pov and sts-pov
+
+```agda
+POST-CERT-pov : {Γ : CertEnv} {s s' : CertState}
+  → Γ ⊢ s ⇀⦇ _ ,POST-CERT⦈ s' → getCoin s ≡ getCoin s'
+
+POST-CERT-pov CERT-post = refl
+
+sts-pov : {Γ : CertEnv} {s₁ sₙ : CertState} {sigs : List DCert}
+  → RunTraceAndThen _⊢_⇀⦇_,CERT⦈_ _⊢_⇀⦇_,POST-CERT⦈_ Γ s₁ sigs sₙ
+  → getCoin s₁ ≡ getCoin sₙ
+sts-pov (run-[] x) = POST-CERT-pov x
+sts-pov (run-∷ x xs) = trans (CERT-pov x) (sts-pov xs)
+```
+
+## PRE-CERT-pov (CIP-159: partial withdrawals)
+
+The key new assumption `applyWithdrawals-pov` states that applying withdrawals
+decreases `rewardsBalance` by exactly the total withdrawn amount.  This replaces
+Conway's `constMap`/`res-decomp`/`sumConstZero` chain.
+
+<!--
+```agda
+injOn : (wdls : Withdrawals)
+      → ∀[ a ∈ dom (wdls ˢ) ] NetworkIdOf a ≡ NetworkId
+      → InjectiveOn (dom (wdls ˢ)) RewardAddress.stake
+injOn _ h {record { stake = stakex }} {record { stake = stakey }} x∈ y∈ refl =
+  cong (λ u → record { net = u ; stake = stakex }) (trans (h x∈) (sym (h y∈)))
+
+module Certs-Pov-lemmas
+  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+
+  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+  where
+    open ApplyWithdrawals-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+```
+-->
+
+```agda
+    PRE-CERT-pov : {Γ : CertEnv} {s s' : CertState}
+      → ∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId
+      → Γ ⊢ s ⇀⦇ _ ,PRE-CERT⦈ s'
+      → getCoin s ≡ getCoin s' + getCoin (WithdrawalsOf Γ)
+```
+
+<!--
+```agda
+    PRE-CERT-pov {Γ = Γ} {s = cs} validNetId
+      (CERT-pre {wdrls = wdrls} (_ , wdrlCreds⊆rwds , wdrlBounded)) =
+        applyWithdrawals-pov wdrls (RewardsOf (dState cs)) wdrlCreds⊆rwds wdrlBounded
+```
+-->

--- a/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Transaction.lagda.md
@@ -412,10 +412,6 @@ could be either of them.
     field CurrentTreasuryOf : A → Maybe Coin
   open HasCurrentTreasury ⦃...⦄ public
 
-  record HasDirectDeposits {a} (A : Type a) : Type a where
-    field DirectDepositsOf : A → DirectDeposits
-  open HasDirectDeposits ⦃...⦄ public
-
   record HasBalanceIntervals {a} (A : Type a) : Type a where
     field BalanceIntervalsOf : A → AccountBalanceIntervals
   open HasBalanceIntervals ⦃...⦄ public

--- a/src/Ledger/Prelude.lagda.md
+++ b/src/Ledger/Prelude.lagda.md
@@ -41,22 +41,26 @@ open import Tactic.Derive.DecEq public
 open import Tactic.Inline public
 open import MyDebugOptions public
 open import Prelude.STS.GenPremises public
+open import Data.List.Membership.Propositional.Properties using (∈-deduplicate⁻)
+open import Relation.Binary using (IsEquivalence)
 
 open import abstract-set-theory.FiniteSetTheory public
   renaming (_⊆_ to _⊆ˢ_)
 open import abstract-set-theory.Axiom.Set.Map.Extra public
+
+open import Axiom.Set.Properties th
 
 import Data.Integer as ℤ
 open import Data.Integer using (0ℤ) public
 import Data.Rational as ℚ
 open import Data.Rational using (ℚ)
 
+open import Data.Nat.Properties using (+-identityʳ)
+
+
 dec-de-morgan : ∀{P Q : Type} → ⦃ P ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
 dec-de-morgan ⦃ ⁇ no ¬p ⦄ ¬pq = inj₁ ¬p
 dec-de-morgan ⦃ ⁇ yes p ⦄ ¬pq = inj₂ λ q → ¬pq (p , q)
-
-≡ᵉ-getCoin : ∀ {A} → ⦃ _ : DecEq A ⦄ → (s s' : A ⇀ Coin) → s ˢ ≡ᵉ s' ˢ → getCoin s ≡ getCoin s'
-≡ᵉ-getCoin {A} ⦃ decEqA ⦄ s s' s≡s' = indexedSumᵛ'-cong {C = Coin} {x = s} {y = s'} s≡s'
 
 setToMap : ∀ {A B : Type} → ⦃ DecEq A ⦄ → ℙ (A × B) → A ⇀ B
 setToMap = fromListᵐ ∘ setToList
@@ -98,4 +102,81 @@ Is-∅ X = Is-[] (setToList X)
 
 concatMapˡ : {A B : Type} → (A → ℙ B) → List A → ℙ B
 concatMapˡ f as = proj₁ $ unions (fromList (map f as))
+
+indexedSumL-proj₂-zero : ∀ {A : Type} (l : List (A × Coin))
+    → (∀ {x} → x ∈ˡ l → proj₂ x ≡ 0)
+    → indexedSumL {M = Coin} proj₂ l ≡ 0
+indexedSumL-proj₂-zero [] _ = refl
+indexedSumL-proj₂-zero ((a , v) ∷ xs) all-zero =
+    trans (cong (_+ indexedSumL proj₂ xs) (all-zero (Prelude.Init.here refl)))
+          (indexedSumL-proj₂-zero xs (all-zero ∘ Prelude.Init.there))
+
+module _ {A : Type} ⦃ _ : DecEq A ⦄ where
+
+  getCoin-singleton : {(a , c) : A × Coin} → indexedSumᵛ' id ❴ (a , c) ❵ ≡ c
+  getCoin-singleton = indexedSum-singleton' {M = Coin} (finiteness _)
+
+  ≡ᵉ-getCoin : (s s' : A ⇀ Coin) → s ˢ ≡ᵉ s' ˢ → getCoin s ≡ getCoin s'
+  ≡ᵉ-getCoin s s' s≡s' = indexedSumᵛ'-cong {C = Coin} {x = s} {y = s'} s≡s'
+
+  getCoin-cong : (s : A ⇀ Coin) (s' : ℙ (A × Coin))
+    → s ˢ ≡ᵉ s' → indexedSum' proj₂ (s ˢ) ≡ indexedSum' proj₂ s'
+  getCoin-cong s s' eq = indexedSum-cong {f = proj₂} {x = (s ˢ) ᶠˢ} {y = s' ᶠˢ} eq
+
+  indexedSumᵛ'-∪ : (m m' : A ⇀ Coin) → disjoint (dom m) (dom m')
+    → getCoin (m ∪ˡ m') ≡ getCoin m + getCoin m'
+  indexedSumᵛ'-∪ m m' disj =
+    trans (indexedSumᵐ-∪ˡ-∪ˡᶠ m m')
+          (indexedSumᵐ-∪ {X = m ᶠᵐ} {m' ᶠᵐ} {f = proj₂} disj)
+
+
+  res-decomp : (m m' : A ⇀ Coin) → (m ∪ˡ m')ˢ ≡ᵉ (m ∪ˡ (m' ∣ dom (m ˢ) ᶜ))ˢ
+  res-decomp m m' = ∪-cong (≡ᵉ.refl {x = m ˢ}) (≡ᵉ.sym (filterᵐ-idem {m = m'}))
+    where module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {A × Coin})
+
+  ∪ˡsingleton∈dom : (m : A ⇀ Coin) {(a , c) : A × Coin}
+    → a ∈ dom m → getCoin (m ∪ˡ ❴ (a , c) ❵ᵐ) ≡ getCoin m
+  ∪ˡsingleton∈dom m {(a , c)} a∈dom = ≡ᵉ-getCoin (m ∪ˡ ❴ (a , c) ❵) m (singleton-∈-∪ˡ {m = m} a∈dom)
+
+  ∪ˡsingleton∉dom : (m : A ⇀ Coin) {(a , c) : A × Coin}
+    → a ∉ dom m → getCoin (m ∪ˡ ❴ (a , c) ❵ᵐ) ≡ getCoin m + c
+  ∪ˡsingleton∉dom m {(a , c)} a∉dom =
+    trans (indexedSumᵛ'-∪ m ❴ a , c ❵ᵐ ( λ x y → a∉dom (subst (_∈ dom m) (from ∈-dom-singleton-pair y) x) ))
+          (cong (getCoin m +_) getCoin-singleton)
+    where open Equivalence
+
+  ∪ˡsingleton0≡ : (m : A ⇀ Coin) {a : A} → getCoin (m ∪ˡ ❴ (a , 0) ❵ᵐ) ≡ getCoin m
+  ∪ˡsingleton0≡ m {a} with a ∈? dom m
+  ... | yes a∈dom = ∪ˡsingleton∈dom m a∈dom
+  ... | no a∉dom = trans (∪ˡsingleton∉dom m a∉dom) (+-identityʳ (getCoin m))
+
+opaque
+  unfolding List-Model finiteness
+
+  sumConstZero : {A : Type} ⦃ _ : DecEq A ⦄ {X : ℙ A} → getCoin (constMap X 0) ≡ 0
+  sumConstZero {A} {X} = indexedSumL-proj₂-zero (deduplicate _≟_ l) all-zero-dedup
+    where
+    open Equivalence
+
+    fin : finite (mapˢ (_, 0) X)
+    fin = finiteness (mapˢ (_, 0) X)
+
+    l : List (A × Coin)
+    l   = fin .proj₁
+
+    h : ∀ {a} → a ∈ (mapˢ (_, 0) X) ⇔ a ∈ˡ l
+    h   = fin .proj₂
+
+    all-zero : ∀ {x} → x ∈ˡ l → proj₂ x ≡ 0
+    all-zero x∈l with from ∈-map (from h x∈l)
+    ... | (a , refl , _) = refl
+
+    all-zero-dedup : ∀ {x} → x ∈ˡ deduplicate _≟_ l → proj₂ x ≡ 0
+    all-zero-dedup x∈dedup = all-zero (∈-deduplicate⁻ (DecEq._≟_ DecEq-×′) l x∈dedup)
+
+opaque
+  unfolding setToList List-Model
+
+  setToList-∈ : ∀ {A : Type} {a : A} {X : ℙ A} → a ∈ˡ setToList X → a ∈ X
+  setToList-∈ = id
 ```


### PR DESCRIPTION
**DEPRECATED**. This PR was based on CERT-Post and CERT-Pre setup. It is superseded by #1210 which is based on the `ENTITIES` approach.

---

# Description

Closes #1185.

This PR adds the preservation-of-value (PoV) proofs for the Dijkstra `Certs` rules.  The Conway `CERTS-pov` proves `getCoin s₁ ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)` assuming full withdrawals; CIP-159 introduces partial withdrawals (#1116), so the equation still holds — `getCoin (WithdrawalsOf Γ)` is the *actual amount withdrawn* — but the underlying `PRE-CERT` rule changes from `constMap`-based zeroing to fold-based subtraction, requiring a new `applyWithdrawals-pov` lemma.

This PR is the first of three replacing the original PR #1169, which has been split along module-tree boundaries.  It contains only the `Certs/Properties` sub-tree.

---

## Modules

| Module | Purpose | Status |
|--------|---------|--------|
| `Certs.Properties.ApplyWithdrawalsPoV` | `applyWithdrawals-pov` (top-level) plus `applyOne-pov` / `foldl-applyOne-pov` building blocks | Proved (modulo three module parameters) |
| `Certs.Properties.PoVLemmas` | `CERT-pov`, `POST-CERT-pov`, `sts-pov`, `PRE-CERT-pov` | Proved |
| `Certs.Properties.PoV` | `CERTS-pov` top-level theorem | Proved |

---

## Design notes

### `PRE-CERT-pov` uses `applyWithdrawals-pov` instead of Conway's `constMap` chain

Conway's `PRE-CERT` zeros out withdrawn credentials via `constMap wdrlCreds 0 ∪ˡ rewards`, and the PoV proof decomposes the rewards map into restricted/complement parts, showing the zeroing removes exactly `getCoin wdrls`.

Dijkstra's `PRE-CERT` uses `applyWithdrawals wdrls rewards` (CIP-159 partial withdrawals), which subtracts each withdrawal amount.  The PoV equation `getCoin s ≡ getCoin s' + getCoin wdrls` still holds, but the proof requires a new lemma — `applyWithdrawals-pov` — based on fold induction rather than map decomposition.

### `applyWithdrawals-pov` is structured as three layers

+  *Single step* (`applyOne-pov`).  Decomposes the accumulator into complement + restriction, shows the per-step decrease equals `amt` using `m∸n+n≡m`.
+  *Fold induction* (`foldl-applyOne-pov`).  Induction over `setToList (wdrls ˢ)`, maintaining an invariant that remaining entries have registered credentials with bounded balances.  Relies on `Unique` (from `stake` injectivity, which follows from the per-batch `NetworkId` constraint).
+  *Top-level* (`applyWithdrawals-pov`).  Instantiates the fold with the withdrawal map's list representation.

### `CERT-pov`, `POST-CERT-pov`, `sts-pov` are essentially unchanged from Conway

The Dijkstra `DELEG-delegate` and `DELEG-dereg` constructors have the same value-relevant structure (adding/removing zero-balance entries), and `POST-CERT` still only filters `voteDelegs`.  `CERT-pov` is missing the `CERT-vdel` case because Dijkstra has only `CERT-deleg`, `CERT-pool`, `CERT-gov`.

---

## Outstanding proof obligations

Three lemmas are stated as module parameters with detailed proof sketches in comments.  Each is provable from the existing `agda-sets` / `Withdrawals` machinery; they are kept as parameters here to keep this PR focused on the new fold-induction infrastructure.

+  `∪ˡ-res-lookup-preserve` — for any `c' ≠ c`, lookup in `❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)` agrees with lookup in `m`.  Painful to thread through `agda-sets` `⁇` instance resolution.
+  `sum-map-proj₂≡getCoin` — `getCoin` representation of a withdrawal map's coin sum.
+  `setToList-Unique` — `Unique` on `map (stake ∘ proj₁) (setToList (wdrls ˢ))`.  Follows from `stake` injectivity, which holds because the per-batch `NetworkId` constraint forces all withdrawals to share the same `net`.

These will be discharged in a follow-up; the relevant tracking has been added to issue #1185.

---

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
