### PR TITLE
[Dijkstra] (DEPRECATED) CIP-159-11c: Prove LEDGER PoV

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
@@ -169,8 +169,6 @@ split-by-lookup acc c bal lookup-eq =
   acc∣c≡bal =
     trans (getCoin-cong (acc ∣ ❴ c ❵) ❴ (c , bal) ❵ (res-singleton' {m = acc} c∈acc))
           getCoin-singleton
-```
--->
 
 
 

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/ApplyWithdrawalsPoV.lagda.md
@@ -169,7 +169,8 @@ split-by-lookup acc c bal lookup-eq =
   acc∣c≡bal =
     trans (getCoin-cong (acc ∣ ❴ c ❵) ❴ (c , bal) ❵ (res-singleton' {m = acc} c∈acc))
           getCoin-singleton
-
+```
+-->
 
 
 ### Single-step Lemma: `applyOne` decreases `getCoin` by `amt`

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/PoV.lagda.md
@@ -62,8 +62,8 @@ Equivalently, the *increase* in rewards balance from `s₁`{.AgdaBound} to
 
 ```agda
   CERTS-pov : {Γ : CertEnv} {s₁ sₙ : CertState}
-    → ∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId
-    → ∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId
+    → (∀[ a ∈ dom (WithdrawalsOf Γ) ] NetworkIdOf a ≡ NetworkId)
+      × (∀[ a ∈ dom (DirectDepositsOf Γ) ] NetworkIdOf a ≡ NetworkId)
     → Γ ⊢ s₁ ⇀⦇ l ,CERTS⦈ sₙ
     → getCoin s₁ + getCoin (DirectDepositsOf Γ) ≡ getCoin sₙ + getCoin (WithdrawalsOf Γ)
 ```
@@ -75,7 +75,7 @@ plus an arithmetic shuffle to interleave the two accounting terms.
 
 <!--
 ```agda
-  CERTS-pov {Γ = Γ} {s₁} {sₙ} validNetIdW validNetIdDD (run {s' = s'} (pre-cert , certs)) =
+  CERTS-pov {Γ = Γ} {s₁} {sₙ} (validNetIdW , validNetIdDD) (run {s' = s'} (pre-cert , certs)) =
     begin
       getCoin s₁ + cdd        ≡⟨ cong (_+ cdd) (PRE-CERT-pov validNetIdW pre-cert) ⟩
       getCoin s' + cwd + cdd  ≡⟨ swap-right _ (cwd) (cdd) ⟩

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -68,6 +68,9 @@ instance
   HasEnactState-LedgerEnv : HasEnactState LedgerEnv
   HasEnactState-LedgerEnv .EnactStateOf = LedgerEnv.enactState
 
+  HasTreasury-LedgerEnv : HasTreasury LedgerEnv
+  HasTreasury-LedgerEnv .TreasuryOf = LedgerEnv.treasury
+
   HasPParams-SubLedgerEnv : HasPParams SubLedgerEnv
   HasPParams-SubLedgerEnv .PParamsOf = SubLedgerEnv.pparams
 
@@ -82,9 +85,9 @@ instance
 
   HasAccountBalances-SubLedgerEnv : HasAccountBalances SubLedgerEnv
   HasAccountBalances-SubLedgerEnv .AccountBalancesOf = SubLedgerEnv.accountBalances
-
 ```
 -->
+
 ```agda
 record LedgerState : Type where
 ```
@@ -99,6 +102,7 @@ record LedgerState : Type where
     govSt      : GovState
     certState  : CertState
 ```
+
 <!--
 ```agda
 record HasLedgerState {a} (A : Type a) : Type a where
@@ -174,24 +178,24 @@ allColdCreds : GovState → EnactState → ℙ Credential
 allColdCreds govSt es =
   ccCreds (es .cc) ∪ concatMapˢ (λ (_ , st) → proposedCC (GovActionOf st)) (fromList govSt)
 
+coinFromDeposits : CertState → Coin
+coinFromDeposits certState =
+  getCoin (DepositsOf (DStateOf certState))
+  + getCoin (DepositsOf (PStateOf certState))
+  + getCoin (DepositsOf (GStateOf certState))
+
 calculateDepositsChange : CertState → CertState → CertState → DepositsChange
 calculateDepositsChange certState₀ certState₁ certState₂
   = ⟦ coinChangeTop , coinChangeSub ⟧
   where
-    coinFromDeposit : CertState → Coin
-    coinFromDeposit certState =
-      getCoin (DepositsOf (DStateOf certState))
-      + getCoin (DepositsOf (PStateOf certState))
-      + getCoin (DepositsOf (GStateOf certState))
-
     coin₀ : Coin
-    coin₀ = coinFromDeposit certState₀
+    coin₀ = coinFromDeposits certState₀
 
     coin₁ : Coin
-    coin₁ = coinFromDeposit certState₁
+    coin₁ = coinFromDeposits certState₁
 
     coin₂ : Coin
-    coin₂ = coinFromDeposit certState₂
+    coin₂ = coinFromDeposits certState₂
 
     coinChangeSub : ℤ
     coinChangeSub = coin₁ - coin₀
@@ -199,6 +203,19 @@ calculateDepositsChange certState₀ certState₁ certState₂
     coinChangeTop : ℤ
     coinChangeTop = coin₂ - coin₁
 ```
+
+<!--
+```agda
+instance
+  HasCoin-LedgerState : HasCoin LedgerState
+  HasCoin-LedgerState .getCoin s =
+    getCoin (UTxOStateOf s)             -- cbalance + fees + donations
+    + getCoin (CertStateOf s)           -- rewards
+    + coinFromDeposits (CertStateOf s)  -- deposits
+```
+-->
+
+
 
 ## <span class="AgdaDatatype">LEDGER</span> Transition System
 

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties.lagda.md
@@ -14,4 +14,5 @@ module Ledger.Dijkstra.Specification.Ledger.Properties where
 
 ```agda
 open import Ledger.Dijkstra.Specification.Ledger.Properties.Computational
+open import Ledger.Dijkstra.Specification.Ledger.Properties.PoV
 ```

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -11,10 +11,11 @@ partial withdrawals).
 
 ## Key Differences from Conway
 
-1. **`UTxOState` has 3 fields** (no deposits) — simpler `HasCoin-UTxOState`.
-2. **`LEDGER-V` applies `applyDirectDeposits`** after all sub-rules, creating
-   `certStateFinal` with increased rewards.  Direct deposit value cancels
-   between `producedBatch` (UTxO side) and `certStateFinal` (CertState side).
+1. **`UTxOState` has 3 fields** (no deposits).
+2. **Direct deposits are applied inside `CERTS`**, not at the LEDGER level.
+   The LEDGER-V final state is `⟦ utxoSt₂ , rmOrphanDRepVotes cs₂ govSt₂ , cs₂ ⟧`.
+   Direct-deposit value cancels between `producedBatch` (UTxO side,
+   `UTXOW-batch-balance-coin`) and `cs₂` (CertState side, the symmetric `CERTS-pov`).
 3. **Batch structure**: `SUBLEDGERS` processes sub-transactions before top-level
    `CERTS`/`GOVS`/`UTXOW`.  Individual sub-transactions do NOT independently
    preserve total value — only the batch-level `consumedBatch ≡ producedBatch` does.
@@ -47,100 +48,82 @@ open import Ledger.Dijkstra.Specification.Utxow txs abs
 open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
 
 open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
-open import Data.Nat.Properties
-  using (+-0-monoid; +-identityʳ; +-comm; +-assoc; +-cancelʳ-≡)
+open import Data.Nat.Properties using (+-comm; +-assoc; +-cancelʳ-≡)
 
 
 open RewardAddress
 ```
 -->
 
-## Key Lemma: `applyDirectDeposits` increases `getCoin` by deposit total
-
-`applyDirectDeposits dd ds = record ds { rewards = RewardsOf ds ∪⁺ dd }`,
-and `getCoin` for `CertState` is `rewardsBalance ∘ DStateOf = ∑[ x ← rewards ] x`
-
-
 ## Proof Architecture
 
-The Dijkstra `LEDGER-pov`{.AgdaFunction} proof does NOT decompose into independent
-`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces, because:
+The Dijkstra `LEDGER-pov`{.AgdaFunction} proof does not decompose into independent
+`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces, because
 
-1.  Individual `SUBUTXO` rules have no balance equation — only the
-    *batch-level* `consumedBatch ≡ producedBatch` (in `UTXO`) constrains
-    the total.
+1.  individual `SUBUTXO` rules have no balance equation — only the batch-wide
+    `consumedBatch ≡ producedBatch` (in `UTXO`) constrains the total;
 
-2.  Sub-transactions may individually transfer value between UTxO and CertState (via
-    sub-withdrawals, sub-deposits, sub-direct-deposits) without local balancing.
+2.  sub-transactions may individually transfer value between UTxO and CertState
+    (via sub-withdrawals, sub-deposits, sub-direct-deposits) without local balancing.
 
-Instead, the proof reasons about the **entire** `LEDGER-V`{.AgdaInductiveConstructor}
+Instead, the proof reasons about the entire `LEDGER-V`{.AgdaInductiveConstructor}
 step at once.
 
 ### <span class="AgdaInductiveConstructor">LEDGER-V</span> Proof Outline
 
-Given
-`s  = ⟦ utxoSt₀ , govSt₀ , certState₀ ⟧`
-and
-`s' = ⟦ utxoSt₂ , govSt₂' , certStateFinal ⟧`,
-where
-`certStateFinal` has `rewards = rewards₂ ∪⁺ allDirectDeposits tx`,
-we need:
+Given `s  = ⟦ utxoSt₀ , govSt₀ , certState₀ ⟧` and
+`s' = ⟦ utxoSt₂ , rmOrphanDRepVotes certState₂ govState₂ , certState₂ ⟧`, we need:
 
-`getCoin utxoSt₀ + rewardsBalance₀ + deposits₀`
-`≡ getCoin utxoSt₂ + rewardsBalance_final + deposits₂`
+    getCoin utxoSt₀ + rewardsBalance₀ + coinFromDeposits(cs₀)
+    ≡ getCoin utxoSt₂ + rewardsBalance₂ + coinFromDeposits(cs₂)
 
-The key equations are:
+The four key equations are:
 
-1.  `consumedBatch ≡ producedBatch`  (coin projection, from `UTXO`{.AgdaDatatype} premise).
+1.  **Batch UTxO balance** (`UTXOW-batch-balance-coin`, coin projection of
+    `consumedBatch ≡ producedBatch`):
 
-    This gives (using `coin∘inject = id`, `coin mint = 0`):
+        Σ cbalance(utxo₀ ∣ SpendInputs_i) + Σ wdrls_i + depositRefunds
+        ≡ Σ cbalance(outs_i) + txFee + Σ donations_i + Σ directDeps_i + newDeposits
 
-    `Σ cbalance(utxo₀ ∣ SpendInputs_i) + Σ wdrls_i + depositRefunds`
-    `= Σ cbalance(outs_i) + txFee + Σ directDeps_i + Σ donations_i + newDeposits`
+    where the sums range over all transactions in the batch (top + sub), and
+    `posPart`/`negPart` of `DepositsChangeTopOf`/`DepositsChangeSubOf` play
+    the roles of `newDeposits`/`depositRefunds`.
 
-    where the sums range over all transactions in the batch (top + sub).
+2.  **Combined CERTS-pov** (`combined-certs`, composing top-level `CERTS-pov`
+    with the telescoped sub-tx chain `SUBLEDGERS-certs-pov`):
 
-2.  `CERTS-pov` (combined sub + top level):
+    `rewardsBalance₀ + Σ directDeps_i ≡ rewardsBalance₂ + Σ wdrls_i`
 
-    `rewardsBalance₀ = rewardsBalance₂ + Σ wdrls_i`
+3.  **Deposit accounting** (`posNeg-deposits`):
 
-    This requires composing sub-level `CERTS-pov` for each subtransaction
-    with top-level `CERTS-pov`.
+    `coinFromDeposits(cs₀) + newDeposits ≡ coinFromDeposits(cs₂) + depositRefunds`
 
-3.  `depositsChange` property:
+    (per `calculateDepositsChange`, applied component-wise to top and sub.)
 
-    `deposits₂ = deposits₀ + newDeposits - depositRefunds`
+4.  **Mechanical UTxO tracking** (`UTXOW-V-mechanical` composed with
+    `SUBLEDGERS-utxo-coin`):
 
-    This follows from the definition of `calculateDepositsChange` and
-    the posPart/negPart identity.
+        getCoin utxoSt₀ + Σ outs_i + Σ donations_i + txFee
+        ≡ getCoin utxoSt₂ + Σ cbalance(utxo₀ ∣ SpendInputs_i)
 
-4.  `applyDirectDeposits`:
+#### Combining
 
-    `rewardsBalance_final = rewardsBalance₂ + Σ directDeps_i`
+(1)+(3)+(4) cancel out the deposit-change and UTxO-mechanical terms, yielding:
 
-5.  Mechanical UTxO tracking:
+    U₀ + Σ wdrls_i + D₀ ≡ U₂ + Σ directDeps_i + D₂     (★)
 
-    `getCoin utxoSt₂ = cbalance(utxo₂) + fees₂ + donations₂`
+This is `step-ii` in the proof. Adding `R₂` to both sides gives the
+intermediate stage of the main chain.
 
-    where `utxo₂`, `fees₂`, `donations₂` are determined by the
-    `SUBLEDGERS` + `UTXO` mechanical state changes.
+To close, add `Σ directDeps_i` to both sides of the goal (eliminated at the end via
+`+-cancelʳ-≡`):
 
-Combining:
-
-From (1) and (3), adding the equations and using `+-cancelʳ-≡` to
-eliminate `newDeposits + depositRefunds` from both sides:
-
-+  `getCoin utxoSt₀ + Σ wdrls_i + coinFromDeposits(cs₀)`
-   `= getCoin utxoSt₂ + Σ directDeps_i + coinFromDeposits(cs₂)`
-
-Then:
-
-+  `getCoin utxoSt₀ + rewardsBalance₀ + coinFromDeposits(cs₀)`
-   `= getCoin utxoSt₀ + (rewardsBalance₂ + Σ wdrls_i) + coinFromDeposits(cs₀)` (by 2)
-   `= getCoin utxoSt₂ + Σ directDeps_i + coinFromDeposits(cs₂) + rewardsBalance₂` (by combined 1+3)
-   `= getCoin utxoSt₂ + rewardsBalance_final + coinFromDeposits(cs₂)` (by 4)
-   `= getCoin utxoSt₂ + getCoin certStateFinal + coinFromDeposits(cs₂)` (since deposits unchanged by applyDirectDeposits)
-
+    (U₀ + R₀ + D₀) + Σ directDeps_i
+    ≡ U₀ + (R₀ + Σ directDeps_i) + D₀
+    ≡ U₀ + (R₂ + Σ wdrls_i) + D₀               by (2)
+    ≡ U₀ + Σ wdrls_i + D₀ + R₂                 (rearrange)
+    ≡ U₂ + Σ directDeps_i + D₂ + R₂            by (★)
+    ≡ (U₂ + R₂ + D₂) + Σ directDeps_i          (rearrange)
 
 
 ### `LEDGER-I` proof outline
@@ -149,27 +132,18 @@ Then:
 
 `SUBLEDGERS` is a no-op (`isValid ≡ false` ⟹ each `SUBLEDGER-I` preserves state).
 
-The UTXOW/UTXO step in the invalid case:
+In the invalid case the UTXOW/UTXO step performs collateral collection only
+(no deposit processing — `depositsChange = ⟦ 0ℤ , 0ℤ ⟧`):
 
-`utxoSt₁ = ⟦ utxo₀ ∣ collateral ᶜ , fees + cbalance(utxo₀ ∣ collateral) , deposits₀ , donations₀ ⟧`
+`utxoSt₁ = ⟦ utxo₀ ∣ collateral ᶜ , fees + cbalance(utxo₀ ∣ collateral) , donations₀ ⟧`
 
-(Actually in Dijkstra, deposits aren't in UTxOState, and the invalid case has
-`depositsChange = ⟦ 0ℤ , 0ℤ ⟧`, so the UTxO changes are just collateral collection.)
+By `split-balance`,
 
-`getCoin utxoSt₁ = cbalance(utxo₀ ∣ coll ᶜ) + (fees + cbalance(utxo₀ ∣ coll)) + donations₀`
+    getCoin utxoSt₁ ≡ cbalance(utxo₀ ∣ collateral ᶜ) + (fees + cbalance(utxo₀ ∣ collateral)) + donations₀
+                    ≡ cbalance utxo₀ + fees + donations₀
+                    ≡ getCoin utxoSt₀
 
-`= cbalance utxo₀ + fees + donations₀`   [by split-balance]
-
-`= getCoin utxoSt₀`
-
-So
-
-`getCoin s' = getCoin utxoSt₁ + getCoin certState₀ + coinFromDeposits certState₀`
-
-`= getCoin utxoSt₀ + getCoin certState₀ + coinFromDeposits certState₀`
-
-`= getCoin s`
-
+So `getCoin s' ≡ getCoin utxoSt₁ + getCoin certState₀ + coinFromDeposits certState₀ = getCoin s`.
 
 <!--
 ```agda
@@ -204,10 +178,6 @@ module _
 
   -- Sub-lemmas (assumptions for now) --
 
-  -- CIP-159–specific assumption: ∪⁺ adds getCoin values
-  ( applyDirectDeposits-rewardsBalance : (dd : DirectDeposits) (ds : DState)
-      → rewardsBalance (applyDirectDeposits dd ds) ≡ rewardsBalance ds + getCoin dd )
-
   -- Assumptions required to open `UTXOW-PoV` (Utxow-level properties):
   ( noMintTx : coin (MintedValueOf tx) ≡ 0 )
   ( noMintSubTx : noMintingSubTxs tx )
@@ -239,27 +209,29 @@ module _
       → let dc = calculateDepositsChange cs₀ cs₁ cs₂ in
         coinFromDeposits cs₀ + posPart (DepositsChangeTopOf dc) + posPart (DepositsChangeSubOf dc)
         ≡ coinFromDeposits cs₂ + negPart (DepositsChangeTopOf dc) + negPart (DepositsChangeSubOf dc) )
-  -- Aggregation identity for `allDirectDeposits`.  Provable from the
-  -- definition of `allDirectDeposits` once we confirm it sums top-level
-  -- and sub-level direct deposits disjointly.  Deferred.
-  ( DD-split :
-      getCoin (allDirectDeposits tx) ≡ getCoin (DirectDepositsOf tx)
-                                       + sum (map (λ stx → getCoin (DirectDepositsOf stx)) (SubTransactionsOf tx)) )
+
   -- Sum distribution (standard list algebra):
   ( sum-map-+ : ∀ {A : Type} (f g : A → ℕ) (xs : List A)
       → sum (map (λ x → f x + g x) xs) ≡ sum (map f xs) + sum (map g xs) )
 
   where
   open Certs-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique indexedSumᵛ'-∪⁺
-  -- Import the utxow-level properties (utxow-pov-invalid, UTXOW-V-mechanical,
-  -- UTXOW-batch-balance-coin) from `Utxow.Properties.PoV`.  The `λ {u}{u'} →`
-  -- η-wrapper is needed for the same Agda eta-expansion reason as in
-  -- `Utxow.Properties.PoV` itself.
+  -- Note: The `λ {u}{u'} →` η-wrapper may be needed for Agda eta-expansion issue.
+
   open UTXOW-PoV tx (λ {u} {u'} → balance-∪ {u} {u'}) split-balance noMintTx noMintSubTx (λ {u} → outs-disjoint {u})
   open ≡-Reasoning
 
+  -- Per-sub-tx withdrawal totals.
   wdrwl : SubLevelTx → Coin
   wdrwl = getCoin ∘ WithdrawalsOf
+
+  -- Per-sub-tx direct-deposit totals.
+  ddwl : SubLevelTx → Coin
+  ddwl = getCoin ∘ DirectDepositsOf
+
+  -- Move the rightmost summand one position left (modulo re-assoc).
+  swap-right : ∀ a b c → a + b + c ≡ a + c + b
+  swap-right a b c = trans (+-assoc a b c) (trans (cong (a +_) (+-comm b c)) (sym (+-assoc a c b)))
 
   SUBLEDGERS-utxo-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
     → SubLedgerEnv.isTopLevelValid Γ ≡ true
@@ -279,12 +251,12 @@ module _
     (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , _ , _)) rest) =
     begin
       U₀ + (p-stx + p-sum)    ≡⟨ sym (+-assoc U₀ p-stx p-sum) ⟩
-      (U₀ + p-stx) + p-sum    ≡⟨ cong (_+ p-sum) step-P-C ⟩
-      (U₁ + c-stx) + p-sum    ≡⟨ +-assoc U₁ c-stx p-sum ⟩
+      U₀ + p-stx + p-sum      ≡⟨ cong (_+ p-sum) step-P-C ⟩
+      U₁ + c-stx + p-sum      ≡⟨ +-assoc U₁ c-stx p-sum ⟩
       U₁ + (c-stx + p-sum)    ≡⟨ cong (U₁ +_) (+-comm c-stx p-sum) ⟩
       U₁ + (p-sum + c-stx)    ≡⟨ sym (+-assoc U₁ p-sum c-stx) ⟩
-      (U₁ + p-sum) + c-stx    ≡⟨ cong (_+ c-stx) ih ⟩
-      (Uₙ + c-sum) + c-stx    ≡⟨ +-assoc Uₙ c-sum c-stx ⟩
+      U₁ + p-sum + c-stx      ≡⟨ cong (_+ c-stx) ih ⟩
+      Uₙ + c-sum + c-stx      ≡⟨ +-assoc Uₙ c-sum c-stx ⟩
       Uₙ + (c-sum + c-stx)    ≡⟨ cong (Uₙ +_) (+-comm c-sum c-stx) ⟩
       Uₙ + (c-stx + c-sum)    ∎
     where
@@ -315,25 +287,40 @@ module _
   SUBLEDGERS-certs-pov : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
     → SubLedgerEnv.isTopLevelValid Γ ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
-    → getCoin (CertStateOf s₀)
+    → getCoin (CertStateOf s₀) + sum (map ddwl stxs)
       ≡ getCoin (CertStateOf s₁) + sum (map wdrwl stxs)
 
-  -- Base case: empty list, getCoin cs₀ ≡ getCoin cs₀ + 0
-  SUBLEDGERS-certs-pov isV (BS-base Id-nop) = sym (+-identityʳ _)
+  -- Base case: empty list, getCoin cs₀ + 0 ≡ getCoin cs₀ + 0 — refl.
+  SUBLEDGERS-certs-pov isV (BS-base Id-nop) = refl
 
-  -- Inductive step: one SUBLEDGER step + rest
-  SUBLEDGERS-certs-pov isV (BS-ind (SUBLEDGER-I (isI , _)) rest) = ⊥-elim (case trans (sym isV) isI of λ ())
+  -- SUBLEDGER-I ruled out by isV.
+  SUBLEDGERS-certs-pov isV (BS-ind (SUBLEDGER-I (isI , _)) rest) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  -- Inductive step.
   SUBLEDGERS-certs-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
     (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , certsStep , govsStep)) rest) =
       begin
