### PR TITLE
Change the type of DirectDeposits to have RewardAddress as its domain

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Account.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Account.lagda.md
@@ -30,7 +30,7 @@ receiving account address to a `Coin`{.AgdaDatatype} amount.
 
 ```agda
 DirectDeposits : Type
-DirectDeposits = Credential ⇀ Coin
+DirectDeposits = RewardAddress ⇀ Coin
 ```
 
 ## Balance Intervals {#sec:balance-intervals}

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -283,13 +283,25 @@ private variable
 ```
 -->
 
+<!--
+```agda
+applyToRewards : (Coin → Coin → Coin)
+  → (RewardAddress ⇀ Coin)
+  → Rewards
+  → Rewards
+applyToRewards f m rwds =
+  foldl (λ acc (addr , amt) → maybe (λ bal → ❴ stake addr , f bal amt ❵ ∪ˡ acc) acc (lookupᵐ? acc (stake addr)))
+        rwds
+        (setToList (m ˢ))
+```
+-->
 
 ```agda
 rewardsBalance : DState → Coin
 rewardsBalance ds = ∑[ x ← RewardsOf ds ] x
 
-applyDirectDeposits : DirectDeposits → DState → DState
-applyDirectDeposits dd ds = record ds { rewards = RewardsOf ds ∪⁺ dd }
+applyDirectDeposits : DirectDeposits → Rewards → Rewards
+applyDirectDeposits = applyToRewards _+_
 ```
 
 The `POST-CERT`{.AgdaDatatype} rule calls `applyDirectDeposits`{.AgdaFunction} to
@@ -298,19 +310,7 @@ processing.  See *Direct Deposit Application (CIP-159)* below for details.
 
 ```agda
 applyWithdrawals : Withdrawals → Rewards → Rewards
-applyWithdrawals wdrls rwds =
-  foldl applyOne rwds (setToList (wdrls ˢ))
-  where
-    -- For each withdrawal entry `(addr, amt)`, look up `stake addr` in the acc,
-    -- compute `bal ∸ amt`, create a singleton map with the new balance, and
-    -- merge it with the rest (complement-restricted, to remove the old entry).
-    applyOne : Rewards → RewardAddress × Coin → Rewards
-    applyOne acc (addr , amt) =
-      case lookupᵐ? acc (stake addr) of λ where
-        (just bal) → ❴ stake addr , bal ∸ amt ❵ ∪ˡ (acc ∣ ❴ stake addr ❵ ᶜ)
-        nothing    → acc
-        -- `nothing` case is defensive; the PRE-CERT precondition guarantees the
-        -- credential is registered, but handling it makes the function total.
+applyWithdrawals = applyToRewards _∸_
 ```
 
 In the Dijkstra era, CIP-159 allows **partial withdrawals**: a transaction may
@@ -532,9 +532,9 @@ data _⊢_⇀⦇_,POST-CERT⦈_ : CertEnv → CertState → ⊤ → CertState �
     let activeVDelegs = mapˢ vDelegCredential (dom (DRepsOf stᵍ))
                          ∪ fromList (vDelegNoConfidence ∷ vDelegAbstain ∷ [])
     in
-    ∙ dom dd ⊆ dom rewards
+    ∙ mapˢ stake (dom dd) ⊆ dom rewards
       ────────────────────────────────
-      ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , stᵍ ⟧ ⇀⦇ _ ,POST-CERT⦈ ⟦ ⟦ voteDelegs ∣^ activeVDelegs , stakeDelegs , rewards ∪⁺ dd , deposits ⟧ , stᵖ , stᵍ ⟧
+      ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , stᵍ ⟧ ⇀⦇ _ ,POST-CERT⦈ ⟦ ⟦ voteDelegs ∣^ activeVDelegs , stakeDelegs , applyDirectDeposits dd rewards , deposits ⟧ , stᵖ , stᵍ ⟧
 
 
 

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -283,20 +283,29 @@ private variable
 ```
 -->
 
