### PR TITLE
Allow V4 Plutus scripts in legacy mode

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -170,7 +170,7 @@ instance
 
 1. All needed phase-2 scripts use Plutus language V4.
 
-3. Required top-level guards are well-formed. If the credential is a
+2. Required top-level guards are well-formed. If the credential is a
    `KeyHash`{.AgdaDatatype} or a phase-1 script, then no datum should
    be specified, otherwise, when it is a phase-2 script, the datum
    should be specified.
@@ -233,9 +233,10 @@ data _⊢_⇀⦇_,SUBUTXOW⦈_ : SubUTxOEnv → UTxOState → SubLevelTx → UTx
                                                        else nothing)
                                       (credsNeeded utxo₀ txSub)
     in
+    ∙ ∀[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV4 ∷ []) -- (1)
     ∙ ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ
     ∙ ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided (GuardsOf txSub) txVldt s
-    ∙ ∀[ tlg ∈ TopLevelGuardsOf txSub ] TopLevelGuardWellFormed scriptsProvided tlg -- (3)
+    ∙ ∀[ tlg ∈ TopLevelGuardsOf txSub ] TopLevelGuardWellFormed scriptsProvided tlg -- (2)
     ∙ vKeyHashesNeeded ⊆ vKeyHashesProvided
     ∙ scriptHashesNeeded ⊆ mapˢ hash scriptsProvided
     ∙ dataHashesNeededSpendInputs ⊆ dataHashesProvided
@@ -436,6 +437,6 @@ unquoteDecl UTXOW-legacy-premises = genPremises UTXOW-legacy-premises (quote UTX
 unquoteDecl SUBUTXOW-premises = genPremises SUBUTXOW-premises (quote SUBUTXOW)
 pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)
 pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)
-pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)
+pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -115,12 +115,14 @@ languages p2Scripts = mapˢ language p2Scripts
 
 allowedLanguagesLegacyMode : TopLevelTx → UTxO → ℙ Language
 allowedLanguagesLegacyMode tx utxo =
-  if UsesV3Features tx
+  if UsesBootstrapAddress utxo tx
+    then ∅
+  else if UsesV3Features tx
     then fromList (PlutusV3 ∷ [])
-    else
-  if UsesV2Features tx utxo
+  else if UsesV2Features tx utxo
     then fromList (PlutusV3 ∷ PlutusV2 ∷ [])
-    else fromList (PlutusV3 ∷ PlutusV2 ∷ PlutusV1 ∷ [])
+  else
+    fromList (PlutusV3 ∷ PlutusV2 ∷ PlutusV1 ∷ [])
 ```
 
 ## Checking the script integrity hash
@@ -432,7 +434,6 @@ mode up front rather than deciding both.
     in
 
     ∙ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ [])
-    ∙ ¬ (UsesBootstrapAddress (UTxOOf Γ) txTop)
     ∙ ∀[ g ∈ GuardsOf txTop ] IsKeyHashObj g     -- (4)
     ∙ Is-∅ (dom txDirectDeposits)                -- (5)
     ∙ Is-∅ (dom txBalanceIntervals)              -- (6)
@@ -444,7 +445,7 @@ mode up front rather than deciding both.
     ∙ scriptHashesNeeded ⊆ mapˢ hash scriptsProvided
     ∙ dataHashesNeededSpendInputs ⊆ dataHashesProvided
     ∙ dataHashesProvided ⊆ dataHashesNeededSpendInputs ∪ dataHashesOutputs ∪ dataHashesReferenceInputs
-    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguagesLegacyMode txTop (UTxOOf Γ)
+    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ (allowedLanguagesLegacyMode txTop (UTxOOf Γ) ∪ ❴ PlutusV4 ❵)
     ∙ txADhash ≡ map hash txAuxData
     ∙ (Γ , true) ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
       ────────────────────────────────
@@ -457,7 +458,7 @@ unquoteDecl UTXOW-normal-premises = genPremises UTXOW-normal-premises (quote UTX
 unquoteDecl UTXOW-legacy-premises = genPremises UTXOW-legacy-premises (quote UTXOW-legacy)
 unquoteDecl SUBUTXOW-premises = genPremises SUBUTXOW-premises (quote SUBUTXOW)
 pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)
-pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , h)
+pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)
 pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -110,7 +110,7 @@ allowedLanguagesLegacy tx utxo =
   if UsesBootstrapAddress utxo tx
     then ∅
   else if UsesV4Features tx
-    then fromList (PlutusV4 ∷ [])
+    then ∅
   else if UsesV3Features tx
     then fromList (PlutusV4 ∷ PlutusV3 ∷ [])
   else if UsesV2Features tx utxo

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -58,11 +58,9 @@ module _ (tx : TopLevelTx) where
     hasTreasure  : Is-just (CurrentTreasuryOf tx)       → UsesV3Features
 
   data UsesV4Features : Set where
-    hasSubtransactions   : ¬ Is-[] (SubTransactionsOf tx)        → UsesV4Features
-    hasGuards            : ¬ Is-∅ (GuardsOf tx)                  → UsesV4Features
+    hasScriptGuards      : ¬ (∀[ g ∈ GuardsOf tx ] IsKeyHashObj g) → UsesV4Features
     hasDirectDeposits    : ¬ Is-∅ (dom (DirectDepositsOf tx))    → UsesV4Features
     hasBalanceIntervals  : ¬ Is-∅ (dom (BalanceIntervalsOf tx))  → UsesV4Features
-
 ```
 
 <!--