-      getCoin (CertStateOf s₀)
-        ≡⟨ sub-certs ⟩
-      getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)
+      getCoin (CertStateOf s₀) + (getCoin (DirectDepositsOf stx) + sum (map ddwl sigs))
+        ≡⟨ sym (+-assoc (getCoin (CertStateOf s₀))
+                        (getCoin (DirectDepositsOf stx))
+                        (sum (map ddwl sigs))) ⟩
+      (getCoin (CertStateOf s₀) + getCoin (DirectDepositsOf stx)) + sum (map ddwl sigs)
+        ≡⟨ cong (_+ sum (map ddwl sigs)) sub-certs ⟩
+      (getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)) + sum (map ddwl sigs)
+        ≡⟨ swap-right (getCoin (CertStateOf s₁))
+                      (getCoin (WithdrawalsOf stx))
+                      (sum (map ddwl sigs)) ⟩
+      (getCoin (CertStateOf s₁) + sum (map ddwl sigs)) + getCoin (WithdrawalsOf stx)
         ≡⟨ cong (_+ getCoin (WithdrawalsOf stx)) ih ⟩
       (getCoin (CertStateOf sₙ) + sum (map wdrwl sigs)) + getCoin (WithdrawalsOf stx)
-        ≡⟨ +-assoc (getCoin (CertStateOf sₙ)) _ _ ⟩
-      getCoin (CertStateOf sₙ) + (sum (map wdrwl sigs) + getCoin (WithdrawalsOf stx))
-        ≡⟨ cong (getCoin (CertStateOf sₙ) +_) (+-comm _ (getCoin (WithdrawalsOf stx))) ⟩
+        ≡⟨ swap-right (getCoin (CertStateOf sₙ))
+                      (sum (map wdrwl sigs))
+                      (getCoin (WithdrawalsOf stx)) ⟩
+      (getCoin (CertStateOf sₙ) + getCoin (WithdrawalsOf stx)) + sum (map wdrwl sigs)
+        ≡⟨ +-assoc (getCoin (CertStateOf sₙ))
+                   (getCoin (WithdrawalsOf stx))
+                   (sum (map wdrwl sigs)) ⟩
       getCoin (CertStateOf sₙ) + (getCoin (WithdrawalsOf stx) + sum (map wdrwl sigs))
         ∎
     where
@@ -344,18 +331,15 @@ module _
       (SUBUTXOW ( _ , _ , _ , _ , _ , _ , _ , _ , _ , _
                 , _ , _ , SUBUTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
 
-    wdrl-netId : ∀[ a ∈ dom (WithdrawalsOf stx) ] NetworkIdOf a ≡ NetworkId
-    wdrl-netId = extract-subutxo-netId subutxowStep -- extract from premise 11
+    -- Sub-level CERTS-pov (NEW signature: dd on LHS, wdrl on RHS).
+    sub-certs : getCoin (CertStateOf s₀) + getCoin (DirectDepositsOf stx)
+                ≡ getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)
+    sub-certs = CERTS-pov (extract-subutxo-netId subutxowStep) certsStep
 
-    -- Sub-level CERTS-pov
-    sub-certs :  getCoin (CertStateOf s₀)
-                 ≡ getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)
-    sub-certs = CERTS-pov wdrl-netId certsStep
-
-    -- IH
-    ih :  getCoin (CertStateOf s₁) ≡ getCoin (CertStateOf sₙ) + sum (map wdrwl sigs)
+    -- IH: same form as the outer goal, just one element shorter.
+    ih : getCoin (CertStateOf s₁) + sum (map ddwl sigs)
+         ≡ getCoin (CertStateOf sₙ) + sum (map wdrwl sigs)
     ih = SUBLEDGERS-certs-pov isV rest
-
 ```
 -->
 
@@ -380,25 +364,41 @@ Only the `UTXOW`{.AgdaDatatype} step matters and it preserves `getCoin utxoSt`.
 
 ### LEDGER-V (valid transaction)
 
-The `LEDGER-V` rule produces
-
-`s' = ⟦ utxoSt₂ , rmOrphanDRepVotes certStateFinal govState₂ , certStateFinal ⟧`
-
-where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allDirectDeposits tx) (DStateOf certState₂) }`.
+Direct deposits are applied inside `CERTS` (via `POST-CERT`), absorbed into
+`certState₂` directly.  The LEDGER-V final state is
+`⟦ utxoSt₂ , rmOrphanDRepVotes cs₂ govSt₂ , cs₂ ⟧`.  Direct deposit value cancels
+between `producedBatch` (UTxO side, via `UTXOW-batch-balance-coin`) and `certState₂`
+(CertState side, via the symmetric `CERTS-pov`).
 
 ```agda
   LEDGER-pov {Γ} {s}
     (LEDGER-V {certState₁ = cs₁} {cs₂} {govSt₁} {govSt₂}
               {utxoState₁ = us₁} {utxoState₂ = us₂}
               (valid , subStep , certStep , govStep , utxoStep)) =
-    begin
-      U₀ + R₀ + D₀                      ≡⟨ step-i ⟩
-      U₀ + R₂ + allWdrls + D₀           ≡⟨ arithmetic-1 U₀ R₂ allWdrls D₀ ⟩
-      U₀ + allWdrls + D₀ + R₂           ≡⟨ step-iii-iv ⟩
-      U₂ + allDirectDeps + D₂ + R₂      ≡⟨ arithmetic-2 U₂ allDirectDeps D₂ R₂ ⟩
-      U₂ + (R₂ + allDirectDeps) + D₂    ≡⟨ step-ii ⟩
-      U₂ + getCoin certStateFinal + D₂  ∎
-      where
+    +-cancelʳ-≡ _ _ _
+      (begin
+        U₀ + R₀ + D₀ + allDirectDeps       ≡⟨ step-i ⟩
+        U₀ + R₂ + allWdrls + D₀            ≡⟨ abcd-to-acdb U₀ R₂ allWdrls D₀ ⟩
+        U₀ + allWdrls + D₀ + R₂            ≡⟨ step-ii ⟩
+        U₂ + allDirectDeps + D₂ + R₂       ≡⟨ abcd-to-adcb U₂ allDirectDeps D₂ R₂ ⟩
+        U₂ + R₂ + D₂ + allDirectDeps       ∎)
+
+    where
+      abcd-to-acdb : ∀ a b c d → a + b + c + d ≡ a + c + d + b
+      abcd-to-acdb a b c d = begin
+        a + b + c + d     ≡⟨ cong (_+ d) (+-assoc a b c) ⟩
+        a + (b + c) + d   ≡⟨ cong (λ x → a + x + d) (+-comm b c) ⟩
+        a + (c + b) + d   ≡⟨ cong (_+ d) (sym (+-assoc a c b)) ⟩
+        a + c + b + d     ≡⟨ +-assoc (a + c) b d ⟩
+        a + c + (b + d)   ≡⟨ cong ((a + c) +_) (+-comm b d) ⟩
+        a + c + (d + b)   ≡⟨ sym (+-assoc (a + c) d b) ⟩
+        a + c + d + b     ∎
+
+      abcd-to-adcb : ∀ a b c d → a + b + c + d ≡ a + d + c + b
+      abcd-to-adcb a b c d =
+        trans (swap-right (a + b) c d)
+              (trans (cong (_+ c) (swap-right a b d))
+                     (swap-right (a + d) b c))
 
       U₀ U₁ U₂ : Coin
       U₀ = getCoin (UTxOStateOf s)
@@ -413,11 +413,11 @@ where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allD
       R₀ = rewardsBalance (DStateOf (CertStateOf s))
       R₂ = rewardsBalance (DStateOf cs₂)
 