-<!--
+Since it underpins both `applyDirectDeposits`{.AgdaFunction} and
+`applyWithdrawals`{.AgdaFunction}, the `applyToRewards`{.AgdaFunction} function
+bears explaining.  Given three arguments —
+a binary function `f` (e.g., addition or subtraction),
+a map `m` from `RewardAddress`{.AgdaDatatype} to `Coin`{.AgdaDatatype} (e.g.,
+direct deposits or withdrawals), and
+a `Rewards` map (of account balances) — for each `(addr , amt)`, the
+`applyToRewards`{.AgdaFunction} function does the following:
+
+1.  Look up `stake addr` in the accumulator.
+2.  If found with current balance `bal`, replace the entry with `(stake addr, f bal amt)`.
+    *Note*. since `∪ˡ` is left-biased, the fresh singleton wins at `stake addr` and all
+    other entries of `acc` are preserved; no explicit complement restriction is needed.
+3.  If not found (defensive; the caller's precondition will rule this out), return `acc`
+    unchanged; this keeps `applyToRewards` total.
+
 ```agda
-applyToRewards : (Coin → Coin → Coin)
-  → (RewardAddress ⇀ Coin)
-  → Rewards
-  → Rewards
+applyToRewards : (Coin → Coin → Coin) → (RewardAddress ⇀ Coin) → Rewards → Rewards
 applyToRewards f m rwds =
   foldl (λ acc (addr , amt) → maybe (λ bal → ❴ stake addr , f bal amt ❵ ∪ˡ acc) acc (lookupᵐ? acc (stake addr)))
         rwds
         (setToList (m ˢ))
-```
--->
 
-```agda
 rewardsBalance : DState → Coin
 rewardsBalance ds = ∑[ x ← RewardsOf ds ] x
 

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -21,6 +21,7 @@ import Data.Maybe.Relation.Unary.Any as M
 import Data.Maybe.Relation.Unary.All as M
 
 open GovStructure govStructure
+open RewardAddress
 open Inverse
 
 open Computational ⦃...⦄
@@ -182,7 +183,7 @@ instance
         p .proj₂ = refl
 
   Computational-POST-CERT : Computational _⊢_⇀⦇_,POST-CERT⦈_ String
-  Computational-POST-CERT .computeProof ce cs tt with ¿ dom (CertEnv.directDeposits ce) ⊆ dom (RewardsOf cs) ¿
+  Computational-POST-CERT .computeProof ce cs tt with ¿ mapˢ stake (dom (CertEnv.directDeposits ce)) ⊆ dom (RewardsOf cs) ¿
   ... | (no ¬p) = failure (genErrors ¬p)
   ... | (yes p) = success (cs' , CERT-post p)
     where
@@ -190,12 +191,12 @@ instance
       validVoteDelegs = VoteDelegsOf cs ∣^ (mapˢ vDelegCredential (dom (DRepsOf cs)) ∪ fromList (vDelegNoConfidence ∷ vDelegAbstain ∷ []) )
 
       newRewards : Rewards
-      newRewards = RewardsOf cs ∪⁺ CertEnv.directDeposits ce
+      newRewards = applyDirectDeposits (CertEnv.directDeposits ce) (RewardsOf cs)
 
       cs' : CertState
       cs' = ⟦ ⟦ validVoteDelegs , StakeDelegsOf cs , newRewards , DepositsOf (DStateOf cs) ⟧ , PStateOf cs , GStateOf cs ⟧
 
-  Computational-POST-CERT .completeness ce cs _ cs' (CERT-post p) with ¿ dom (CertEnv.directDeposits ce) ⊆ dom (RewardsOf cs) ¿
+  Computational-POST-CERT .completeness ce cs _ cs' (CERT-post p) with ¿ mapˢ stake (dom (CertEnv.directDeposits ce)) ⊆ dom (RewardsOf cs) ¿
   ... | yes _ = refl
   ... | no ¬p = ⊥-elim (¬p p)
 

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -48,6 +48,7 @@ import Data.List.Relation.Unary.AllPairs as List
 import Data.List.Relation.Unary.Any as List
 import Data.Sum.Relation.Unary.All as Sum
 
+open RewardAddress
 
 totExUnits : ∀{ℓ} → Tx ℓ → ExUnits
 totExUnits tx = ∑[ (_ , eu) ← RedeemersOf tx ] eu
@@ -503,9 +504,10 @@ data _⊢_⇀⦇_,SUBUTXO⦈_ : SubUTxOEnv → UTxOState → SubLevelTx → UTxO
     ∙ ∀[ (a , _) ∈ range (TxOutsOf txSub) ] (Sum.All (const ⊤) (λ a → AttrSizeOf a ≤ maxBootstrapAddrSize) a)
     ∙ ∀[ (a , _) ∈ range (TxOutsOf txSub) ] (netId a ≡ NetworkId)
     ∙ ∀[ a ∈ dom (WithdrawalsOf txSub)] (NetworkIdOf a ≡ NetworkId)
+    ∙ ∀[ a ∈ dom (DirectDepositsOf txSub)] (NetworkIdOf a ≡ NetworkId)
     ∙ MaybeNetworkIdOf txSub ~ just NetworkId
     ∙ CurrentTreasuryOf txSub ~ just (TreasuryOf Γ)
-    ∙ dom (DirectDepositsOf txSub) ⊆ dom (AccountBalancesOf Γ)
+    ∙ mapˢ stake (dom (DirectDepositsOf txSub)) ⊆ dom (AccountBalancesOf Γ)
     ∙ dom (BalanceIntervalsOf txSub) ⊆ dom (AccountBalancesOf Γ)
     ∙ ∀[ (c , interval) ∈ BalanceIntervalsOf txSub ˢ ]
         (InBalanceInterval (maybe id 0 (lookupᵐ? (AccountBalancesOf Γ) c)) interval)
@@ -566,9 +568,10 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
     ∙ ∀[ (a , _) ∈ range (TxOutsOf txTop) ] (Sum.All (const ⊤) (λ a → AttrSizeOf a ≤ maxBootstrapAddrSize)) a
     ∙ ∀[ (a , _) ∈ range (TxOutsOf txTop) ] (netId a ≡ NetworkId)
     ∙ ∀[ a ∈ dom (WithdrawalsOf txTop)] NetworkIdOf a ≡ NetworkId
+    ∙ ∀[ a ∈ dom (DirectDepositsOf txTop)] (NetworkIdOf a ≡ NetworkId)
     ∙ MaybeNetworkIdOf txTop ~ just NetworkId
     ∙ CurrentTreasuryOf txTop  ~ just (TreasuryOf Γ)
-    ∙ dom (DirectDepositsOf txTop) ⊆ dom (AccountBalancesOf Γ)
+    ∙ mapˢ stake (dom (DirectDepositsOf txTop)) ⊆ dom (AccountBalancesOf Γ)
     ∙ dom (BalanceIntervalsOf txTop) ⊆ dom (AccountBalancesOf Γ)
     ∙ ∀[ (c , interval) ∈ BalanceIntervalsOf txTop ˢ ]
         (InBalanceInterval (maybe id 0 (lookupᵐ? (AccountBalancesOf Γ) c)) interval)
@@ -584,8 +587,8 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
 <!--
 ```agda
 unquoteDecl UTXO-premises = genPremises UTXO-premises (quote UTXO)
-pattern UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ p₂₁ h
-  = UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , h)
+pattern UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ p₂₁ p₂₂ h
+  = UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , p₂₂ , h)
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Utxo/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo/Properties/Computational.lagda.md
@@ -130,30 +130,30 @@ instance
       ... | false | [ refl ]
         with H?
       ... | (no ¬p) = failure "UTXO" -- (genErrors ¬p)
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)
+      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , p₂₂)
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop
-      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , proj₂ h))
+      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , p₂₂ , proj₂ h))
       ... | failure ¬h = failure "UTXOS"
       computeProof | true | [ refl ]
         with H?
       ... | (no ¬p) = failure "UTXO" -- (genErrors ¬p)