@@ -82,47 +80,50 @@ module _ {tx : TopLevelTx} where
 
 module _ {tx : TopLevelTx} where
   open Tx tx
-  -- open TxBody txBody
 
   instance
     Dec-UsesV4Features : UsesV4Features tx ⁇
     Dec-UsesV4Features .dec
-      with ¿ ¬ Is-[] (SubTransactionsOf tx) ¿ | ¿ ¬ Is-∅ (GuardsOf tx) ¿
+      with ¿ ¬ (∀[ g ∈ GuardsOf tx ] IsKeyHashObj g) ¿
          | ¿ ¬ Is-∅ (dom (DirectDepositsOf tx)) ¿ | ¿ ¬ Is-∅ (dom (BalanceIntervalsOf tx)) ¿
-    ... | yes p | _ | _ | _ = yes (hasSubtransactions p)
-    ... | _ | yes p | _ | _ = yes (hasGuards p)
-    ... | _ | _ | yes p | _ = yes (hasDirectDeposits p)
-    ... | _ | _ | _ | yes p = yes (hasBalanceIntervals p)
-    ... | no p₁ | no p₂ | no p₃ | no p₄
-      = no λ { (hasSubtransactions x) → p₁ x ; (hasGuards x) → p₂ x
-             ; (hasDirectDeposits x) → p₃ x ; (hasBalanceIntervals x) → p₄ x }
+    ... | yes p | _ | _ = yes (hasScriptGuards p)
+    ... | _ | yes p | _ = yes (hasDirectDeposits p)
+    ... | _ | _ | yes p = yes (hasBalanceIntervals p)
+    ... | no p₂ | no p₃ | no p₄
+      = no λ { (hasScriptGuards x) → p₂ x
+             ; (hasDirectDeposits x) → p₃ x
+             ; (hasBalanceIntervals x) → p₄ x }
 ```
 -->
 
-CIP-159 fields (`txDirectDeposits`{.AgdaField} and `txBalanceIntervals`{.AgdaField})
-require at least PlutusV4 and are explicitly forbidden in legacy mode via the
-`Is-∅ (dom txDirectDeposits)` and `Is-∅ (dom txBalanceIntervals)` premises in
-`UTXOW-legacy`.  This follows the same pattern as `Is-∅ (GuardsOf txTop)` for guard
-scripts.
-
-When backward compatibility with older Plutus scripts (v1–v3) is needed, CIP-159
-fields can appear in sub-transactions while older scripts run at the top level
-(the CIP-118 escape hatch).
+The set of languages allowed in phase-2 scripts within a transaction
+depends on (1) the operation mode (see
+[below](sec:the-utxow-transition-system)), and (2) the features of a
+transaction and their compatibility with Plutus versions.
 
 ```agda
 languages :  ℙ P2Script → ℙ Language
 languages p2Scripts = mapˢ language p2Scripts
 
-allowedLanguagesLegacyMode : TopLevelTx → UTxO → ℙ Language
-allowedLanguagesLegacyMode tx utxo =
+allowedLanguagesLegacy : TopLevelTx → UTxO → ℙ Language
+allowedLanguagesLegacy tx utxo =
   if UsesBootstrapAddress utxo tx
     then ∅
+  else if UsesV4Features tx
+    then fromList (PlutusV4 ∷ [])
   else if UsesV3Features tx
-    then fromList (PlutusV3 ∷ [])
+    then fromList (PlutusV4 ∷ PlutusV3 ∷ [])
   else if UsesV2Features tx utxo