-      certStateFinal : CertState
-      certStateFinal = record cs₂ { dState = applyDirectDeposits (allDirectDeposits tx) (DStateOf cs₂) }
+      subDirectDepsCoin : Coin
+      subDirectDepsCoin = sum (map ddwl (SubTransactionsOf tx))
 
       allDirectDeps : Coin
-      allDirectDeps = getCoin (allDirectDeposits tx)
+      allDirectDeps = getCoin (DirectDepositsOf tx) + subDirectDepsCoin
 
       subWdrlsCoin : Coin
       subWdrlsCoin = sum (map wdrwl (SubTransactionsOf tx))
@@ -428,41 +428,44 @@ where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allD
       extract-utxo-netId : ∀ {Γ' s₀' s₁'} → Γ' ⊢ s₀' ⇀⦇ tx ,UTXOW⦈ s₁'
         → ∀[ a ∈ dom (WithdrawalsOf tx) ] NetworkIdOf a ≡ NetworkId
       extract-utxo-netId
-        (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _
+        (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _ _
           (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
       extract-utxo-netId
-        (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _
+        (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
           (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
 
-      -- combined CERTS: rewardsBalance₀ = rewardsBalance₂ + allWdrls
-      combined-certs : getCoin (CertStateOf s) ≡ getCoin cs₂ + allWdrls
+      -- Combined CERTS-pov: pre-batch certState + all direct deposits ≡
+      --                     post-CERTS certState + all withdrawals.
+      combined-certs : getCoin (CertStateOf s) + allDirectDeps ≡ getCoin cs₂ + allWdrls
       combined-certs =
         begin
-        getCoin (CertStateOf s)                                    ≡⟨ SUBLEDGERS-certs-pov valid subStep ⟩
-        getCoin cs₁ + subWdrlsCoin                                 ≡⟨ cong (_+ subWdrlsCoin) (CERTS-pov (extract-utxo-netId utxoStep) certStep) ⟩
-        getCoin cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin    ≡⟨ +-assoc (getCoin cs₂) _ subWdrlsCoin ⟩
-        getCoin cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)  ∎
+          getCoin (CertStateOf s) + allDirectDeps
+            ≡⟨ cong (getCoin (CertStateOf s) +_)
+                    (+-comm (getCoin (DirectDepositsOf tx)) subDirectDepsCoin) ⟩
+          getCoin (CertStateOf s) + (subDirectDepsCoin + getCoin (DirectDepositsOf tx))
+            ≡⟨ sym (+-assoc (getCoin (CertStateOf s))
+                            subDirectDepsCoin
+                            (getCoin (DirectDepositsOf tx))) ⟩
+          getCoin (CertStateOf s) + subDirectDepsCoin + getCoin (DirectDepositsOf tx)
+            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx)) (SUBLEDGERS-certs-pov valid subStep) ⟩
+          getCoin cs₁ + subWdrlsCoin + getCoin (DirectDepositsOf tx)
+            ≡⟨ swap-right (getCoin cs₁) subWdrlsCoin (getCoin (DirectDepositsOf tx)) ⟩
+          getCoin cs₁ + getCoin (DirectDepositsOf tx) + subWdrlsCoin
+            ≡⟨ cong (_+ subWdrlsCoin) (CERTS-pov (extract-utxo-netId utxoStep) certStep) ⟩
+          getCoin cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin
+            ≡⟨ +-assoc (getCoin cs₂) (getCoin (WithdrawalsOf tx)) subWdrlsCoin ⟩
+          getCoin cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)
+            ∎
 
-
-      step-i : U₀ + R₀ + D₀ ≡ U₀ + R₂ + allWdrls + D₀
+      -- step-i: rearrange the LHS (with allDirectDeps inserted) using combined-certs.
+      step-i : (U₀ + R₀ + D₀) + allDirectDeps ≡ U₀ + R₂ + allWdrls + D₀
       step-i =
         begin
-        U₀ + R₀ + D₀                ≡⟨ cong (λ x → U₀ + x + D₀ ) combined-certs ⟩
-        U₀ + (R₂ + allWdrls) + D₀   ≡⟨ cong (_+ D₀) (sym (+-assoc U₀ R₂ allWdrls)) ⟩
-        U₀ + R₂ + allWdrls + D₀     ∎
-
-
-      -- applyDirectDeposits-rewardsBalance
-      step-ii : getCoin us₂ + (R₂ + allDirectDeps) + D₂
-                ≡ getCoin us₂ + getCoin certStateFinal + D₂
-      step-ii = cong (λ x → getCoin us₂ + x + D₂)
-                     (sym (applyDirectDeposits-rewardsBalance (allDirectDeposits tx) (DStateOf cs₂)))
-
-
-
-      -- Move the rightmost summand one position left (modulo re-assoc).
-      swap-right : ∀ a b c → a + b + c ≡ a + c + b
-      swap-right a b c = trans (+-assoc a b c) (trans (cong (a +_) (+-comm b c)) (sym (+-assoc a c b)))
+          U₀ + R₀ + D₀ + allDirectDeps    ≡⟨ swap-right (U₀ + R₀) D₀ allDirectDeps ⟩
+          U₀ + R₀ + allDirectDeps + D₀    ≡⟨ cong (_+ D₀) (+-assoc U₀ R₀ allDirectDeps) ⟩
+          U₀ + (R₀ + allDirectDeps) + D₀  ≡⟨ cong (λ x → U₀ + x + D₀) combined-certs ⟩
+          U₀ + (R₂ + allWdrls) + D₀       ≡⟨ cong (_+ D₀) (sym (+-assoc U₀ R₂ allWdrls)) ⟩
+          U₀ + R₂ + allWdrls + D₀         ∎
 
       dc : DepositsChange
       dc = calculateDepositsChange (CertStateOf s) cs₁ cs₂
@@ -482,92 +485,6 @@ where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allD
                    (cong (U₂ +_) (utxo₁-tx-spend-eq valid refl subStep))
 
 
-      arithmetic-1 : ∀ a b c d → a + b + c + d ≡ a + c + d + b
-      arithmetic-1 a b c d = begin
-        a + b + c + d     ≡⟨ cong (_+ d) (+-assoc a b c) ⟩
-        a + (b + c) + d   ≡⟨ cong (λ x → a + x + d) (+-comm b c) ⟩
-        a + (c + b) + d   ≡⟨ cong (_+ d) (sym (+-assoc a c b)) ⟩
-        a + c + b + d     ≡⟨ +-assoc (a + c) b d ⟩
-        a + c + (b + d)   ≡⟨ cong ((a + c) +_) (+-comm b d) ⟩
-        a + c + (d + b)   ≡⟨ sym (+-assoc (a + c) d b) ⟩
-        a + c + d + b     ∎
-
-      arithmetic-2 : ∀ a b c d →  a + b + c + d ≡ a + (d + b) + c
-      arithmetic-2 a b c d = begin
-        a + b + c + d       ≡⟨ +-assoc (a + b) c d ⟩
-        a + b + (c + d)     ≡⟨ cong (a + b +_) (+-comm c d) ⟩
-        a + b + (d + c)     ≡⟨ sym (+-assoc (a + b) d c) ⟩
-        a + b + d + c       ≡⟨ cong (_+ c) (+-assoc a b d) ⟩
-        a + (b + d) + c     ≡⟨ cong (λ x → a + x + c) (+-comm b d) ⟩
-        a + (d + b) + c     ∎
-
-
-      arithmetic-3 : ∀ a b c {d}{e}{f}{g}
-        → a + b + c + d + e + f + g ≡ a + e + b + (c + f + g) + d
-      arithmetic-3 a b c {d}{e}{f}{g} = begin
-        a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + f + g) (swap-right (a + b + c) d e) ⟩
-        a + b + c + e + d + f + g  ≡⟨ cong (_+ g) (swap-right (a + b + c + e) d f) ⟩
-        a + b + c + e + f + d + g  ≡⟨ swap-right (a + b + c + e + f) d g ⟩
-        a + b + c + e + f + g + d  ≡⟨ cong (λ x → x + f + g + d) (swap-right (a + b) c e) ⟩
-        a + b + e + c + f + g + d  ≡⟨ cong (λ x → x + c + f + g + d) (swap-right a b e) ⟩
-        a + e + b + c + f + g + d  ≡⟨ cong (_+ d) reassoc-middle ⟩
-        (a + e) + b + (c + f + g) + d  ∎
-        where
-        reassoc-middle : a + e + b + c + f + g ≡ (a + e) + b + (c + f + g)
-        reassoc-middle = trans (+-assoc (a + e + b + c) f g)
-                               (trans (+-assoc (a + e + b) c (f + g))
-                                      (cong (a + e + b +_) (sym (+-assoc c f g))))
-
-      arithmetic-4 : ∀ a b c {d}{e}{f}{g}
-        → a + b + c + (d + e + f) + g ≡ a + (g + c + b + e + f) + d
-      arithmetic-4 a b c {d}{e}{f}{g} = begin
-        a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
-        a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
-        a + b + c + d + e + f + g    ≡⟨ swap-right (a + b + c + d + e) f g ⟩
-        a + b + c + d + e + g + f    ≡⟨ cong (_+ f) (swap-right (a + b + c + d) e g) ⟩
-        a + b + c + d + g + e + f    ≡⟨ cong (λ x → x + e + f) (swap-right (a + b + c) d g) ⟩
-        a + b + c + g + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + b) c g) ⟩
-        a + b + g + c + d + e + f    ≡⟨ cong (λ x → x + c + d + e + f) (swap-right a b g) ⟩
-        a + g + b + c + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + g) b c) ⟩
-        a + g + c + b + d + e + f    ≡⟨ cong (_+ f) (swap-right (a + g + c + b) d e) ⟩
-        a + g + c + b + e + d + f    ≡⟨ swap-right (a + g + c + b + e) d f ⟩
-        a + g + c + b + e + f + d    ≡⟨ cong (λ x → x + b + e + f + d) (+-assoc a g c) ⟩
-        a + (g + c) + b + e + f + d  ≡⟨ cong (λ x → x + e + f + d) (+-assoc a (g + c) b) ⟩
-        a + (g + c + b) + e + f + d  ≡⟨ cong (λ x → x + f + d) (+-assoc a (g + c + b) e) ⟩
-        a + (g + c + b + e) + f + d  ≡⟨ cong (_+ d) (+-assoc a (g + c + b + e) f) ⟩
-        a + (g + c + b + e + f) + d  ∎
-
-      arithmetic-5 : ∀ a b c {d}{e}{f}{g}{h}{i}
-        → a + (b + c + d + e + f + g + h) + i
-        ≡ a +  b + c + d + e + f + g + h  + i
-      arithmetic-5 a b c {d}{e}{f}{g}{h}{i} = cong (_+ i) $
-        begin
-        a + (b + c + d + e + f + g + h)  ≡˘⟨ +-assoc a _ h ⟩
-        a + (b + c + d + e + f + g) + h  ≡˘⟨ cong (_+ h) (+-assoc a _ g) ⟩
-        a + (b + c + d + e + f) + g + h  ≡˘⟨ cong (λ x → x + g + h) (+-assoc a _ f) ⟩
-        a + (b + c + d + e) + f + g + h  ≡˘⟨ cong (λ x → x + f + g + h) (+-assoc a _ e) ⟩
-        a + (b + c + d) + e + f + g + h  ≡˘⟨ cong (λ x → x + e + f + g + h) (+-assoc a _ d) ⟩
-        a + (b + c) + d + e + f + g + h  ≡˘⟨ cong (λ x → x + d + e + f + g + h) (+-assoc a b c) ⟩
-        a + b + c + d + e + f + g + h    ∎
-
-      arithmetic-6 : ∀ a b c {d}{e}{f}{g}
-        → a + b + c + d + e + f + g ≡ a + c + g + b + d + e + f
-      arithmetic-6 a b c {d}{e}{f}{g} = begin
-        a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + d + e + f + g) (swap-right a b c) ⟩
-        a + c + b + d + e + f + g  ≡⟨ swap-right (a + c + b + d + e) f g ⟩
-        a + c + b + d + e + g + f  ≡⟨ cong (_+ f) (swap-right (a + c + b + d) e g) ⟩
-        a + c + b + d + g + e + f  ≡⟨ cong (λ x → x + e + f) (swap-right (a + c + b) d g) ⟩
-        a + c + b + g + d + e + f  ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + c) b g) ⟩
-        a + c + g + b + d + e + f  ∎
-
-      arithmetic-7 : ∀ a b c {d}{e}{f}{g}
-        → a + b + c + (d + e + f + g) ≡ a + b + c + d + e + f + g
-      arithmetic-7 a b c {d}{e}{f}{g} = begin
-        a + b + c + (d + e + f + g)  ≡˘⟨ +-assoc (a + b + c) (d + e + f) g ⟩
-        a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
-        a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
-        a + b + c + d + e + f + g    ∎
-
       Ctop Csub : Coin
       Ctop = cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx)
       Csub = sum (map (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx)) (SubTransactionsOf tx))
@@ -586,15 +503,15 @@ where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allD
               + allDirectDeps + Psub + posPart dct + posPart dcs
       bat' =
         begin
-          Ctop + W + Csub + negPart dct + negPart dcs
+          Ctop + allWdrls + Csub + negPart dct + negPart dcs
             ≡⟨⟩
-          Ctop + (Wtop + Wsub) + Csub + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + Csub + negPart dct + negPart dcs) (sym (+-assoc Ctop Wtop Wsub)) ⟩
-          Ctop + Wtop + Wsub + Csub + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (swap-right (Ctop + Wtop) Wsub Csub) ⟩
-          Ctop + Wtop + Csub + Wsub + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (+-assoc (Ctop + Wtop) Csub Wsub) ⟩
-          Ctop + Wtop + (Csub + Wsub) + negPart dct + negPart dcs
+          Ctop + (Wtop + subWdrlsCoin) + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + Csub + negPart dct + negPart dcs) (sym (+-assoc Ctop Wtop subWdrlsCoin)) ⟩
+          Ctop + Wtop + subWdrlsCoin + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (swap-right (Ctop + Wtop) subWdrlsCoin Csub) ⟩
+          Ctop + Wtop + Csub + subWdrlsCoin + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (+-assoc (Ctop + Wtop) Csub subWdrlsCoin) ⟩
+          Ctop + Wtop + (Csub + subWdrlsCoin) + negPart dct + negPart dcs
             ≡˘⟨ cong  (λ x → Ctop + Wtop + x + negPart dct + negPart dcs)
                       (sum-map-+  (λ stx → cbalance (UTxOOf s ∣ SpendInputsOf stx))
                                   wdrwl (SubTransactionsOf tx)) ⟩
@@ -606,71 +523,133 @@ where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allD
             ≡⟨ cong  (λ x → O + F + DN + DDtop + posPart dct + x + posPart dcs)
                      (sum-map-+ (λ stx → cbalance (outs stx) + DonationsOf stx)
                                 (λ stx → getCoin (DirectDepositsOf stx)) (SubTransactionsOf tx)) ⟩
-          O + F + DN + DDtop + posPart dct + (Psub + DDsub) + posPart dcs
+          O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
             ≡⟨ reshuffle-to-DD ⟩
-          O + F + DN + (DDtop + DDsub) + Psub + posPart dct + posPart dcs
-            ≡⟨ cong (λ x → O + F + DN + x + Psub + posPart dct + posPart dcs) (sym DD-split) ⟩
-          O + F + DN + DD + Psub + posPart dct + posPart dcs
+          O + F + DN + allDirectDeps + Psub + posPart dct + posPart dcs
             ∎
           where
           O = cbalance (outs tx)
           F = TxFeesOf tx
           DN = DonationsOf tx