-      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)
+      ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , p₂₂)
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop
-      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , proj₂ h))
+      ... | success h = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , p₂₂ , proj₂ h))
       ... | failure ¬h = failure "UTXOS"
 
       completeness : ∀ s₁ → Γ,legacyMode ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁ → map proj₁ computeProof ≡ success s₁
-      completeness s₁ (UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ p₂₁ h)
+      completeness s₁ (UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ p₁₈ p₁₉ p₂₀ p₂₁ p₂₂ h)
         with IsValidFlagOf txTop | inspect IsValidFlagOf txTop
       ... | false | [ refl ]
         with H?
-      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)))
+      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , p₂₂)))
       ... | yes _
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop | UTXOS.completeness _ _ _ _ h
       ... | success h | refl = refl
-      completeness s₁ (UTXO-⋯ p₀  p₁  p₂  p₃  p₄  p₅  p₆  p₇  p₈  p₉  p₁₀  p₁₁  p₁₂  p₁₃  p₁₄  p₁₅  p₁₆  p₁₇  p₁₈ p₁₉ p₂₀ p₂₁ h) | true | [ refl ]
+      completeness s₁ (UTXO-⋯ p₀  p₁  p₂  p₃  p₄  p₅  p₆  p₇  p₈  p₉  p₁₀  p₁₁  p₁₂  p₁₃  p₁₄  p₁₅  p₁₆  p₁₇  p₁₈ p₁₉ p₂₀ p₂₁ p₂₂ h) | true | [ refl ]
         with H?
-      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁)))
+      ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , p₁₈ , p₁₉ , p₂₀ , p₂₁ , p₂₂)))
       ... | yes _
         with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop | UTXOS.completeness _ _ _ _ h
       ... | success h | refl = refl


### PR DESCRIPTION
# Description

This aligns its type with that of Withdrawals.

In addition, it adds a precondition to UTXO to check that the NetworkId of DirectDeposits aligns with the global constant (like for Withdrawals)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