-    then fromList (PlutusV3 ∷ PlutusV2 ∷ [])
+    then fromList (PlutusV4 ∷ PlutusV3 ∷ PlutusV2 ∷ [])
   else
-    fromList (PlutusV3 ∷ PlutusV2 ∷ PlutusV1 ∷ [])
+    fromList (PlutusV4 ∷ PlutusV3 ∷ PlutusV2 ∷ PlutusV1 ∷ [])
+
+allowedLanguages : Tx ℓ → UTxO → ℙ Language
+allowedLanguages tx utxo =
+  if UsesBootstrapAddress utxo tx
+    then ∅
+  else
+    fromList (PlutusV4 ∷ [])
 ```
 
 ## Checking the script integrity hash
@@ -168,8 +169,6 @@ instance
 ## The <span class="AgdaDatatype">SUBUTXOW</span> Transition System {#sec:the-subutxow-transition-system}
 
 1. All needed phase-2 scripts use Plutus language V4.
-
-2. Sub-transactions cannot reference or use bootstrap addresses
 
 3. Required top-level guards are well-formed. If the credential is a
    `KeyHash`{.AgdaDatatype} or a phase-1 script, then no datum should
@@ -237,13 +236,12 @@ data _⊢_⇀⦇_,SUBUTXOW⦈_ : SubUTxOEnv → UTxOState → SubLevelTx → UTx
     ∙ ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ
     ∙ ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided (GuardsOf txSub) txVldt s
     ∙ ∀[ tlg ∈ TopLevelGuardsOf txSub ] TopLevelGuardWellFormed scriptsProvided tlg -- (3)
-    ∙ (¬ UsesBootstrapAddress utxo₀ txSub) -- (2)
     ∙ vKeyHashesNeeded ⊆ vKeyHashesProvided
     ∙ scriptHashesNeeded ⊆ mapˢ hash scriptsProvided
     ∙ dataHashesNeededSpendInputs ⊆ dataHashesProvided
     ∙ dataHashesProvided ⊆ dataHashesNeededSpendInputs ∪ dataHashesOutputs ∪ dataHashesReferenceInputs
     ∙ dom txRedeemers ≡ᵉ scriptRedeemerPtrs
-    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ ❴ PlutusV4 ❵ -- (1)
+    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguages txSub utxo₀
     ∙ txADhash ≡ map hash txAuxData
     ∙ scriptIntegrityHash ≡ hashScriptIntegrity (PParamsOf Γ) (languages p2ScriptsNeeded) txRedeemers txData
     ∙ Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXO⦈ s₁
@@ -270,10 +268,7 @@ mode up front rather than deciding both.
 
 1. All needed phase-2 scripts use Plutus language V4.
 
-2. If the top-level transaction uses or references bootstrap addresses then the
-   set of needed phase-2 scripts must be empty.
-
-3. The required top-level guards of subtransactions appear in the set of
+2. The required top-level guards of subtransactions appear in the set of
    guards at the top-level.
 
 ```agda
@@ -336,8 +331,7 @@ mode up front rather than deciding both.
     in
 
     ∙ ∀[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV4 ∷ []) -- (1)
-    ∙ (UsesBootstrapAddress (UTxOOf Γ) txTop → Is-∅ p2ScriptsNeeded) -- (2)
-    ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (3)
+    ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (2)
     ∙ ∀[ (vk , σ) ∈ TxWitnesses.vKeySigs (Tx.txWitnesses txTop) ] isSigned vk (txidBytes (TxIdOf txTop)) σ
     ∙ ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided (GuardsOf txTop) txVldt s
     ∙ vKeyHashesNeeded ⊆ vKeyHashesProvided
@@ -345,7 +339,7 @@ mode up front rather than deciding both.
     ∙ scriptHashesNeeded ⊆ mapˢ hash scriptsProvided
     ∙ dataHashesNeededSpendInputs ⊆ dataHashesProvided
     ∙ dataHashesProvided ⊆ dataHashesNeededSpendInputs ∪ dataHashesOutputs ∪ dataHashesReferenceInputs
-    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ ❴ PlutusV4 ❵ -- (1)
+    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguages txTop (UTxOOf Γ)
     ∙ txADhash ≡ map hash txAuxData
     ∙ (Γ , false) ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
       ────────────────────────────────
@@ -355,24 +349,10 @@ mode up front rather than deciding both.
 ### Legacy mode
 
 1. There is at least a needed phase-2 script with Plutus language version V1, V2