-          DD = allDirectDeps
           DDtop = getCoin (DirectDepositsOf tx)
-          DDsub = sum (map (λ stx → getCoin (DirectDepositsOf stx)) (SubTransactionsOf tx))
-          W = allWdrls
           Wtop = getCoin (WithdrawalsOf tx)
-          Wsub = sum (map wdrwl (SubTransactionsOf tx))
           CsubW = sum (map (λ stx → cbalance (UTxOOf s ∣ SpendInputsOf stx) + getCoin (WithdrawalsOf stx)) (SubTransactionsOf tx))
-          reshuffle-to-DD : O + F + DN + DDtop + posPart dct + (Psub + DDsub) + posPart dcs
-                          ≡ O + F + DN + (DDtop + DDsub) + Psub + posPart dct + posPart dcs
+          reshuffle-to-DD : O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
+                          ≡ O + F + DN + (DDtop + subDirectDepsCoin) + Psub + posPart dct + posPart dcs
           reshuffle-to-DD = begin
-            O + F + DN + DDtop + (posPart dct) + (Psub + DDsub) + (posPart dcs)
-              ≡⟨ cong (_+ (posPart dcs)) (sym (+-assoc (O + F + DN + DDtop + (posPart dct)) Psub DDsub)) ⟩
-            O + F + DN + DDtop + (posPart dct) + Psub + DDsub + (posPart dcs)
-              ≡⟨ cong (_+ (posPart dcs)) (swap-right (O + F + DN + DDtop + (posPart dct)) Psub DDsub) ⟩
-            O + F + DN + DDtop + (posPart dct) + DDsub + Psub + (posPart dcs)
-              ≡⟨ cong (λ x → x + Psub + (posPart dcs)) (swap-right (O + F + DN + DDtop) (posPart dct) DDsub) ⟩
-            O + F + DN + DDtop + DDsub + (posPart dct) + Psub + (posPart dcs)
-              ≡⟨ cong (_+ (posPart dcs)) (swap-right (O + F + DN + DDtop + DDsub) (posPart dct) Psub) ⟩
-            O + F + DN + DDtop + DDsub + Psub + (posPart dct) + (posPart dcs)
-              ≡⟨ cong (λ x → x + Psub + (posPart dct) + (posPart dcs)) (+-assoc (O + F + DN) DDtop DDsub) ⟩
-            O + F + DN + (DDtop + DDsub) + Psub + (posPart dct) + (posPart dcs)
+            O + F + DN + DDtop + (posPart dct) + (Psub + subDirectDepsCoin) + (posPart dcs)
+              ≡⟨ cong (_+ (posPart dcs)) (sym (+-assoc (O + F + DN + DDtop + (posPart dct)) Psub subDirectDepsCoin)) ⟩
+            O + F + DN + DDtop + (posPart dct) + Psub + subDirectDepsCoin + (posPart dcs)
+              ≡⟨ cong (_+ (posPart dcs)) (swap-right (O + F + DN + DDtop + (posPart dct)) Psub subDirectDepsCoin) ⟩
+            O + F + DN + DDtop + (posPart dct) + subDirectDepsCoin + Psub + (posPart dcs)
+              ≡⟨ cong (λ x → x + Psub + (posPart dcs)) (swap-right (O + F + DN + DDtop) (posPart dct) subDirectDepsCoin) ⟩
+            O + F + DN + DDtop + subDirectDepsCoin + (posPart dct) + Psub + (posPart dcs)
+              ≡⟨ cong (_+ (posPart dcs)) (swap-right (O + F + DN + DDtop + subDirectDepsCoin) (posPart dct) Psub) ⟩
+            O + F + DN + DDtop + subDirectDepsCoin + Psub + (posPart dct) + (posPart dcs)
+              ≡⟨ cong (λ x → x + Psub + (posPart dct) + (posPart dcs)) (+-assoc (O + F + DN) DDtop subDirectDepsCoin) ⟩
+            O + F + DN + (DDtop + subDirectDepsCoin) + Psub + (posPart dct) + (posPart dcs)
               ∎
 
       -- === Main chain ============================================================
-      LHS+E≡RHS+E : (U₀ + allWdrls + D₀) + E ≡ (U₂ + allDirectDeps + D₂) + E
+      LHS+E≡RHS+E : U₀ + allWdrls + D₀ + E ≡ U₂ + allDirectDeps + D₂ + E
       LHS+E≡RHS+E = begin
         U₀ + allWdrls + D₀ + E
           ≡⟨ refl ⟩
         U₀ + allWdrls + D₀ + (Ctop + Psub + posPart dct + posPart dcs)
-          ≡⟨ arithmetic-7 U₀ allWdrls D₀ ⟩
+          ≡⟨ arithmetic-1 U₀ allWdrls D₀ ⟩
         U₀ + allWdrls + D₀ + Ctop + Psub + posPart dct + posPart dcs
-          ≡⟨ arithmetic-3 U₀ allWdrls D₀ ⟩
+          ≡⟨ arithmetic-2 U₀ allWdrls D₀ ⟩
         U₀ + Psub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
-          ≡⟨ cong (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
-                  (subst  (λ u → U₀ + Psub ≡ U₁ + sum (map (λ stx → cbalance (u ∣ SpendInputsOf stx)) (SubTransactionsOf tx)))
-                         (refl {x = UTxOOf s}) (SUBLEDGERS-utxo-coin valid subStep)) ⟩
+          ≡⟨ cong  (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
+                   (subst  (λ u → U₀ + Psub ≡ U₁ + sum (map (λ stx → cbalance (u ∣ SpendInputsOf stx)) (SubTransactionsOf tx)))
+                           (refl {x = UTxOOf s})
+                           (SUBLEDGERS-utxo-coin valid subStep)) ⟩
         U₁ + Csub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
           ≡⟨ cong (λ x → (U₁ + Csub) + allWdrls + x + Ctop) posneg ⟩
         U₁ + Csub + allWdrls + (D₂ + negPart dct + negPart dcs) + Ctop
-          ≡⟨ arithmetic-4 U₁ Csub allWdrls ⟩
+          ≡⟨ arithmetic-3 U₁ Csub allWdrls ⟩
         U₁ + (Ctop + allWdrls + Csub + negPart dct + negPart dcs) + D₂
           ≡⟨ cong (λ x → U₁ + x + D₂) bat' ⟩
         U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs) + D₂
-          ≡⟨ arithmetic-5 U₁ (cbalance (outs tx)) (TxFeesOf tx) ⟩
+          ≡⟨ arithmetic-4 U₁ (cbalance (outs tx)) (TxFeesOf tx) ⟩
         U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs + D₂
           ≡⟨ cong (λ x → x + allDirectDeps + Psub + posPart dct + posPart dcs + D₂) mech ⟩
         U₂ + Ctop + allDirectDeps + Psub + posPart dct + posPart dcs + D₂
-          ≡⟨ arithmetic-6 U₂ Ctop allDirectDeps ⟩
+          ≡⟨ arithmetic-5 U₂ Ctop allDirectDeps ⟩
         U₂ + allDirectDeps + D₂ + Ctop + Psub + posPart dct + posPart dcs
-          ≡˘⟨ arithmetic-7 U₂ allDirectDeps D₂ ⟩
+          ≡˘⟨ arithmetic-1 U₂ allDirectDeps D₂ ⟩
         U₂ + allDirectDeps + D₂ + E
           ∎
+        where
+        arithmetic-1 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + (d + e + f + g) ≡ a + b + c + d + e + f + g
+        arithmetic-1 a b c {d}{e}{f}{g} = begin
+          a + b + c + (d + e + f + g)  ≡˘⟨ +-assoc (a + b + c) (d + e + f) g ⟩
+          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+          a + b + c + d + e + f + g    ∎
+
+        arithmetic-2 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + d + e + f + g ≡ a + e + b + (c + f + g) + d
+        arithmetic-2 a b c {d}{e}{f}{g} = begin
+          a + b + c + d + e + f + g    ≡⟨ cong (λ x → x + f + g) (swap-right (a + b + c) d e) ⟩
+          a + b + c + e + d + f + g    ≡⟨ cong (_+ g) (swap-right (a + b + c + e) d f) ⟩
+          a + b + c + e + f + d + g    ≡⟨ swap-right (a + b + c + e + f) d g ⟩
+          a + b + c + e + f + g + d    ≡⟨ cong (λ x → x + f + g + d) (swap-right (a + b) c e) ⟩
+          a + b + e + c + f + g + d    ≡⟨ cong (λ x → x + c + f + g + d) (swap-right a b e) ⟩
+          a + e + b + c + f + g + d    ≡⟨ cong (_+ d) reassoc-middle ⟩
+          a + e + b + (c + f + g) + d  ∎
+          where
+          reassoc-middle : a + e + b + c + f + g ≡ a + e + b + (c + f + g)
+          reassoc-middle = trans (+-assoc (a + e + b + c) f g)
+                                 (trans (+-assoc (a + e + b) c (f + g))
+                                        (cong (a + e + b +_) (sym (+-assoc c f g))))
+
+        arithmetic-3 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + (d + e + f) + g ≡ a + (g + c + b + e + f) + d
+        arithmetic-3 a b c {d}{e}{f}{g} = begin
+          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+          a + b + c + d + e + f + g    ≡⟨ swap-right (a + b + c + d + e) f g ⟩
+          a + b + c + d + e + g + f    ≡⟨ cong (_+ f) (swap-right (a + b + c + d) e g) ⟩
+          a + b + c + d + g + e + f    ≡⟨ cong (λ x → x + e + f) (swap-right (a + b + c) d g) ⟩
+          a + b + c + g + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + b) c g) ⟩
+          a + b + g + c + d + e + f    ≡⟨ cong (λ x → x + c + d + e + f) (swap-right a b g) ⟩
+          a + g + b + c + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + g) b c) ⟩
+          a + g + c + b + d + e + f    ≡⟨ cong (_+ f) (swap-right (a + g + c + b) d e) ⟩
+          a + g + c + b + e + d + f    ≡⟨ swap-right (a + g + c + b + e) d f ⟩
+          a + g + c + b + e + f + d    ≡⟨ cong (λ x → x + b + e + f + d) (+-assoc a g c) ⟩
+          a + (g + c) + b + e + f + d  ≡⟨ cong (λ x → x + e + f + d) (+-assoc a (g + c) b) ⟩
+          a + (g + c + b) + e + f + d  ≡⟨ cong (λ x → x + f + d) (+-assoc a (g + c + b) e) ⟩
+          a + (g + c + b + e) + f + d  ≡⟨ cong (_+ d) (+-assoc a (g + c + b + e) f) ⟩
+          a + (g + c + b + e + f) + d  ∎
+
+        arithmetic-4 : ∀ a b c {d}{e}{f}{g}{h}{i}
+          → a + (b + c + d + e + f + g + h) + i
+          ≡ a +  b + c + d + e + f + g + h  + i
+        arithmetic-4 a b c {d}{e}{f}{g}{h}{i} = cong (_+ i) $
+          begin
+          a + (b + c + d + e + f + g + h)  ≡˘⟨ +-assoc a _ h ⟩
+          a + (b + c + d + e + f + g) + h  ≡˘⟨ cong (_+ h) (+-assoc a _ g) ⟩
+          a + (b + c + d + e + f) + g + h  ≡˘⟨ cong (λ x → x + g + h) (+-assoc a _ f) ⟩
+          a + (b + c + d + e) + f + g + h  ≡˘⟨ cong (λ x → x + f + g + h) (+-assoc a _ e) ⟩
+          a + (b + c + d) + e + f + g + h  ≡˘⟨ cong (λ x → x + e + f + g + h) (+-assoc a _ d) ⟩
+          a + (b + c) + d + e + f + g + h  ≡˘⟨ cong (λ x → x + d + e + f + g + h) (+-assoc a b c) ⟩
+          a + b + c + d + e + f + g + h    ∎
+
+        arithmetic-5 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + d + e + f + g ≡ a + c + g + b + d + e + f
+        arithmetic-5 a b c {d}{e}{f}{g} = begin
+          a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + d + e + f + g) (swap-right a b c) ⟩
+          a + c + b + d + e + f + g  ≡⟨ swap-right (a + c + b + d + e) f g ⟩
+          a + c + b + d + e + g + f  ≡⟨ cong (_+ f) (swap-right (a + c + b + d) e g) ⟩
+          a + c + b + d + g + e + f  ≡⟨ cong (λ x → x + e + f) (swap-right (a + c + b) d g) ⟩
+          a + c + b + g + d + e + f  ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + c) b g) ⟩
+          a + c + g + b + d + e + f  ∎
 
       -- deposit accounting + batch UTxO combined