-   or V3.
+   or V3. Note that Plutus V4 scripts are allowed in legacy mode.
 
-2. The language of all needed phase-2 scripts is compatible with the features
-   used by the top-level transaction, (votes, proposals, inline datum, ...) (See
-   `allowedLanguagesLegacy`). Moreover, all needed phase-2 scripts use Plutus
-   language versions V1, V2, or V3.
-
-3. The top-level transaction does not use or reference bootstrap addresses (in
-   case it does, it is handled in normal mode).
-
-4. `Guards` only contains keyhashes, and, thus, all sub-transaction's
-   `requiredTopLevelGuards` contain only keyhashes. (`Guards` with
-   only keyhashes correspond to `reqSignerHashes` in pre-Dijkstra).
-
-5. The top-level transaction does not contain direct deposits (`txDirectDeposits` is empty).
-
-6. The top-level transaction does not contain balance interval assertions
-   (`txBalanceIntervals` is empty).
+2. The required top-level guards of subtransactions appear in the set of
+   guards at the top-level.
 
 ```agda
   UTXOW-legacy :
@@ -433,11 +413,8 @@ mode up front rather than deciding both.
 
     in
 
-    ∙ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ [])
-    ∙ ∀[ g ∈ GuardsOf txTop ] IsKeyHashObj g     -- (4)
-    ∙ Is-∅ (dom txDirectDeposits)                -- (5)
-    ∙ Is-∅ (dom txBalanceIntervals)              -- (6)
-    ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (3)
+    ∙ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) -- (1)
+    ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (2)
     ∙ ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes (TxIdOf txTop)) σ
     ∙ ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided (GuardsOf txTop) txVldt s
     ∙ vKeyHashesNeeded ⊆ vKeyHashesProvided
@@ -445,7 +422,7 @@ mode up front rather than deciding both.
     ∙ scriptHashesNeeded ⊆ mapˢ hash scriptsProvided
     ∙ dataHashesNeededSpendInputs ⊆ dataHashesProvided
     ∙ dataHashesProvided ⊆ dataHashesNeededSpendInputs ∪ dataHashesOutputs ∪ dataHashesReferenceInputs
-    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ (allowedLanguagesLegacyMode txTop (UTxOOf Γ) ∪ ❴ PlutusV4 ❵)
+    ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguagesLegacy txTop (UTxOOf Γ)
     ∙ txADhash ≡ map hash txAuxData
     ∙ (Γ , true) ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
       ────────────────────────────────
@@ -457,8 +434,8 @@ mode up front rather than deciding both.
 unquoteDecl UTXOW-normal-premises = genPremises UTXOW-normal-premises (quote UTXOW-normal)
 unquoteDecl UTXOW-legacy-premises = genPremises UTXOW-legacy-premises (quote UTXOW-legacy)
 unquoteDecl SUBUTXOW-premises = genPremises SUBUTXOW-premises (quote SUBUTXOW)
-pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)
-pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)
-pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)
+pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)
+pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)
+pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -93,8 +93,8 @@ instance
       computeProof-aux : DecV3 → Dec H-legacy → Dec H-normal
                        → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
       computeProof-aux (yes _) (no _) _ = failure "UTXOW"
-      computeProof-aux (yes _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ )) _ =
-        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , h)))
+      computeProof-aux (yes _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ )) _ =
+        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)))
             (UTXO.computeProof (Γ , true) s₀ txTop)
       computeProof-aux (no _) _ (no _) = failure "UTXOW"
       computeProof-aux (no _) _ (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁)) =
@@ -110,11 +110,11 @@ instance
                        → map proj₁ (computeProof-aux dV3 dLeg dNorm) ≡ success s₁
       completeness-aux (yes (s , p , q)) _ _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _) =
         ⊥-elim (Properties.∉-∅ (V1,V2,V3∩V4⊆∅ (∈-∩ .Equivalence.to (q , (p₀ p)))))
-      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
+      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
         ⊥-elim (¬p p₀)
-      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ _) =
-        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄))
-      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
+      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃))
+      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
         with UTXO.computeProof (Γ , true) s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
       completeness-aux (no _) _ (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ _) =

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -40,8 +40,8 @@ instance
 
       computeProof-aux : Dec H → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁))
       computeProof-aux (no ¬p) = failure "SUBUTXOW"
-      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁)) =
-          map (map₂′ (λ h → SUBUTXOW {txSub = txSub} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)))
+      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀)) =
+          map (map₂′ (λ h → SUBUTXOW {txSub = txSub} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)))
               (SUBUTXO.computeProof Γ s₀ txSub)
 
       computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁))
@@ -50,9 +50,9 @@ instance
       completeness-aux : (d : Dec H) (s₁ : UTxOState)
                        → Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁
                        → map proj₁ (computeProof-aux d) ≡ success s₁
-      completeness-aux (no ¬p) _ (SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h) =
-        ⊥-elim $ ¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁)
-      completeness-aux (yes _) _ (SUBUTXOW-⋯ _ _ _ _ _ _ _ _ _ _ _ _ h)
+      completeness-aux (no ¬p) _ (SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h) =
+        ⊥-elim $ ¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀)
+      completeness-aux (yes _) _ (SUBUTXOW-⋯ _ _ _ _ _ _ _ _ _ _ _ h)
         with SUBUTXO.computeProof Γ s₀ txSub | SUBUTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
 
@@ -93,12 +93,12 @@ instance
       computeProof-aux : DecV3 → Dec H-legacy → Dec H-normal
                        → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
       computeProof-aux (yes _) (no _) _ = failure "UTXOW"
-      computeProof-aux (yes _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ )) _ =
-        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)))
+      computeProof-aux (yes _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ )) _ =
+        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)))
             (UTXO.computeProof (Γ , true) s₀ txTop)
       computeProof-aux (no _) _ (no _) = failure "UTXOW"
-      computeProof-aux (no _) _ (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁)) =
-        map (map₂′ (λ h → UTXOW-normal {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)))
+      computeProof-aux (no _) _ (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀)) =
+        map (map₂′ (λ h → UTXOW-normal {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)))
             (UTXO.computeProof (Γ , false) s₀ txTop)
 
       computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
@@ -108,18 +108,18 @@ instance
                          (s₁ : UTxOState)
                        → Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁
                        → map proj₁ (computeProof-aux dV3 dLeg dNorm) ≡ success s₁
-      completeness-aux (yes (s , p , q)) _ _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _) =
+      completeness-aux (yes (s , p , q)) _ _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _) =
         ⊥-elim (Properties.∉-∅ (V1,V2,V3∩V4⊆∅ (∈-∩ .Equivalence.to (q , (p₀ p)))))
-      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
+      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _) =
         ⊥-elim (¬p p₀)
-      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ _) =
-        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃))
-      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
+      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ ))
+      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ h)
         with UTXO.computeProof (Γ , true) s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
-      completeness-aux (no _) _ (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ _) =
-        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁))
-      completeness-aux (no _) _ (yes _) _ (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _ _ h)
+      completeness-aux (no _) _ (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ ))
+      completeness-aux (no _) _ (yes _) _ (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _ h)
         with UTXO.computeProof (Γ , false) s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
 

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -40,8 +40,8 @@ instance
 
       computeProof-aux : Dec H → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁))
       computeProof-aux (no ¬p) = failure "SUBUTXOW"
-      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀)) =
-          map (map₂′ (λ h → SUBUTXOW {txSub = txSub} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , h)))
+      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁)) =
+          map (map₂′ (λ h → SUBUTXOW {txSub = txSub} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)))
               (SUBUTXO.computeProof Γ s₀ txSub)
 
       computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁))
@@ -50,9 +50,9 @@ instance
       completeness-aux : (d : Dec H) (s₁ : UTxOState)
                        → Γ ⊢ s₀ ⇀⦇ txSub ,SUBUTXOW⦈ s₁
                        → map proj₁ (computeProof-aux d) ≡ success s₁
-      completeness-aux (no ¬p) _ (SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ h) =
-        ⊥-elim $ ¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀)
-      completeness-aux (yes _) _ (SUBUTXOW-⋯ _ _ _ _ _ _ _ _ _ _ _ h)
+      completeness-aux (no ¬p) _ (SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h) =
+        ⊥-elim $ ¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁)
+      completeness-aux (yes _) _ (SUBUTXOW-⋯ _ _ _ _ _ _ _ _ _ _ _ _ h)
         with SUBUTXO.computeProof Γ s₀ txSub | SUBUTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
 


### PR DESCRIPTION
# Description

This PR refactors the logic about Plutus scripts use in normal and legacy mode.

In particular it refactors the `allowedLanguage` logic to take into account transaction features for both modes of operation.

It also adds a explicit (and redundant) precondition to SUBUTXO to check that all needed phase-2 scripts languages' are V4.

Closes #1192.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