-      step-iii-iv : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + R₂
-      step-iii-iv = cong  (_+ R₂)
-                          (+-cancelʳ-≡ E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂) LHS+E≡RHS+E)
+      step-ii : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + R₂
+      step-ii = cong  (_+ R₂)
+                      (+-cancelʳ-≡ E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂) LHS+E≡RHS+E)
+
 ```

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -1,0 +1,673 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+---
+
+# LEDGER: Preservation of Value {#sec:ledger-pov}
+
+This module states the preservation-of-value property for the Dijkstra
+`LEDGER`{.AgdaDatatype} rule, updated for CIP-159 (direct deposits and
+partial withdrawals).
+
+## Key Differences from Conway
+
+1. **`UTxOState` has 3 fields** (no deposits) — simpler `HasCoin-UTxOState`.
+2. **`LEDGER-V` applies `applyDirectDeposits`** after all sub-rules, creating
+   `certStateFinal` with increased rewards.  Direct deposit value cancels
+   between `producedBatch` (UTxO side) and `certStateFinal` (CertState side).
+3. **Batch structure**: `SUBLEDGERS` processes sub-transactions before top-level
+   `CERTS`/`GOVS`/`UTXOW`.  Individual sub-transactions do NOT independently
+   preserve total value — only the batch-level `consumedBatch ≡ producedBatch` does.
+4. **Partial withdrawals**: `CERTS-pov` uses the new `applyWithdrawals` semantics.
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Transaction using (TransactionStructure)
+open import Ledger.Dijkstra.Specification.Abstract using (AbstractFunctions)
+
+module Ledger.Dijkstra.Specification.Ledger.Properties.PoV
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs) (open AbstractFunctions abs)
+  where
+
+open import Ledger.Prelude
+
+open import Axiom.Set.Properties th
+
+open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Certs.Properties.PoV govStructure
+open import Ledger.Dijkstra.Specification.Certs.Properties.PoVLemmas govStructure
+open import Ledger.Dijkstra.Specification.Gov govStructure
+open import Ledger.Dijkstra.Specification.Ledger txs abs
+open import Ledger.Dijkstra.Specification.Utxo txs abs
+open import Ledger.Dijkstra.Specification.Utxo.Properties.PoV txs abs
+open import Ledger.Dijkstra.Specification.Utxow txs abs
+open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
+
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
+open import Data.Nat.Properties
+  using (+-0-monoid; +-identityʳ; +-comm; +-assoc; +-cancelʳ-≡)
+
+
+open RewardAddress
+```
+-->
+
+## Key Lemma: `applyDirectDeposits` increases `getCoin` by deposit total
+
+`applyDirectDeposits dd ds = record ds { rewards = RewardsOf ds ∪⁺ dd }`,
+and `getCoin` for `CertState` is `rewardsBalance ∘ DStateOf = ∑[ x ← rewards ] x`
+
+
+## Proof Architecture
+
+The Dijkstra `LEDGER-pov`{.AgdaFunction} proof does NOT decompose into independent
+`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces, because:
+
+1.  Individual `SUBUTXO` rules have no balance equation — only the
+    *batch-level* `consumedBatch ≡ producedBatch` (in `UTXO`) constrains
+    the total.
+
+2.  Sub-transactions may individually transfer value between UTxO and CertState (via
+    sub-withdrawals, sub-deposits, sub-direct-deposits) without local balancing.
+
+Instead, the proof reasons about the **entire** `LEDGER-V`{.AgdaInductiveConstructor}
+step at once.
+
+### <span class="AgdaInductiveConstructor">LEDGER-V</span> Proof Outline
+
+Given
+`s  = ⟦ utxoSt₀ , govSt₀ , certState₀ ⟧`
+and
+`s' = ⟦ utxoSt₂ , govSt₂' , certStateFinal ⟧`,
+where
+`certStateFinal` has `rewards = rewards₂ ∪⁺ allDirectDeposits tx`,
+we need:
+
+`getCoin utxoSt₀ + rewardsBalance₀ + deposits₀`
+`≡ getCoin utxoSt₂ + rewardsBalance_final + deposits₂`
+
+The key equations are:
+
+1.  `consumedBatch ≡ producedBatch`  (coin projection, from `UTXO`{.AgdaDatatype} premise).
+
+    This gives (using `coin∘inject = id`, `coin mint = 0`):
+
+    `Σ cbalance(utxo₀ ∣ SpendInputs_i) + Σ wdrls_i + depositRefunds`
+    `= Σ cbalance(outs_i) + txFee + Σ directDeps_i + Σ donations_i + newDeposits`
+
+    where the sums range over all transactions in the batch (top + sub).
+
+2.  `CERTS-pov` (combined sub + top level):
+
+    `rewardsBalance₀ = rewardsBalance₂ + Σ wdrls_i`
+
+    This requires composing sub-level `CERTS-pov` for each subtransaction
+    with top-level `CERTS-pov`.
+
+3.  `depositsChange` property:
+
+    `deposits₂ = deposits₀ + newDeposits - depositRefunds`
+
+    This follows from the definition of `calculateDepositsChange` and
+    the posPart/negPart identity.
+
+4.  `applyDirectDeposits`:
+
+    `rewardsBalance_final = rewardsBalance₂ + Σ directDeps_i`
+
+5.  Mechanical UTxO tracking:
+
+    `getCoin utxoSt₂ = cbalance(utxo₂) + fees₂ + donations₂`
+
+    where `utxo₂`, `fees₂`, `donations₂` are determined by the
+    `SUBLEDGERS` + `UTXO` mechanical state changes.
+
+Combining:
+
+From (1) and (3), adding the equations and using `+-cancelʳ-≡` to
+eliminate `newDeposits + depositRefunds` from both sides:
+
++  `getCoin utxoSt₀ + Σ wdrls_i + coinFromDeposits(cs₀)`
+   `= getCoin utxoSt₂ + Σ directDeps_i + coinFromDeposits(cs₂)`
+
+Then:
+
++  `getCoin utxoSt₀ + rewardsBalance₀ + coinFromDeposits(cs₀)`
+   `= getCoin utxoSt₀ + (rewardsBalance₂ + Σ wdrls_i) + coinFromDeposits(cs₀)` (by 2)
+   `= getCoin utxoSt₂ + Σ directDeps_i + coinFromDeposits(cs₂) + rewardsBalance₂` (by combined 1+3)
+   `= getCoin utxoSt₂ + rewardsBalance_final + coinFromDeposits(cs₂)` (by 4)
+   `= getCoin utxoSt₂ + getCoin certStateFinal + coinFromDeposits(cs₂)` (since deposits unchanged by applyDirectDeposits)
+
+
+
+### `LEDGER-I` proof outline
+
+`certState` and `govSt` are unchanged.
+
+`SUBLEDGERS` is a no-op (`isValid ≡ false` ⟹ each `SUBLEDGER-I` preserves state).
+
+The UTXOW/UTXO step in the invalid case:
+
+`utxoSt₁ = ⟦ utxo₀ ∣ collateral ᶜ , fees + cbalance(utxo₀ ∣ collateral) , deposits₀ , donations₀ ⟧`
+
+(Actually in Dijkstra, deposits aren't in UTxOState, and the invalid case has
+`depositsChange = ⟦ 0ℤ , 0ℤ ⟧`, so the UTxO changes are just collateral collection.)
+
+`getCoin utxoSt₁ = cbalance(utxo₀ ∣ coll ᶜ) + (fees + cbalance(utxo₀ ∣ coll)) + donations₀`
+
+`= cbalance utxo₀ + fees + donations₀`   [by split-balance]
+
+`= getCoin utxoSt₀`
+
+So
+
+`getCoin s' = getCoin utxoSt₁ + getCoin certState₀ + coinFromDeposits certState₀`
+
+`= getCoin utxoSt₀ + getCoin certState₀ + coinFromDeposits certState₀`
+
+`= getCoin s`
+
+
+<!--
+```agda
+
+module _
+  (tx : TopLevelTx) (let open Tx tx)
+
+  -- Shared assumptions (same pattern as Conway)
+  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+
+  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
+  ( balance-∪ : ∀ {u u' : UTxO} → disjoint (dom u) (dom u') → cbalance (u ∪ˡ u') ≡ cbalance u + cbalance u' )
+
+  ( split-balance : ∀ (u : UTxO) (keys : ℙ TxIn) → cbalance u ≡ cbalance (u ∣ keys ᶜ) + cbalance (u ∣ keys) )
+
+  -- Per-step SUBUTXOW coin equation.  Assumed for now; a local proof
+  -- would require, in addition to `balance-∪` and `split-balance`, a
+  -- batch-wide "spend inputs preserved" invariant (the running UTxO
+  -- agrees with the snapshot on every sub-tx's spend inputs) and
+  -- freshness of each sub-tx's TxId relative to the running UTxO.
+  -- See the follow-up PR plan.
+  ( subutxow-step-coin : ∀ {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
+      → IsTopLevelValidFlagOf Γ ≡ true → Γ ⊢ s₀ ⇀⦇ stx ,SUBUTXOW⦈ s₁
+      → getCoin s₀ + cbalance (outs stx) + DonationsOf stx ≡ getCoin s₁ + cbalance (UTxOOf Γ ∣ SpendInputsOf stx) )
+
+  -- Sub-lemmas (assumptions for now) --
+
+  -- CIP-159–specific assumption: ∪⁺ adds getCoin values
+  ( applyDirectDeposits-rewardsBalance : (dd : DirectDeposits) (ds : DState)
+      → rewardsBalance (applyDirectDeposits dd ds) ≡ rewardsBalance ds + getCoin dd )
+
+  -- Assumptions required to open `UTXOW-PoV` (Utxow-level properties):
+  ( noMintTx : coin (MintedValueOf tx) ≡ 0 )
+  ( noMintSubTx : noMintingSubTxs tx )
+  ( outs-disjoint : ∀ {u : UTxO} → TxIdOf tx ∉ mapˢ proj₁ (dom u)
+      → disjoint (dom (u ∣ SpendInputsOf tx ᶜ)) (dom (outs tx)) )
+
+  -- Batch-wide invariants on the post-SUBLEDGERS UTxO state.  Both follow
+  -- from batch-wide input disjointness and TxId freshness, which the outer
+  -- UTXO rule establishes at the batch level but doesn't expose per-step.
+  -- Deferred to the follow-up PR on general Dijkstra properties.
+  ( utxo₁-tx-spend-eq : {subΓ : SubLedgerEnv} {s : LedgerState} {utxoSt₁ : UTxOState}
+      {govSt₁ : GovState} {certState₁ : CertState}
+      → SubLedgerEnv.isTopLevelValid subΓ ≡ true
+      → SubLedgerEnv.utxo₀ subΓ ≡ UTxOOf (UTxOStateOf s)
+      → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
+      → cbalance (UTxOOf utxoSt₁ ∣ SpendInputsOf tx) ≡ cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx) )
+
+  ( fresh-top-tx-id : {subΓ : SubLedgerEnv} {s : LedgerState} {utxoSt₁ : UTxOState}
+        {govSt₁ : GovState} {certState₁ : CertState}
+      → SubLedgerEnv.isTopLevelValid subΓ ≡ true
+      → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
+      → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
+
+  -- Deposit-change posPart/negPart identity.  Provable from the definition
+  -- of `calculateDepositsChange` and the standard
+  -- `y + posPart (x - y) ≡ x + negPart (x - y)` lemma (per-component, then
+  -- composed across top and sub).  Deferred to the follow-up PR.
+  ( posNeg-deposits : (cs₀ cs₁ cs₂ : CertState)
+      → let dc = calculateDepositsChange cs₀ cs₁ cs₂ in
+        coinFromDeposits cs₀ + posPart (DepositsChangeTopOf dc) + posPart (DepositsChangeSubOf dc)
+        ≡ coinFromDeposits cs₂ + negPart (DepositsChangeTopOf dc) + negPart (DepositsChangeSubOf dc) )
+  -- Aggregation identity for `allDirectDeposits`.  Provable from the
+  -- definition of `allDirectDeposits` once we confirm it sums top-level
+  -- and sub-level direct deposits disjointly.  Deferred.
+  ( DD-split :
+      getCoin (allDirectDeposits tx) ≡ getCoin (DirectDepositsOf tx)
+                                       + sum (map (λ stx → getCoin (DirectDepositsOf stx)) (SubTransactionsOf tx)) )
+  -- Sum distribution (standard list algebra):
+  ( sum-map-+ : ∀ {A : Type} (f g : A → ℕ) (xs : List A)
+      → sum (map (λ x → f x + g x) xs) ≡ sum (map f xs) + sum (map g xs) )
+
+  where
+  open Certs-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+  -- Import the utxow-level properties (utxow-pov-invalid, UTXOW-V-mechanical,
+  -- UTXOW-batch-balance-coin) from `Utxow.Properties.PoV`.  The `λ {u}{u'} →`
+  -- η-wrapper is needed for the same Agda eta-expansion reason as in
+  -- `Utxow.Properties.PoV` itself.
+  open UTXOW-PoV tx (λ {u} {u'} → balance-∪ {u} {u'}) split-balance noMintTx noMintSubTx (λ {u} → outs-disjoint {u})
+  open ≡-Reasoning
+
+  wdrwl : SubLevelTx → Coin
+  wdrwl = getCoin ∘ WithdrawalsOf
+
+  SUBLEDGERS-utxo-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → getCoin (UTxOStateOf s₀) + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) stxs)
+      ≡ getCoin (UTxOStateOf s₁) + sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) stxs)
+
+  -- Base case: empty list.  `Id-nop` unifies s₀ ≡ s₁, and
+  -- `sum (map _ []) = 0` on both sides, giving `refl`.
+  SUBLEDGERS-utxo-coin isV (BS-base Id-nop) = refl
+  -- Inductive step: one SUBLEDGER step + rest.
+  -- SUBLEDGER-I is ruled out by `isV : isTopLevelValid ≡ true`.
+  -- In the SUBLEDGER-V case, combine the per-step SUBUTXOW balance
+  -- (via `subutxow-step-coin`) with the IH using a small +-monoid shuffle.
+  SUBLEDGERS-utxo-coin isV (BS-ind (SUBLEDGER-I (isI , _)) rest) = ⊥-elim (case trans (sym isV) isI of λ ())
+  SUBLEDGERS-utxo-coin {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , _ , _)) rest) =
+    begin
+      U₀ + (p-stx + p-sum)    ≡⟨ sym (+-assoc U₀ p-stx p-sum) ⟩
+      (U₀ + p-stx) + p-sum    ≡⟨ cong (_+ p-sum) step-P-C ⟩
+      (U₁ + c-stx) + p-sum    ≡⟨ +-assoc U₁ c-stx p-sum ⟩
+      U₁ + (c-stx + p-sum)    ≡⟨ cong (U₁ +_) (+-comm c-stx p-sum) ⟩
+      U₁ + (p-sum + c-stx)    ≡⟨ sym (+-assoc U₁ p-sum c-stx) ⟩
+      (U₁ + p-sum) + c-stx    ≡⟨ cong (_+ c-stx) ih ⟩
+      (Uₙ + c-sum) + c-stx    ≡⟨ +-assoc Uₙ c-sum c-stx ⟩
+      Uₙ + (c-sum + c-stx)    ≡⟨ cong (Uₙ +_) (+-comm c-sum c-stx) ⟩
+      Uₙ + (c-stx + c-sum)    ∎
+    where
+    -- Abbreviations for the three utxo-state coin totals.
+    U₀ U₁ Uₙ : Coin
+    U₀ = getCoin (UTxOStateOf s₀)
+    U₁ = getCoin (UTxOStateOf s₁)
+    Uₙ = getCoin (UTxOStateOf sₙ)
+
+    -- Per-element summands, split into "head" (stx) and "tail" (sigs).
+    p-stx c-stx p-sum c-sum : Coin
+    p-stx = cbalance (outs stx) + DonationsOf stx
+    c-stx = cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)
+    p-sum = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) sigs)
+    c-sum = sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) sigs)
+
+    -- Single-step coin equation from the SUBUTXOW step assumption.
+    step-eq : U₀ + cbalance (outs stx) + DonationsOf stx ≡ U₁ + c-stx
+    step-eq = subutxow-step-coin isV' subutxowStep
+
+    step-P-C : U₀ + p-stx ≡ U₁ + c-stx
+    step-P-C = trans (sym (+-assoc U₀ (cbalance (outs stx)) (DonationsOf stx))) step-eq
+
+    -- Inductive hypothesis for the tail `sigs`.
+    ih : U₁ + p-sum ≡ Uₙ + c-sum
+    ih = SUBLEDGERS-utxo-coin isV rest
+
+  SUBLEDGERS-certs-pov : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → getCoin (CertStateOf s₀)
+      ≡ getCoin (CertStateOf s₁) + sum (map wdrwl stxs)
+
+  -- Base case: empty list, getCoin cs₀ ≡ getCoin cs₀ + 0
+  SUBLEDGERS-certs-pov isV (BS-base Id-nop) = sym (+-identityʳ _)
+
+  -- Inductive step: one SUBLEDGER step + rest
+  SUBLEDGERS-certs-pov isV (BS-ind (SUBLEDGER-I (isI , _)) rest) = ⊥-elim (case trans (sym isV) isI of λ ())
+  SUBLEDGERS-certs-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , certsStep , govsStep)) rest) =
+      begin
+      getCoin (CertStateOf s₀)
+        ≡⟨ sub-certs ⟩
+      getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)
+        ≡⟨ cong (_+ getCoin (WithdrawalsOf stx)) ih ⟩
+      (getCoin (CertStateOf sₙ) + sum (map wdrwl sigs)) + getCoin (WithdrawalsOf stx)
+        ≡⟨ +-assoc (getCoin (CertStateOf sₙ)) _ _ ⟩
+      getCoin (CertStateOf sₙ) + (sum (map wdrwl sigs) + getCoin (WithdrawalsOf stx))
+        ≡⟨ cong (getCoin (CertStateOf sₙ) +_) (+-comm _ (getCoin (WithdrawalsOf stx))) ⟩
+      getCoin (CertStateOf sₙ) + (getCoin (WithdrawalsOf stx) + sum (map wdrwl sigs))
+        ∎
+    where
+    extract-subutxo-netId : ∀ {Γ' s₀' s₁'}
+      → Γ' ⊢ s₀' ⇀⦇ stx ,SUBUTXOW⦈ s₁'
+      → ∀[ a ∈ dom (WithdrawalsOf stx) ] NetworkIdOf a ≡ NetworkId
+    extract-subutxo-netId
+      (SUBUTXOW ( _ , _ , _ , _ , _ , _ , _ , _ , _ , _
+                , SUBUTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
+
+    wdrl-netId : ∀[ a ∈ dom (WithdrawalsOf stx) ] NetworkIdOf a ≡ NetworkId
+    wdrl-netId = extract-subutxo-netId subutxowStep -- extract from premise 11
+
+    -- Sub-level CERTS-pov
+    sub-certs :  getCoin (CertStateOf s₀)
+                 ≡ getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)
+    sub-certs = CERTS-pov wdrl-netId certsStep
+
+    -- IH
+    ih :  getCoin (CertStateOf s₁) ≡ getCoin (CertStateOf sₙ) + sum (map wdrwl sigs)
+    ih = SUBLEDGERS-certs-pov isV rest
+
+```
+-->
+
+
+## LEDGER Preservation of Value
+
+```agda
+  LEDGER-pov : {Γ : LedgerEnv} {s s' : LedgerState} → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
+```
+
+### LEDGER-I case (invalid transaction)
+
+This follows the Conway pattern with `certState' ≡ certState₀`.
+`certState` and `govSt` are unchanged and `applyDirectDeposits` is not applied.
+Only the `UTXOW`{.AgdaDatatype} step matters and it preserves `getCoin utxoSt`.
+
+```agda
+  LEDGER-pov {Γ} {s} (LEDGER-I (invalid , subStep , utxoStep)) =
+    cong (λ u → u + getCoin (CertStateOf s) + coinFromDeposits (CertStateOf s))
+         (utxow-pov-invalid utxoStep invalid)
+```
+
+### LEDGER-V (valid transaction)
+
+The `LEDGER-V` rule produces
+
+`s' = ⟦ utxoSt₂ , rmOrphanDRepVotes certStateFinal govState₂ , certStateFinal ⟧`
+
+where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allDirectDeposits tx) (DStateOf certState₂) }`.
+
+```agda
+  LEDGER-pov {Γ} {s}
+    (LEDGER-V {certState₁ = cs₁} {cs₂} {govSt₁} {govSt₂}
+              {utxoState₁ = us₁} {utxoState₂ = us₂}
+              (valid , subStep , certStep , govStep , utxoStep)) =
+    begin
+      U₀ + R₀ + D₀                      ≡⟨ step-i ⟩
+      U₀ + R₂ + allWdrls + D₀           ≡⟨ arithmetic-1 U₀ R₂ allWdrls D₀ ⟩
+      U₀ + allWdrls + D₀ + R₂           ≡⟨ step-iii-iv ⟩
+      U₂ + allDirectDeps + D₂ + R₂      ≡⟨ arithmetic-2 U₂ allDirectDeps D₂ R₂ ⟩
+      U₂ + (R₂ + allDirectDeps) + D₂    ≡⟨ step-ii ⟩
+      U₂ + getCoin certStateFinal + D₂  ∎
+      where
+
+      U₀ U₁ U₂ : Coin
+      U₀ = getCoin (UTxOStateOf s)
+      U₁ = getCoin us₁
+      U₂ = getCoin us₂
+
+      D₀ D₂ : Coin
+      D₀ = coinFromDeposits (CertStateOf s)
+      D₂ = coinFromDeposits cs₂
+
+      R₀ R₂ : Coin
+      R₀ = rewardsBalance (DStateOf (CertStateOf s))
+      R₂ = rewardsBalance (DStateOf cs₂)
+
+      certStateFinal : CertState
+      certStateFinal = record cs₂ { dState = applyDirectDeposits (allDirectDeposits tx) (DStateOf cs₂) }
+
+      allDirectDeps : Coin
+      allDirectDeps = getCoin (allDirectDeposits tx)
+
+      subWdrlsCoin : Coin
+      subWdrlsCoin = sum (map wdrwl (SubTransactionsOf tx))
+
+      allWdrls : Coin
+      allWdrls = getCoin (WithdrawalsOf tx) + subWdrlsCoin
+
+      extract-utxo-netId : ∀ {Γ' s₀' s₁'} → Γ' ⊢ s₀' ⇀⦇ tx ,UTXOW⦈ s₁'
+        → ∀[ a ∈ dom (WithdrawalsOf tx) ] NetworkIdOf a ≡ NetworkId
+      extract-utxo-netId
+        (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _
+          (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
+      extract-utxo-netId
+        (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _
+          (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
+
+      -- combined CERTS: rewardsBalance₀ = rewardsBalance₂ + allWdrls
+      combined-certs : getCoin (CertStateOf s) ≡ getCoin cs₂ + allWdrls
+      combined-certs =
+        begin
+        getCoin (CertStateOf s)                                    ≡⟨ SUBLEDGERS-certs-pov valid subStep ⟩
+        getCoin cs₁ + subWdrlsCoin                                 ≡⟨ cong (_+ subWdrlsCoin) (CERTS-pov (extract-utxo-netId utxoStep) certStep) ⟩
+        getCoin cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin  ≡⟨ +-assoc (getCoin cs₂) _ subWdrlsCoin ⟩
+        getCoin cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)  ∎
+
+
+      step-i : U₀ + R₀ + D₀ ≡ U₀ + R₂ + allWdrls + D₀
+      step-i =
+        begin
+        U₀ + R₀ + D₀                ≡⟨ cong (λ x → U₀ + x + D₀ ) combined-certs ⟩
+        U₀ + (R₂ + allWdrls) + D₀   ≡⟨ cong (_+ D₀) (sym (+-assoc U₀ R₂ allWdrls)) ⟩
+        U₀ + R₂ + allWdrls + D₀     ∎
+
+
+      -- applyDirectDeposits-rewardsBalance
+      step-ii : getCoin us₂ + (R₂ + allDirectDeps) + D₂
+                ≡ getCoin us₂ + getCoin certStateFinal + D₂
+      step-ii = cong (λ x → getCoin us₂ + x + D₂)
+                     (sym (applyDirectDeposits-rewardsBalance (allDirectDeposits tx) (DStateOf cs₂)))
+
+
+
+      -- Move the rightmost summand one position left (modulo re-assoc).
+      swap-right : ∀ a b c → a + b + c ≡ a + c + b
+      swap-right a b c = trans (+-assoc a b c) (trans (cong (a +_) (+-comm b c)) (sym (+-assoc a c b)))
+
+      dc : DepositsChange
+      dc = calculateDepositsChange (CertStateOf s) cs₁ cs₂
+
+      dct dcs : ℤ
+      dct = DepositsChangeTopOf dc
+      dcs = DepositsChangeSubOf dc
+
+      posneg : D₀ + posPart dct + posPart dcs ≡ D₂ + negPart dct + negPart dcs
+      posneg = posNeg-deposits (CertStateOf s) cs₁ cs₂
+
+    -- (MECH) UTXOW-V-mechanical, composed with the batch-wide invariants.
+      mech :  U₁ + cbalance (outs tx) + TxFeesOf tx +  DonationsOf tx
+              ≡ U₂ + cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx)
+
+      mech = trans (UTXOW-V-mechanical utxoStep valid (fresh-top-tx-id valid subStep))
+                   (cong (U₂ +_) (utxo₁-tx-spend-eq valid refl subStep))
+
+
+      arithmetic-1 : ∀ a b c d → a + b + c + d ≡ a + c + d + b
+      arithmetic-1 a b c d = begin
+        a + b + c + d     ≡⟨ cong (_+ d) (+-assoc a b c) ⟩
+        a + (b + c) + d   ≡⟨ cong (λ x → a + x + d) (+-comm b c) ⟩
+        a + (c + b) + d   ≡⟨ cong (_+ d) (sym (+-assoc a c b)) ⟩
+        a + c + b + d     ≡⟨ +-assoc (a + c) b d ⟩
+        a + c + (b + d)   ≡⟨ cong ((a + c) +_) (+-comm b d) ⟩
+        a + c + (d + b)   ≡⟨ sym (+-assoc (a + c) d b) ⟩
+        a + c + d + b     ∎
+
+      arithmetic-2 : ∀ a b c d →  a + b + c + d ≡ a + (d + b) + c
+      arithmetic-2 a b c d = begin
+        a + b + c + d       ≡⟨ +-assoc (a + b) c d ⟩
+        a + b + (c + d)     ≡⟨ cong (a + b +_) (+-comm c d) ⟩
+        a + b + (d + c)     ≡⟨ sym (+-assoc (a + b) d c) ⟩
+        a + b + d + c       ≡⟨ cong (_+ c) (+-assoc a b d) ⟩
+        a + (b + d) + c     ≡⟨ cong (λ x → a + x + c) (+-comm b d) ⟩
+        a + (d + b) + c     ∎
+
+
+      arithmetic-3 : ∀ a b c {d}{e}{f}{g}
+        → a + b + c + d + e + f + g ≡ a + e + b + (c + f + g) + d
+      arithmetic-3 a b c {d}{e}{f}{g} = begin
+        a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + f + g) (swap-right (a + b + c) d e) ⟩
+        a + b + c + e + d + f + g  ≡⟨ cong (_+ g) (swap-right (a + b + c + e) d f) ⟩
+        a + b + c + e + f + d + g  ≡⟨ swap-right (a + b + c + e + f) d g ⟩
+        a + b + c + e + f + g + d  ≡⟨ cong (λ x → x + f + g + d) (swap-right (a + b) c e) ⟩
+        a + b + e + c + f + g + d  ≡⟨ cong (λ x → x + c + f + g + d) (swap-right a b e) ⟩
+        a + e + b + c + f + g + d  ≡⟨ cong (_+ d) reassoc-middle ⟩
+        (a + e) + b + (c + f + g) + d  ∎
+        where
+        reassoc-middle : a + e + b + c + f + g ≡ (a + e) + b + (c + f + g)
+        reassoc-middle = trans (+-assoc (a + e + b + c) f g)
+                               (trans (+-assoc (a + e + b) c (f + g))
+                                      (cong (a + e + b +_) (sym (+-assoc c f g))))
+
+      arithmetic-4 : ∀ a b c {d}{e}{f}{g}
+        → a + b + c + (d + e + f) + g ≡ a + (g + c + b + e + f) + d
+      arithmetic-4 a b c {d}{e}{f}{g} = begin
+        a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+        a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+        a + b + c + d + e + f + g    ≡⟨ swap-right (a + b + c + d + e) f g ⟩
+        a + b + c + d + e + g + f    ≡⟨ cong (_+ f) (swap-right (a + b + c + d) e g) ⟩
+        a + b + c + d + g + e + f    ≡⟨ cong (λ x → x + e + f) (swap-right (a + b + c) d g) ⟩
+        a + b + c + g + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + b) c g) ⟩
+        a + b + g + c + d + e + f    ≡⟨ cong (λ x → x + c + d + e + f) (swap-right a b g) ⟩
+        a + g + b + c + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + g) b c) ⟩
+        a + g + c + b + d + e + f    ≡⟨ cong (_+ f) (swap-right (a + g + c + b) d e) ⟩
+        a + g + c + b + e + d + f    ≡⟨ swap-right (a + g + c + b + e) d f ⟩
+        a + g + c + b + e + f + d    ≡⟨ cong (λ x → x + b + e + f + d) (+-assoc a g c) ⟩
+        a + (g + c) + b + e + f + d  ≡⟨ cong (λ x → x + e + f + d) (+-assoc a (g + c) b) ⟩
+        a + (g + c + b) + e + f + d  ≡⟨ cong (λ x → x + f + d) (+-assoc a (g + c + b) e) ⟩
+        a + (g + c + b + e) + f + d  ≡⟨ cong (_+ d) (+-assoc a (g + c + b + e) f) ⟩
+        a + (g + c + b + e + f) + d  ∎
+
+      arithmetic-5 : ∀ a b c {d}{e}{f}{g}{h}{i}
+        → a + (b + c + d + e + f + g + h) + i
+        ≡ a +  b + c + d + e + f + g + h  + i
+      arithmetic-5 a b c {d}{e}{f}{g}{h}{i} = cong (_+ i) $
+        begin
+        a + (b + c + d + e + f + g + h)  ≡˘⟨ +-assoc a _ h ⟩
+        a + (b + c + d + e + f + g) + h  ≡˘⟨ cong (_+ h) (+-assoc a _ g) ⟩
+        a + (b + c + d + e + f) + g + h  ≡˘⟨ cong (λ x → x + g + h) (+-assoc a _ f) ⟩
+        a + (b + c + d + e) + f + g + h  ≡˘⟨ cong (λ x → x + f + g + h) (+-assoc a _ e) ⟩
+        a + (b + c + d) + e + f + g + h  ≡˘⟨ cong (λ x → x + e + f + g + h) (+-assoc a _ d) ⟩
+        a + (b + c) + d + e + f + g + h  ≡˘⟨ cong (λ x → x + d + e + f + g + h) (+-assoc a b c) ⟩
+        a + b + c + d + e + f + g + h    ∎
+
+      arithmetic-6 : ∀ a b c {d}{e}{f}{g}
+        → a + b + c + d + e + f + g ≡ a + c + g + b + d + e + f
+      arithmetic-6 a b c {d}{e}{f}{g} = begin
+        a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + d + e + f + g) (swap-right a b c) ⟩
+        a + c + b + d + e + f + g  ≡⟨ swap-right (a + c + b + d + e) f g ⟩
+        a + c + b + d + e + g + f  ≡⟨ cong (_+ f) (swap-right (a + c + b + d) e g) ⟩
+        a + c + b + d + g + e + f  ≡⟨ cong (λ x → x + e + f) (swap-right (a + c + b) d g) ⟩
+        a + c + b + g + d + e + f  ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + c) b g) ⟩
+        a + c + g + b + d + e + f  ∎
+
+      arithmetic-7 : ∀ a b c {d}{e}{f}{g}
+        → a + b + c + (d + e + f + g) ≡ a + b + c + d + e + f + g
+      arithmetic-7 a b c {d}{e}{f}{g} = begin
+        a + b + c + (d + e + f + g)  ≡˘⟨ +-assoc (a + b + c) (d + e + f) g ⟩
+        a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+        a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+        a + b + c + d + e + f + g    ∎
+
+      Ctop Csub : Coin
+      Ctop = cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx)
+      Csub = sum (map (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx)) (SubTransactionsOf tx))
+
+      Psub PsubDD : Coin
+      Psub = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) (SubTransactionsOf tx))
+      PsubDD = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx + getCoin (DirectDepositsOf stx))
+                        (SubTransactionsOf tx))
+
+      -- === The additive constant =================================================
+      E : Coin
+      E = Ctop + Psub + posPart dct + posPart dcs
+
+      bat' :  Ctop + allWdrls + Csub + negPart dct + negPart dcs
+              ≡ cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+              + allDirectDeps + Psub + posPart dct + posPart dcs
+      bat' =
+        begin
+          Ctop + W + Csub + negPart dct + negPart dcs
+            ≡⟨⟩
+          Ctop + (Wtop + Wsub) + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + Csub + negPart dct + negPart dcs) (sym (+-assoc Ctop Wtop Wsub)) ⟩
+          Ctop + Wtop + Wsub + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (swap-right (Ctop + Wtop) Wsub Csub) ⟩
+          Ctop + Wtop + Csub + Wsub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (+-assoc (Ctop + Wtop) Csub Wsub) ⟩
+          Ctop + Wtop + (Csub + Wsub) + negPart dct + negPart dcs
+            ≡˘⟨ cong  (λ x → Ctop + Wtop + x + negPart dct + negPart dcs)
+                      (sum-map-+  (λ stx → cbalance (UTxOOf s ∣ SpendInputsOf stx))
+                                  wdrwl (SubTransactionsOf tx)) ⟩
+          Ctop + Wtop + CsubW + negPart dct + negPart dcs
+            ≡⟨ cong (_+ negPart dcs) (swap-right (Ctop + Wtop) CsubW (negPart dct)) ⟩
+          Ctop + Wtop + negPart dct + CsubW + negPart dcs
+            ≡⟨ UTXOW-batch-balance-coin utxoStep ⟩
+          O + F + DN + DDtop + posPart dct + PsubDD + (posPart dcs)
+            ≡⟨ cong  (λ x → O + F + DN + DDtop + posPart dct + x + posPart dcs)
+                     (sum-map-+ (λ stx → cbalance (outs stx) + DonationsOf stx)
+                                (λ stx → getCoin (DirectDepositsOf stx)) (SubTransactionsOf tx)) ⟩
+          O + F + DN + DDtop + posPart dct + (Psub + DDsub) + posPart dcs
+            ≡⟨ reshuffle-to-DD ⟩
+          O + F + DN + (DDtop + DDsub) + Psub + posPart dct + posPart dcs
+            ≡⟨ cong (λ x → O + F + DN + x + Psub + posPart dct + posPart dcs) (sym DD-split) ⟩
+          O + F + DN + DD + Psub + posPart dct + posPart dcs
+            ∎
+          where
+          O = cbalance (outs tx)
+          F = TxFeesOf tx
+          DN = DonationsOf tx
+          DD = allDirectDeps
+          DDtop = getCoin (DirectDepositsOf tx)
+          DDsub = sum (map (λ stx → getCoin (DirectDepositsOf stx)) (SubTransactionsOf tx))
+          W = allWdrls
+          Wtop = getCoin (WithdrawalsOf tx)
+          Wsub = sum (map wdrwl (SubTransactionsOf tx))
+          CsubW = sum (map (λ stx → cbalance (UTxOOf s ∣ SpendInputsOf stx) + getCoin (WithdrawalsOf stx)) (SubTransactionsOf tx))
+          reshuffle-to-DD : O + F + DN + DDtop + posPart dct + (Psub + DDsub) + posPart dcs
+                          ≡ O + F + DN + (DDtop + DDsub) + Psub + posPart dct + posPart dcs
+          reshuffle-to-DD = begin
+            O + F + DN + DDtop + (posPart dct) + (Psub + DDsub) + (posPart dcs)
+              ≡⟨ cong (_+ (posPart dcs)) (sym (+-assoc (O + F + DN + DDtop + (posPart dct)) Psub DDsub)) ⟩
+            O + F + DN + DDtop + (posPart dct) + Psub + DDsub + (posPart dcs)
+              ≡⟨ cong (_+ (posPart dcs)) (swap-right (O + F + DN + DDtop + (posPart dct)) Psub DDsub) ⟩
+            O + F + DN + DDtop + (posPart dct) + DDsub + Psub + (posPart dcs)
+              ≡⟨ cong (λ x → x + Psub + (posPart dcs)) (swap-right (O + F + DN + DDtop) (posPart dct) DDsub) ⟩
+            O + F + DN + DDtop + DDsub + (posPart dct) + Psub + (posPart dcs)
+              ≡⟨ cong (_+ (posPart dcs)) (swap-right (O + F + DN + DDtop + DDsub) (posPart dct) Psub) ⟩
+            O + F + DN + DDtop + DDsub + Psub + (posPart dct) + (posPart dcs)
+              ≡⟨ cong (λ x → x + Psub + (posPart dct) + (posPart dcs)) (+-assoc (O + F + DN) DDtop DDsub) ⟩
+            O + F + DN + (DDtop + DDsub) + Psub + (posPart dct) + (posPart dcs)
+              ∎
+
+      -- === Main chain ============================================================
+      LHS+E≡RHS+E : (U₀ + allWdrls + D₀) + E ≡ (U₂ + allDirectDeps + D₂) + E
+      LHS+E≡RHS+E = begin
+        U₀ + allWdrls + D₀ + E
+          ≡⟨ refl ⟩
+        U₀ + allWdrls + D₀ + (Ctop + Psub + posPart dct + posPart dcs)
+          ≡⟨ arithmetic-7 U₀ allWdrls D₀ ⟩
+        U₀ + allWdrls + D₀ + Ctop + Psub + posPart dct + posPart dcs
+          ≡⟨ arithmetic-3 U₀ allWdrls D₀ ⟩
+        U₀ + Psub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
+          ≡⟨ cong (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
+                  (subst  (λ u → U₀ + Psub ≡ U₁ + sum (map (λ stx → cbalance (u ∣ SpendInputsOf stx)) (SubTransactionsOf tx)))
+                         (refl {x = UTxOOf s}) (SUBLEDGERS-utxo-coin valid subStep)) ⟩
+        U₁ + Csub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
+          ≡⟨ cong (λ x → (U₁ + Csub) + allWdrls + x + Ctop) posneg ⟩
+        U₁ + Csub + allWdrls + (D₂ + negPart dct + negPart dcs) + Ctop
+          ≡⟨ arithmetic-4 U₁ Csub allWdrls ⟩
+        U₁ + (Ctop + allWdrls + Csub + negPart dct + negPart dcs) + D₂
+          ≡⟨ cong (λ x → U₁ + x + D₂) bat' ⟩
+        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs) + D₂
+          ≡⟨ arithmetic-5 U₁ (cbalance (outs tx)) (TxFeesOf tx) ⟩
+        U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs + D₂
+          ≡⟨ cong (λ x → x + allDirectDeps + Psub + posPart dct + posPart dcs + D₂) mech ⟩
+        U₂ + Ctop + allDirectDeps + Psub + posPart dct + posPart dcs + D₂
+          ≡⟨ arithmetic-6 U₂ Ctop allDirectDeps ⟩
+        U₂ + allDirectDeps + D₂ + Ctop + Psub + posPart dct + posPart dcs
+          ≡˘⟨ arithmetic-7 U₂ allDirectDeps D₂ ⟩
+        U₂ + allDirectDeps + D₂ + E
+          ∎
+
+      -- deposit accounting + batch UTxO combined
+      step-iii-iv : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + R₂
+      step-iii-iv = cong  (_+ R₂)
+                          (+-cancelʳ-≡ E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂) LHS+E≡RHS+E)
+```

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -189,6 +189,9 @@ module _
 
   ( split-balance : ∀ (u : UTxO) (keys : ℙ TxIn) → cbalance u ≡ cbalance (u ∣ keys ᶜ) + cbalance (u ∣ keys) )
 
+  -- New CIP-159 assumption (forwarded to Certs-Pov-lemmas): see PoVLemmas.
+  ( indexedSumᵛ'-∪⁺ : ∀ (m m' : Rewards) → getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m' )
+
   -- Per-step SUBUTXOW coin equation.  Assumed for now; a local proof
   -- would require, in addition to `balance-∪` and `split-balance`, a
   -- batch-wide "spend inputs preserved" invariant (the running UTxO
@@ -247,7 +250,7 @@ module _
       → sum (map (λ x → f x + g x) xs) ≡ sum (map f xs) + sum (map g xs) )
 
   where
-  open Certs-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+  open Certs-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique indexedSumᵛ'-∪⁺
   -- Import the utxow-level properties (utxow-pov-invalid, UTXOW-V-mechanical,
   -- UTXOW-batch-balance-coin) from `Utxow.Properties.PoV`.  The `λ {u}{u'} →`
   -- η-wrapper is needed for the same Agda eta-expansion reason as in
@@ -339,7 +342,7 @@ module _
       → ∀[ a ∈ dom (WithdrawalsOf stx) ] NetworkIdOf a ≡ NetworkId
     extract-subutxo-netId
       (SUBUTXOW ( _ , _ , _ , _ , _ , _ , _ , _ , _ , _
-                , SUBUTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
+                , _ , _ , SUBUTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
 
     wdrl-netId : ∀[ a ∈ dom (WithdrawalsOf stx) ] NetworkIdOf a ≡ NetworkId
     wdrl-netId = extract-subutxo-netId subutxowStep -- extract from premise 11
@@ -437,7 +440,7 @@ where `certStateFinal = record certState₂ { dState = applyDirectDeposits (allD
         begin
         getCoin (CertStateOf s)                                    ≡⟨ SUBLEDGERS-certs-pov valid subStep ⟩
         getCoin cs₁ + subWdrlsCoin                                 ≡⟨ cong (_+ subWdrlsCoin) (CERTS-pov (extract-utxo-netId utxoStep) certStep) ⟩
-        getCoin cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin  ≡⟨ +-assoc (getCoin cs₂) _ subWdrlsCoin ⟩
+        getCoin cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin    ≡⟨ +-assoc (getCoin cs₂) _ subWdrlsCoin ⟩
         getCoin cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)  ∎
 
 

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -118,12 +118,12 @@ intermediate stage of the main chain.
 To close, add `Σ directDeps_i` to both sides of the goal (eliminated at the end via
 `+-cancelʳ-≡`):
 
-    (U₀ + R₀ + D₀) + Σ directDeps_i
+    U₀ + R₀ + D₀ + Σ directDeps_i
     ≡ U₀ + (R₀ + Σ directDeps_i) + D₀
     ≡ U₀ + (R₂ + Σ wdrls_i) + D₀               by (2)
     ≡ U₀ + Σ wdrls_i + D₀ + R₂                 (rearrange)
     ≡ U₂ + Σ directDeps_i + D₂ + R₂            by (★)
-    ≡ (U₂ + R₂ + D₂) + Σ directDeps_i          (rearrange)
+    ≡ U₂ + R₂ + D₂ + Σ directDeps_i          (rearrange)
 
 
 ### `LEDGER-I` proof outline
@@ -152,8 +152,8 @@ module _
   (tx : TopLevelTx) (let open Tx tx)
 
   -- Shared assumptions (same pattern as Conway)
-  ( ∪ˡ-res-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
-      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ (m ∣ ❴ c ❵ ᶜ)) c' ≡ lookupᵐ? m c' )
+  ( ∪ˡ-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
 
   ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
@@ -162,9 +162,6 @@ module _
   ( balance-∪ : ∀ {u u' : UTxO} → disjoint (dom u) (dom u') → cbalance (u ∪ˡ u') ≡ cbalance u + cbalance u' )
 
   ( split-balance : ∀ (u : UTxO) (keys : ℙ TxIn) → cbalance u ≡ cbalance (u ∣ keys ᶜ) + cbalance (u ∣ keys) )
-
-  -- New CIP-159 assumption (forwarded to Certs-Pov-lemmas): see PoVLemmas.
-  ( indexedSumᵛ'-∪⁺ : ∀ (m m' : Rewards) → getCoin (m ∪⁺ m') ≡ getCoin m + getCoin m' )
 
   -- Per-step SUBUTXOW coin equation.  Assumed for now; a local proof
   -- would require, in addition to `balance-∪` and `split-balance`, a
@@ -201,25 +198,34 @@ module _
       → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
 
-  -- Deposit-change posPart/negPart identity.  Provable from the definition
-  -- of `calculateDepositsChange` and the standard
-  -- `y + posPart (x - y) ≡ x + negPart (x - y)` lemma (per-component, then
-  -- composed across top and sub).  Deferred to the follow-up PR.
-  ( posNeg-deposits : (cs₀ cs₁ cs₂ : CertState)
-      → let dc = calculateDepositsChange cs₀ cs₁ cs₂ in
-        coinFromDeposits cs₀ + posPart (DepositsChangeTopOf dc) + posPart (DepositsChangeSubOf dc)
-        ≡ coinFromDeposits cs₂ + negPart (DepositsChangeTopOf dc) + negPart (DepositsChangeSubOf dc) )
-
-  -- Sum distribution (standard list algebra):
-  ( sum-map-+ : ∀ {A : Type} (f g : A → ℕ) (xs : List A)
-      → sum (map (λ x → f x + g x) xs) ≡ sum (map f xs) + sum (map g xs) )
-
   where
-  open Certs-PoV ∪ˡ-res-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique indexedSumᵛ'-∪⁺
+  open Certs-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
   -- Note: The `λ {u}{u'} →` η-wrapper may be needed for Agda eta-expansion issue.
 
   open UTXOW-PoV tx (λ {u} {u'} → balance-∪ {u} {u'}) split-balance noMintTx noMintSubTx (λ {u} → outs-disjoint {u})
   open ≡-Reasoning
+
+  posNeg-deposits : (cs₀ cs₁ cs₂ : CertState)
+    → let dc = calculateDepositsChange cs₀ cs₁ cs₂ in
+      coinFromDeposits cs₀ + posPart (DepositsChangeTopOf dc) + posPart (DepositsChangeSubOf dc)
+      ≡ coinFromDeposits cs₂ + negPart (DepositsChangeTopOf dc) + negPart (DepositsChangeSubOf dc)
+  posNeg-deposits cs₀ cs₁ cs₂ = begin
+      coin₀ + pt + psp   ≡⟨ swap-right coin₀ pt psp ⟩
+      coin₀ + psp + pt   ≡⟨ cong (_+ pt) (posPart-negPart-sym coin₁ coin₀) ⟩
+      coin₁ + ns + pt   ≡⟨ swap-right coin₁ ns pt ⟩
+      coin₁ + pt + ns   ≡⟨ cong (_+ ns) (posPart-negPart-sym coin₂ coin₁) ⟩
+      coin₂ + nt + ns   ∎
+    where
+    open ≡-Reasoning
+    coin₀ = coinFromDeposits cs₀
+    coin₁ = coinFromDeposits cs₁
+    coin₂ = coinFromDeposits cs₂
+    psp = posPart (coin₁ ⊖ coin₀)   -- DepositsChangeSubOf dc
+    ns = negPart (coin₁ ⊖ coin₀)
+    pt = posPart (coin₂ ⊖ coin₁)   -- DepositsChangeTopOf dc
+    nt = negPart (coin₂ ⊖ coin₁)
+    swap-right : ∀ a b c → a + b + c ≡ a + c + b
+    swap-right a b c = trans (+-assoc a b c) (trans (cong (a +_) (+-comm b c)) (sym (+-assoc a c b)))
 
   -- Per-sub-tx withdrawal totals.
   wdrwl : SubLevelTx → Coin
@@ -334,7 +340,7 @@ module _
     -- Sub-level CERTS-pov (NEW signature: dd on LHS, wdrl on RHS).
     sub-certs : getCoin (CertStateOf s₀) + getCoin (DirectDepositsOf stx)
                 ≡ getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)
-    sub-certs = CERTS-pov (extract-subutxo-netId subutxowStep) certsStep
+    sub-certs = ? -- CERTS-pov (extract-subutxo-netId subutxowStep) certsStep
 
     -- IH: same form as the outer goal, just one element shorter.
     ih : getCoin (CertStateOf s₁) + sum (map ddwl sigs)

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -152,12 +152,20 @@ module _
   (tx : TopLevelTx) (let open Tx tx)
 
   -- Shared assumptions (same pattern as Conway)
+  -- ( ∪ˡ-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+  --     → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
+
+  -- ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  -- ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
   ( ∪ˡ-lookup-preserve : ∀ (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
       → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
 
-  ( sum-map-proj₂≡getCoin : ∀ (m : Withdrawals) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+  ( sum-map-proj₂≡getCoin : ∀ (m : RewardAddress ⇀ Coin) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
 
-  ( setToList-Unique : ∀ (m : Withdrawals) → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+  ( setToList-Unique : ∀ (m : RewardAddress ⇀ Coin) → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
 
   ( balance-∪ : ∀ {u u' : UTxO} → disjoint (dom u) (dom u') → cbalance (u ∪ˡ u') ≡ cbalance u + cbalance u' )
 
@@ -312,7 +320,7 @@ module _
                         (getCoin (DirectDepositsOf stx))
                         (sum (map ddwl sigs))) ⟩
       (getCoin (CertStateOf s₀) + getCoin (DirectDepositsOf stx)) + sum (map ddwl sigs)
-        ≡⟨ cong (_+ sum (map ddwl sigs)) sub-certs ⟩
+        ≡⟨ cong (_+ sum (map ddwl sigs)) (CERTS-pov (extract-netId subutxowStep) certsStep) ⟩
       (getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)) + sum (map ddwl sigs)
         ≡⟨ swap-right (getCoin (CertStateOf s₁))
                       (getCoin (WithdrawalsOf stx))
@@ -330,17 +338,14 @@ module _
       getCoin (CertStateOf sₙ) + (getCoin (WithdrawalsOf stx) + sum (map wdrwl sigs))
         ∎
     where
-    extract-subutxo-netId : ∀ {Γ' s₀' s₁'}
+    extract-netId : ∀ {Γ' s₀' s₁'}
       → Γ' ⊢ s₀' ⇀⦇ stx ,SUBUTXOW⦈ s₁'
-      → ∀[ a ∈ dom (WithdrawalsOf stx) ] NetworkIdOf a ≡ NetworkId
-    extract-subutxo-netId
+      → (∀[ a ∈ dom (WithdrawalsOf stx) ] NetworkIdOf a ≡ NetworkId)
+        × (∀[ a ∈ dom (DirectDepositsOf stx) ] NetworkIdOf a ≡ NetworkId)
+    extract-netId
       (SUBUTXOW ( _ , _ , _ , _ , _ , _ , _ , _ , _ , _
-                , _ , _ , SUBUTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
-
-    -- Sub-level CERTS-pov (NEW signature: dd on LHS, wdrl on RHS).
-    sub-certs : getCoin (CertStateOf s₀) + getCoin (DirectDepositsOf stx)
-                ≡ getCoin (CertStateOf s₁) + getCoin (WithdrawalsOf stx)
-    sub-certs = ? -- CERTS-pov (extract-subutxo-netId subutxowStep) certsStep
+                , _ , _ , SUBUTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , wd-netId , dd-netId , _))) =
+      wd-netId , dd-netId
 
     -- IH: same form as the outer goal, just one element shorter.
     ih : getCoin (CertStateOf s₁) + sum (map ddwl sigs)
@@ -432,13 +437,16 @@ between `producedBatch` (UTxO side, via `UTXOW-batch-balance-coin`) and `certSta
       allWdrls = getCoin (WithdrawalsOf tx) + subWdrlsCoin
 
       extract-utxo-netId : ∀ {Γ' s₀' s₁'} → Γ' ⊢ s₀' ⇀⦇ tx ,UTXOW⦈ s₁'
-        → ∀[ a ∈ dom (WithdrawalsOf tx) ] NetworkIdOf a ≡ NetworkId
+        → (∀[ a ∈ dom (WithdrawalsOf tx) ] NetworkIdOf a ≡ NetworkId)
+          × (∀[ a ∈ dom (DirectDepositsOf tx) ] NetworkIdOf a ≡ NetworkId)
       extract-utxo-netId
-        (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _ _
-          (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
+        (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _
+          (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , wd-netId , dd-netId , _))) =
+        wd-netId , dd-netId
       extract-utxo-netId
-        (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-          (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , netId , _))) = netId
+        (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _
+          (UTXO (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , wd-netId , dd-netId , _))) =
+        wd-netId , dd-netId
 
       -- Combined CERTS-pov: pre-batch certState + all direct deposits ≡
       --                     post-CERTS certState + all withdrawals.

--- a/src/Ledger/Prelude.lagda.md
+++ b/src/Ledger/Prelude.lagda.md
@@ -55,7 +55,7 @@ open import Data.Integer using (0ℤ) public
 import Data.Rational as ℚ
 open import Data.Rational using (ℚ)
 
-open import Data.Nat.Properties using (+-identityʳ)
+open import Data.Nat.Properties using (+-identityʳ; +-comm; +-assoc)
 
 
 dec-de-morgan : ∀{P Q : Type} → ⦃ P ⁇ ⦄ → ¬ (P × Q) → ¬ P ⊎ ¬ Q
@@ -111,6 +111,17 @@ indexedSumL-proj₂-zero ((a , v) ∷ xs) all-zero =
     trans (cong (_+ indexedSumL proj₂ xs) (all-zero (Prelude.Init.here refl)))
           (indexedSumL-proj₂-zero xs (all-zero ∘ Prelude.Init.there))
 
+
++-interleave : {a b c d : ℕ} → a + b + (c + d) ≡ a + c + (b + d)
++-interleave {a}{b}{c}{d} = begin
+  a + b + (c + d)  ≡⟨ +-assoc a b (c + d) ⟩
+  a + (b + (c + d))  ≡⟨ cong (a +_) (sym (+-assoc b c d)) ⟩
+  a + (b + c + d)    ≡⟨ cong (λ y → a + (y + d)) (+-comm b c) ⟩
+  a + (c + b + d)    ≡⟨ cong (a +_) (+-assoc c b d) ⟩
+  a + (c + (b + d))  ≡⟨ sym (+-assoc a c (b + d)) ⟩
+  a + c + (b + d)  ∎
+  where open ≡-Reasoning
+
 module _ {A : Type} ⦃ _ : DecEq A ⦄ where
 
   getCoin-singleton : {(a , c) : A × Coin} → indexedSumᵛ' id ❴ (a , c) ❵ ≡ c
@@ -149,6 +160,16 @@ module _ {A : Type} ⦃ _ : DecEq A ⦄ where
   ∪ˡsingleton0≡ m {a} with a ∈? dom m
   ... | yes a∈dom = ∪ˡsingleton∈dom m a∈dom
   ... | no a∉dom = trans (∪ˡsingleton∉dom m a∉dom) (+-identityʳ (getCoin m))
+
+sum-map-+ : ∀ {A : Type} (f g : A → ℕ) (xs : List A)
+  → sum (map (λ x → f x + g x) xs) ≡ sum (map f xs) + sum (map g xs)
+sum-map-+ _ _ [] = refl
+sum-map-+ f g (x ∷ xs) =
+  begin
+  f x + g x + sum (map (λ x → f x + g x) xs)    ≡⟨ cong (f x + g x +_) (sum-map-+ f g xs) ⟩
+  f x + g x + (sum (map f xs) + sum (map g xs)) ≡⟨ +-interleave {f x} ⟩
+  f x + sum (map f xs) + (g x + sum (map g xs)) ∎
+  where open ≡-Reasoning
 
 opaque
   unfolding List-Model finiteness

--- a/src/Prelude.lagda.md
+++ b/src/Prelude.lagda.md
@@ -103,9 +103,12 @@ instance
   ~? {A} {x} {y} ⦃ deqEq ⦄ = ⁇ (connected? (DecEq._≟_ deqEq) x y)
 
 -- Positive and negative part of integers
-open import Data.Integer using (sign; ∣_∣; _⊖_)
+open import Data.Integer using (_⊖_) public
+open import Data.Integer using (sign; ∣_∣)
 open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n)
 open import Data.Sign using (Sign)
+
+open import Data.Nat.Properties using (m+[n∸m]≡n; m≤n⇒m∸n≡0; ≤-total; +-identityʳ)
 
 posPart : ℤ → ℕ
 posPart x with sign x
@@ -122,6 +125,33 @@ negPart x with sign x
 ∸≡posPart⊖ {zero} {ℕ.suc n} = _≡_.refl
 ∸≡posPart⊖ {ℕ.suc m} {zero} = _≡_.refl
 ∸≡posPart⊖ {ℕ.suc m} {ℕ.suc n} = trans (∸≡posPart⊖{m}{n}) (sym (cong posPart (([1+m]⊖[1+n]≡m⊖n m n))))
+
+∸≡negPart⊖ : {m n : ℕ} → (n ∸ m) ≡ negPart (m ⊖ n)
+∸≡negPart⊖ {zero}  {zero}  = refl
+∸≡negPart⊖ {zero}  {ℕ.suc n} = refl
+∸≡negPart⊖ {ℕ.suc m} {zero}  = refl
+∸≡negPart⊖ {ℕ.suc m} {ℕ.suc n} =
+  trans (∸≡negPart⊖ {m} {n})
+        (sym (cong negPart ([1+m]⊖[1+n]≡m⊖n m n)))
+
++∸≡∸+ : (a b : ℕ) → a +ℕ (b ∸ a) ≡ b +ℕ (a ∸ b)
++∸≡∸+ a b with ≤-total a b
+... | inj₁ a≤b =
+  trans (m+[n∸m]≡n a≤b)
+        (sym (trans (cong (b +ℕ_) (m≤n⇒m∸n≡0 a≤b)) (+-identityʳ b)))
+... | inj₂ b≤a =
+  trans (cong (a +ℕ_) (m≤n⇒m∸n≡0 b≤a))
+        (trans (+-identityʳ a) (sym (m+[n∸m]≡n b≤a)))
+
+-- y + posPart (x ⊖ y) ≡ x + negPart (x ⊖ y)
+posPart-negPart-sym : ∀ x y → y +ℕ posPart (x ⊖ y) ≡ x +ℕ negPart (x ⊖ y)
+posPart-negPart-sym x y = let _+_ = _+ℕ_ in
+  begin
+    y + posPart (x ⊖ y)  ≡⟨ cong (y +_) (sym (∸≡posPart⊖ {x} {y})) ⟩
+    y + (x ∸ y)          ≡⟨ +∸≡∸+ y x ⟩
+    x + (y ∸ x)          ≡⟨ cong (x +_) (∸≡negPart⊖ {x} {y}) ⟩
+    x + negPart (x ⊖ y)  ∎
+  where open ≡-Reasoning
 
 instance
   Dec-NonZero : ∀ {n} → NonZero n ⁇


### PR DESCRIPTION
**DEPRECATED**. This PR was based on `CERT-Post` and `CERT-Pre` setup.  It is superseded by #1203 which is based on the `ENTITIES` approach.

---

# Description

Closes #1187.

This PR proves the top-level `LEDGER-pov` theorem for the Dijkstra era, building on the `Certs` and `Utxo`/`Utxow` PoV machinery from PRs #`<new-A>` and #`<new-B>`.  It is the third of three replacing the original PR #1169.

It targets the branch of PR #`<new-B>` so that CI sees the full PoV chain in order; once #`<new-B>` merges, this PR will be retargeted to `master`.

---

## Module

| Module | Purpose | Status |
|--------|---------|--------|
| `Ledger.Properties.PoV` | `HasCoin` instances and `LEDGER-pov` | Proved (modulo module parameters) |

---

## Design notes

### Why the proof reasons about `LEDGER-V` as a single step

The Dijkstra `LEDGER-pov` proof does not decompose into independent `SUBLEDGERS-pov` and `UTXOW-pov` pieces, because (i) individual `SUBUTXO` rules have no balance equation — only the batch-level `consumedBatch ≡ producedBatch` (in `UTXO`) constrains the total — and (ii) sub-transactions may individually transfer value between UTxO and CertState (via sub-withdrawals, sub-deposits, sub-direct-deposits) without local balancing.  Instead, the proof reasons about the entire `LEDGER-V` step at once.

### `applyDirectDeposits` cancellation is the main new challenge

In `LEDGER-V`, `certStateFinal = certStateWithDDeps tx certState₂ = record certState₂ { dState = applyDirectDeposits (DirectDepositsOf tx) (DStateOf certState₂) }`.  Direct deposit value appears in `producedBatch` (UTxO side) and in `certStateFinal` (CertState side), so it cancels in the total.  The proof is an equational chain combining `SUBLEDGERS-certs-pov`, top-level `CERTS-pov`, the batch-UTxO-accounting step, and the `applyDirectDeposits-rewardsBalance` identity.  Per-transaction direct deposit application (PR #1161) makes this slightly cleaner than batch-wide application would have been, because each transaction's direct-deposit total appears next to its own `producedTx` term in `producedBatch`, mirrored by its own `certStateWithDDeps` step.

### Helpers proved here

+  `SUBLEDGERS-certs-pov` — induction over the `SUBLEDGERS` reflexive-transitive closure, composing per-sub-transaction `CERTS-pov` invocations.
+  `SUBLEDGERS-utxo-coin` — parallel induction tracking `getCoin (UTxOStateOf _)` through the `SUBLEDGERS` chain via the per-step `SUBUTXOW` coin equation.
+  `LEDGER-pov` — both `LEDGER-V` and `LEDGER-I` cases.

The `LEDGER-I` case is straightforward: `certState` and `govSt` are unchanged, `SUBLEDGERS` is a no-op, and only the `UTXOW` step affects `getCoin`, which it preserves via `utxow-pov-invalid` (from PR #`<new-B>`).

---

## Outstanding proof obligations

The following are stated as module parameters of `Ledger.Properties.PoV`, with detailed proof sketches in comments.  Each will be discharged in a follow-up; the dependencies are now in place.

CIP-159–specific or Dijkstra-specific:

+  `applyDirectDeposits-rewardsBalance` — should follow from `∪⁺` properties.
+  `subutxow-step-coin` — per-step `SUBUTXOW` coin equation.  Requires a batch-wide "spend inputs preserved" invariant and freshness of each sub-tx's TxId relative to the running UTxO.
+  `utxo₁-tx-spend-eq` and `fresh-top-tx-id` — batch-wide invariants on the post-`SUBLEDGERS` UTxO state.  Both follow from batch-wide input disjointness and TxId freshness, which the outer UTXO rule establishes at the batch level but does not expose per-step.

Era-independent (can be discharged in a small standalone follow-up):

+  `posNeg-deposits` — deposit-change posPart/negPart identity.  Provable from the definition of `calculateDepositsChange` and the standard `y + posPart (x − y) ≡ x + negPart (x − y)` lemma.
+  `DD-split` — aggregation identity for `allDirectDeposits`.  Provable once we confirm `allDirectDeposits` sums top-level and sub-level direct deposits disjointly.
+  `sum-map-+` — standard list algebra.

The shared parameters (`balance-∪`, `split-balance`, `outs-disjoint`, `noMintTx`, `noMintSubTx`, `∪ˡ-res-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique`) are the same ones already taken as parameters in PRs #`<new-A>` and #`<new-B>`; they are threaded through here.

The invariant properties from §§3–6 of the parent issue #1123 (phantom asset, non-negative balance, direct-deposit registration, balance-interval satisfaction) are mostly straightforward consequences of `UTXO-Premises` conjuncts and are deferred to a follow-up.


---

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
