### PR TITLE
Add ENTITIES rule

### DIFF
--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
@@ -23,6 +23,8 @@ import MAlonzo.Code.Ledger.Dijkstra.Foreign.Chain             as X
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Certs             as X
   ( StakePoolParams(..), PState(..), DelegEnv(..), CertEnv(..), DState(..), DCert(..), GState(..)
   , delegStep, govCertStep, poolStep)
+import MAlonzo.Code.Ledger.Dijkstra.Foreign.Entities          as X
+  (entitiesStep)
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Enact             as X
   (EnactState(..), EnactEnv(..), enactStep)
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Epoch             as X

--- a/build-tools/static/mkdocs/mkdocs.yml
+++ b/build-tools/static/mkdocs/mkdocs.yml
@@ -225,7 +225,6 @@ nav:
     - Properties: Ledger.Dijkstra.Specification.Certs.Properties.md
     - Properties/:
       - Computational: Ledger.Dijkstra.Specification.Certs.Properties.Computational.md
-
   - Chain: Ledger.Dijkstra.Specification.Chain.md
   - Chain/:
     - Properties: Ledger.Dijkstra.Specification.Chain.Properties.md
@@ -236,7 +235,11 @@ nav:
     - Properties: Ledger.Dijkstra.Specification.Enact.Properties.md
     - Properties/:
       - Computational: Ledger.Dijkstra.Specification.Enact.Properties.Computational.md
-
+  - Entities: Ledger.Dijkstra.Specification.Entities.md
+  - Entities/:
+    - Properties: Ledger.Dijkstra.Specification.Entities.Properties.md
+    - Properties/:
+      - Computational: Ledger.Dijkstra.Specification.Entities.Properties.Computational.md
   - Epoch: Ledger.Dijkstra.Specification.Epoch.md
   - Epoch/:
     - Properties: Ledger.Dijkstra.Specification.Epoch.Properties.md

--- a/src/Ledger/Dijkstra/Foreign.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign.lagda.md
@@ -6,6 +6,7 @@ source_path: src/Ledger/Dijkstra/Foreign.lagda.md
 module Ledger.Dijkstra.Foreign where
 
 open import Ledger.Dijkstra.Foreign.Cert public
+open import Ledger.Dijkstra.Foreign.Entities public
 open import Ledger.Dijkstra.Foreign.Chain public
 open import Ledger.Dijkstra.Foreign.Certs public
 open import Ledger.Dijkstra.Foreign.Enact public

--- a/src/Ledger/Dijkstra/Foreign/Entities.lagda.md
+++ b/src/Ledger/Dijkstra/Foreign/Entities.lagda.md
@@ -1,0 +1,29 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Foreign/Entities.lagda.md
+---
+```agda
+module Ledger.Dijkstra.Foreign.Entities where
+
+open import Foreign.Convertible
+open import Foreign.Convertible.Deriving
+open import Foreign.HaskellTypes
+open import Foreign.HaskellTypes.Deriving
+
+open import Ledger.Prelude
+open import Ledger.Prelude.Foreign.HSTypes
+
+open import Ledger.Core.Foreign.Address
+open import Ledger.Dijkstra.Foreign.HSStructures
+open import Ledger.Dijkstra.Foreign.Gov.Core
+open import Ledger.Dijkstra.Foreign.PParams
+open import Ledger.Dijkstra.Foreign.Cert
+open import Ledger.Dijkstra.Specification.Entities.Properties.Computational DummyGovStructure
+
+open Computational
+
+entities-step : HsType (CertEnv → CertState → List DCert → ComputationResult String CertState)
+entities-step = to (compute Computational-ENTITIES)
+
+{-# COMPILE GHC entities-step as entitiesStep #-}
+```

--- a/src/Ledger/Dijkstra/Specification.lagda.md
+++ b/src/Ledger/Dijkstra/Specification.lagda.md
@@ -63,6 +63,12 @@ import Ledger.Dijkstra.Specification.Enact
 import Ledger.Dijkstra.Specification.Enact.Properties
 ```
 
+## Entities
+
+```agda
+import Ledger.Dijkstra.Specification.Entities
+import Ledger.Dijkstra.Specification.Entities.Properties
+```
 ## <span class="AgdaModule">Epoch</span>
 
 ```agda

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -171,9 +171,23 @@ record HasCertState {a} (A : Type a) : Type a where
   field CertStateOf : A → CertState
 open HasCertState ⦃...⦄ public
 
+record HasEpoch {a} (A : Type a) : Type a where
+  field EpochOf : A → Epoch
+open HasEpoch ⦃...⦄ public
+
+record HasVotes {a} (A : Type a) : Type a where
+  field VotesOf : A → List GovVote
+open HasVotes ⦃...⦄ public
+
 instance
   HasPParams-CertEnv : HasPParams CertEnv
   HasPParams-CertEnv .PParamsOf = CertEnv.pp
+
+  HasEpoch-CertEnv : HasEpoch CertEnv
+  HasEpoch-CertEnv .EpochOf = CertEnv.epoch
+
+  HasVotes-CertEnv : HasVotes CertEnv
+  HasVotes-CertEnv .VotesOf = CertEnv.votes
 
   HasWithdrawals-CertEnv : HasWithdrawals CertEnv
   HasWithdrawals-CertEnv .WithdrawalsOf = CertEnv.wdrls
@@ -298,7 +312,7 @@ instance
 ```
 -->
 
-## Auxiliary Transition Systems
+# Auxiliary Transition Systems
 
 ## `DELEG`{.AgdaDatatype} Transition System
 

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -32,8 +32,6 @@ record StakePoolParams : Type where
     pledge          : Coin
     rewardAccount   : Credential
 
--- Miscellaneous Type Aliases
-
 CCHotKeys : Type
 CCHotKeys = Credential ⇀ Maybe Credential
 
@@ -63,7 +61,6 @@ Stake = Credential ⇀ Coin
 StakeDelegs : Type
 StakeDelegs = Credential ⇀ KeyHash
 
--- Delegation Definitions
 data DCert : Type where
   delegate    : Credential → Maybe VDeleg → Maybe KeyHash → Coin → DCert
   dereg       : Credential → Maybe Coin → DCert
@@ -283,53 +280,10 @@ private variable
 ```
 -->
 
-Since it underpins both `applyDirectDeposits`{.AgdaFunction} and
-`applyWithdrawals`{.AgdaFunction}, the `applyToRewards`{.AgdaFunction} function
-bears explaining.  Given three arguments —
-a binary function `f` (e.g., addition or subtraction),
-a map `m` from `RewardAddress`{.AgdaDatatype} to `Coin`{.AgdaDatatype} (e.g.,
-direct deposits or withdrawals), and
-a `Rewards` map (of account balances) — for each `(addr , amt)`, the
-`applyToRewards`{.AgdaFunction} function does the following:
-
-1.  Look up `stake addr` in the accumulator.
-2.  If found with current balance `bal`, replace the entry with `(stake addr, f bal amt)`.
-    *Note*. since `∪ˡ` is left-biased, the fresh singleton wins at `stake addr` and all
-    other entries of `acc` are preserved; no explicit complement restriction is needed.
-3.  If not found (defensive; the caller's precondition will rule this out), return `acc`
-    unchanged; this keeps `applyToRewards` total.
-
 ```agda
-applyToRewards : (Coin → Coin → Coin) → (RewardAddress ⇀ Coin) → Rewards → Rewards
-applyToRewards f m rwds =
-  foldl (λ acc (addr , amt) → maybe (λ bal → ❴ stake addr , f bal amt ❵ ∪ˡ acc) acc (lookupᵐ? acc (stake addr)))
-        rwds
-        (setToList (m ˢ))
-
 rewardsBalance : DState → Coin
 rewardsBalance ds = ∑[ x ← RewardsOf ds ] x
-
-applyDirectDeposits : DirectDeposits → Rewards → Rewards
-applyDirectDeposits = applyToRewards _+_
 ```
-
-The `POST-CERT`{.AgdaDatatype} rule calls `applyDirectDeposits`{.AgdaFunction} to
-credit each transaction's direct deposits to its account balances after certificate
-processing.  See *Direct Deposit Application (CIP-159)* below for details.
-
-```agda
-applyWithdrawals : Withdrawals → Rewards → Rewards
-applyWithdrawals = applyToRewards _∸_
-```
-
-In the Dijkstra era, CIP-159 allows **partial withdrawals**: a transaction may
-withdraw any amount up to the current account balance.
-`applyWithdrawals`{.AgdaFunction} subtracts each withdrawal amount from the
-corresponding account balance.  Full withdrawals remain valid as a special case
-(where the withdrawn amount equals the balance, leaving a zero balance).
-
-The `PRE-CERT`{.AgdaDatatype} rule calls `applyWithdrawals`{.AgdaFunction}
-to process withdrawals as part of certificate processing.
 
 <!--
 ```agda
@@ -344,8 +298,11 @@ instance
 ```
 -->
 
+## Auxiliary Transition Systems
+
+## `DELEG`{.AgdaDatatype} Transition System
+
 ```agda
--- Auxiliary DELEG transition system --
 data _⊢_⇀⦇_,DELEG⦈_ : DelegEnv → DState → DCert → DState → Type where
 
   DELEG-delegate :
@@ -367,8 +324,11 @@ data _⊢_⇀⦇_,DELEG⦈_ : DelegEnv → DState → DCert → DState → Type 
 
 isPoolRegistered : Pools -> KeyHash -> Maybe StakePoolParams
 isPoolRegistered ps kh = lookupᵐ? ps kh
+```
 
--- Auxiliary POOL transition system --
+## `POOL`{.AgdaDatatype} Transition System
+
+```agda
 data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type where
 
   POOL-reg :
@@ -411,9 +371,11 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
          , ❴ kh , e ❵ ∪ˡ retiring
          , deposits
          ⟧
+```
 
+## `GOVCERT`{.AgdaDatatype} Transition System
 
--- Auxiliary GOVCERT transition system --
+```agda
 data _⊢_⇀⦇_,GOVCERT⦈_ : CertEnv → GState → DCert → GState → Type where
 
   GOVCERT-regdrep :
@@ -432,8 +394,11 @@ data _⊢_⇀⦇_,GOVCERT⦈_ : CertEnv → GState → DCert → GState → Type
     ∙ c ∈ cc
       ────────────────────────────────
       ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ dReps , ccKeys , deposits ⟧ ⇀⦇ ccreghot c mc ,GOVCERT⦈ ⟦ dReps , ❴ c , mc ❵ ∪ˡ ccKeys , deposits ⟧
+```
 
--- CERT Transition System --
+# `CERT`{.AgdaDatatype} Transition System
+
+```agda
 data _⊢_⇀⦇_,CERT⦈_  : CertEnv → CertState → DCert → CertState → Type where
 
   CERT-deleg :
@@ -452,103 +417,9 @@ data _⊢_⇀⦇_,CERT⦈_  : CertEnv → CertState → DCert → CertState → 
       Γ ⊢ ⟦ stᵈ , stᵖ , stᵍ ⟧ ⇀⦇ dCert ,CERT⦈ ⟦ stᵈ , stᵖ , stᵍ' ⟧
 ```
 
-## The <span class="AgdaDatatype">PRE-CERT</span> Transition Rule
-
-### Withdrawal Processing
-
-The `PRE-CERT`{.AgdaDatatype} rule processes withdrawals before certificate
-evaluation.  In the Dijkstra era, CIP-159 extends the withdrawal semantics from an
-"all-or-nothing" model (where the withdrawn amount must equal the full account
-balance) to a "partial withdrawal" model (where any amount up to the full balance
-may be withdrawn).
-
-The precondition checks that each withdrawal targets a registered account and that
-the withdrawal amount does not exceed the account's current balance.  The effect
-subtracts the withdrawal amounts from the corresponding account balances via
-`applyWithdrawals`{.AgdaFunction}.
-
-<!--
-```agda
-open GovVote using (voter)
-```
--->
+# `CERTS`{.AgdaDatatype} Transition System
 
 ```agda
-data _⊢_⇀⦇_,PRE-CERT⦈_ : CertEnv → CertState → ⊤ → CertState → Type where
-
-  CERT-pre :
-    let refresh         = mapPartial (isGovVoterDRep ∘ voter) (fromList vs)
-        refreshedDReps  = mapValueRestricted (const (e + pp .drepActivity)) dReps refresh
-        wdrlCreds       = mapˢ stake (dom wdrls)
-    in
-    ∙ filter isKeyHash wdrlCreds ⊆ dom voteDelegs
-    ∙ wdrlCreds ⊆ dom rewards
-    ∙ ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rewards (stake addr))
-      ────────────────────────────────
-      ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , ⟦ dReps , ccHotKeys , deposits' ⟧ ⟧ ⇀⦇ _ ,PRE-CERT⦈ ⟦ ⟦ voteDelegs , stakeDelegs , applyWithdrawals wdrls rewards , deposits ⟧ , stᵖ , ⟦ refreshedDReps , ccHotKeys , deposits' ⟧ ⟧
-```
-
-**TODO**: Version restriction (deferred).  CIP-159 specifies that partial withdrawals are
-only permitted in transactions without Plutus v1–v3 scripts (i.e., `legacyMode ≡ false`).
-Enforcing this requires threading `legacyMode` into `CertEnv`, which in turn requires
-changes to the `SUBLEDGER` and `LEDGER` rules.  This restriction will be added in a
-follow-up issue.
-
-## The <span class="AgdaDatatype">POST-CERT</span> Transition Rule
-
-### Direct Deposit Application (CIP-159)
-
-The `POST-CERT`{.AgdaDatatype} rule applies CIP-159 direct deposits to the
-threaded `CertState`{.AgdaRecord} after all individual `CERT`{.AgdaDatatype} steps
-for the transaction have run, alongside its existing `voteDelegs`{.AgdaField}
-filtering.  Specifically:
-
-+  `voteDelegs`{.AgdaField} is restricted to credentials that delegate to a
-   currently-registered `DRep`{.AgdaInductiveConstructor} (or to the abstain /
-   no-confidence pseudo-DReps).
-+  `rewards`{.AgdaField} is augmented by `directDeposits`{.AgdaField} via
-   `∪⁺`{.AgdaFunction} (union with addition) — equivalently,
-   `applyDirectDeposits directDeposits` is applied to the threaded
-   `DState`{.AgdaRecord}.
-
-The premise `dom directDeposits ⊆ dom rewards` ensures that
-`applyDirectDeposits`{.AgdaFunction} does not silently re-introduce a credential
-into `rewards`{.AgdaField} that was deregistered earlier in the same
-transaction's `CERT`{.AgdaDatatype} steps (and is therefore no longer present in
-`voteDelegs`{.AgdaField}, `stakeDelegs`{.AgdaField}, or `deposits`{.AgdaField}),
-which would produce an inconsistent `DState`{.AgdaRecord}.  The check is
-performed against the post-`CERT`{.AgdaDatatype} `rewards`{.AgdaField} of the
-*same* transaction, so deregistrations performed by *prior* sub-transactions in
-the same batch are correctly accounted for: a sub-transaction whose deposit
-targets a credential deregistered earlier in the batch will fail this premise.
-
-The phantom-asset prohibition of CIP-159 — that withdrawals in one
-sub-transaction may not draw from deposits made by an earlier sub-transaction in
-the same batch — is enforced separately in the `Utxo`{.AgdaModule} module by the
-`NoPhantomWithdrawals`{.AgdaFunction} predicate, which bounds *batch-wide*
-withdrawal totals (per reward address) by the `accountBalances`{.AgdaField} field
-of `UTxOEnv`{.AgdaRecord} / `SubUTxOEnv`{.AgdaRecord} — the *pre-batch* snapshot
-`RewardsOf certState₀`{.AgdaBound}.  Because `accountBalances`{.AgdaField} is
-fixed at the pre-batch value and never updated by direct deposit application,
-the phantom-asset prohibition holds regardless of the per-transaction
-`rewards`{.AgdaField} updates done by `POST-CERT`{.AgdaDatatype}.
-
-
-```agda
-data _⊢_⇀⦇_,POST-CERT⦈_ : CertEnv → CertState → ⊤ → CertState → Type where
-
-  CERT-post :
-    let activeVDelegs = mapˢ vDelegCredential (dom (DRepsOf stᵍ))
-                         ∪ fromList (vDelegNoConfidence ∷ vDelegAbstain ∷ [])
-    in
-    ∙ mapˢ stake (dom dd) ⊆ dom rewards
-      ────────────────────────────────
-      ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs , stakeDelegs , rewards , deposits ⟧ , stᵖ , stᵍ ⟧ ⇀⦇ _ ,POST-CERT⦈ ⟦ ⟦ voteDelegs ∣^ activeVDelegs , stakeDelegs , applyDirectDeposits dd rewards , deposits ⟧ , stᵖ , stᵍ ⟧
-
-
-
--- CERTS Transition System --
-
 _⊢_⇀⦇_,CERTS⦈_  : CertEnv → CertState  → List DCert  → CertState  → Type
-_⊢_⇀⦇_,CERTS⦈_ = RunTraceAfterAndThen _⊢_⇀⦇_,PRE-CERT⦈_ _⊢_⇀⦇_,CERT⦈_ _⊢_⇀⦇_,POST-CERT⦈_
+_⊢_⇀⦇_,CERTS⦈_ = ReflexiveTransitiveClosure {sts = _⊢_⇀⦇_,CERT⦈_}
 ```

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -166,40 +166,6 @@ instance
     with computeProof Γ (CertState.gState cs) dCert | completeness _ _ _ _ h
   ... | success _ | refl = refl
 
-
-  Computational-PRE-CERT : Computational _⊢_⇀⦇_,PRE-CERT⦈_ String
-  Computational-PRE-CERT .computeProof ce cs _ =
-    case ¿  filterˢ isKeyHash (mapˢ CredentialOf (dom (WithdrawalsOf ce))) ⊆ dom (VoteDelegsOf cs)
-            × mapˢ CredentialOf (dom (WithdrawalsOf ce)) ⊆ dom (RewardsOf cs)
-            × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (CredentialOf addr))  ¿
-    of λ where
-      (yes p) → success (-, CERT-pre p)
-      (no ¬p) → failure (genErrors ¬p)
-
-  Computational-PRE-CERT .completeness ce st _ st' (CERT-pre p) rewrite
-    dec-yes ¿  filterˢ isKeyHash (mapˢ CredentialOf (dom (WithdrawalsOf ce))) ⊆ dom (VoteDelegsOf st)
-               × mapˢ CredentialOf (dom (WithdrawalsOf ce)) ⊆ dom (RewardsOf st)
-               × ∀[ (addr , amt) ∈ WithdrawalsOf ce ˢ ] amt ≤ maybe id 0 (lookupᵐ? (RewardsOf st) (CredentialOf addr))  ¿
-        p .proj₂ = refl
-
-  Computational-POST-CERT : Computational _⊢_⇀⦇_,POST-CERT⦈_ String
-  Computational-POST-CERT .computeProof ce cs tt with ¿ mapˢ stake (dom (CertEnv.directDeposits ce)) ⊆ dom (RewardsOf cs) ¿
-  ... | (no ¬p) = failure (genErrors ¬p)
-  ... | (yes p) = success (cs' , CERT-post p)
-    where
-      validVoteDelegs : VoteDelegs
-      validVoteDelegs = VoteDelegsOf cs ∣^ (mapˢ vDelegCredential (dom (DRepsOf cs)) ∪ fromList (vDelegNoConfidence ∷ vDelegAbstain ∷ []) )
-
-      newRewards : Rewards
-      newRewards = applyDirectDeposits (CertEnv.directDeposits ce) (RewardsOf cs)
-
-      cs' : CertState
-      cs' = ⟦ ⟦ validVoteDelegs , StakeDelegsOf cs , newRewards , DepositsOf (DStateOf cs) ⟧ , PStateOf cs , GStateOf cs ⟧
-
-  Computational-POST-CERT .completeness ce cs _ cs' (CERT-post p) with ¿ mapˢ stake (dom (CertEnv.directDeposits ce)) ⊆ dom (RewardsOf cs) ¿
-  ... | yes _ = refl
-  ... | no ¬p = ⊥-elim (¬p p)
-
 Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_ String
 Computational-CERTS = it
 ```

--- a/src/Ledger/Dijkstra/Specification/Entities.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities.lagda.md
@@ -3,7 +3,7 @@ source_branch: master
 source_path: src/Ledger/Dijkstra/Specification/Entities.lagda.md
 ---
 
-# Certificates {#sec:certificates}
+# Entities {#sec:entities}
 
 <!--
 ```agda
@@ -75,6 +75,12 @@ Premise (1) ensures that each withdrawal targets a registered
 account and that the withdrawal amount does not exceed the account's
 current balance.
 
+The phantom-asset prohibition of CIP-159 — that withdrawals in one
+sub-transaction may not draw from deposits made by an earlier
+sub-transaction in the same batch — is enforced separately in the
+`Utxo`{.AgdaModule} (see [Phantom Asset
+Prevention](Ledger.Dijkstra.Specification.Utxo.md#subsubsec:phantom-asset-prevention)).
+
 ## Direct Deposit Application (CIP-159)
 
 The `ENTITIES`{.AgdaDatatype} rule applies CIP-159 direct deposits to the
@@ -109,8 +115,7 @@ private variable
   voteDelegs₀ voteDelegs₁ : VoteDelegs
   wdrls : Withdrawals
   dd : DirectDeposits
-  A : Type
-  depositsᵍ depositsᵈ₀ depositsᵈ₁ : A ⇀ Coin
+  depositsᵍ depositsᵈ₀ depositsᵈ₁ : Credential ⇀ Coin
 
   dCerts : List DCert
   e : Epoch
@@ -137,8 +142,8 @@ data _⊢_⇀⦇_,ENTITIES⦈_ : CertEnv → CertState → List DCert → CertSt
     ∙ filter isKeyHash wdrlCreds ⊆ dom voteDelegs₀
     ∙ wdrlCreds ⊆ dom rewards₀
     ∙ ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rewards₀ (stake addr)) -- (1)
-    ∙ ddCreds ⊆ dom rewards₁ -- (2)
     ∙ ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs₀ , stakeDelegs₀ , applyWithdrawals wdrls rewards₀ , depositsᵈ₀ ⟧ , pState₀ , ⟦ refreshedDReps , ccHotKeys , depositsᵍ ⟧ ⟧ ⇀⦇ dCerts  ,CERTS⦈ ⟦ ⟦ voteDelegs₁ , stakeDelegs₁ , rewards₁ , depositsᵈ₁ ⟧ , pState₁ , gState₁ ⟧
+    ∙ ddCreds ⊆ dom rewards₁ -- (2)
       ────────────────────────────────
       ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs₀ , stakeDelegs₀ , rewards₀ , depositsᵈ₀ ⟧ , pState₀ , ⟦ dReps , ccHotKeys , depositsᵍ ⟧ ⟧ ⇀⦇ dCerts ,ENTITIES⦈ ⟦ ⟦ voteDelegs₁ ∣^ activeVDelegs , stakeDelegs₁ , applyDirectDeposits dd rewards₁ , depositsᵈ₁ ⟧ , pState₁ , gState₁ ⟧
 ```

--- a/src/Ledger/Dijkstra/Specification/Entities.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities.lagda.md
@@ -1,0 +1,144 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Entities.lagda.md
+---
+
+# Certificates {#sec:certificates}
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Gov.Base using (GovStructure)
+
+module Ledger.Dijkstra.Specification.Entities
+  (gs : GovStructure) (open GovStructure gs) where
+
+open import Ledger.Prelude renaming (filterˢ to filter)
+open import Ledger.Prelude.Numeric.UnitInterval
+open import Ledger.Dijkstra.Specification.Gov.Actions gs hiding (yes; no)
+open import Ledger.Dijkstra.Specification.Account gs
+open import Ledger.Dijkstra.Specification.Certs gs
+open RewardAddress
+open PParams
+```
+-->
+
+# Auxiliary Functions
+
+Since it underpins both `applyDirectDeposits`{.AgdaFunction} and
+`applyWithdrawals`{.AgdaFunction}, the `applyToRewards`{.AgdaFunction} function
+bears explaining.  Given three arguments —
+a binary function `f` (e.g., addition or subtraction),
+a map `m` from `RewardAddress`{.AgdaDatatype} to `Coin`{.AgdaDatatype} (e.g.,
+direct deposits or withdrawals), and
+a `Rewards` map (of account balances) — for each `(addr , amt)`, the
+`applyToRewards`{.AgdaFunction} function does the following:
+
+1.  Look up `stake addr` in the accumulator.
+2.  If found with current balance `bal`, replace the entry with `(stake addr, f bal amt)`.
+    *Note*. since `∪ˡ` is left-biased, the fresh singleton wins at `stake addr` and all
+    other entries of `acc` are preserved; no explicit complement restriction is needed.
+3.  If not found (defensive; the caller's precondition will rule this out), return `acc`
+    unchanged; this keeps `applyToRewards` total.
+
+```agda
+applyToRewards : (Coin → Coin → Coin) → (RewardAddress ⇀ Coin) → Rewards → Rewards
+applyToRewards f m rwds =
+  foldl (λ acc (addr , amt) → maybe (λ bal → ❴ stake addr , f bal amt ❵ ∪ˡ acc) acc (lookupᵐ? acc (stake addr)))
+        rwds
+        (setToList (m ˢ))
+
+applyDirectDeposits : DirectDeposits → Rewards → Rewards
+applyDirectDeposits = applyToRewards _+_
+
+applyWithdrawals : Withdrawals → Rewards → Rewards
+applyWithdrawals = applyToRewards _∸_
+```
+
+# `ENTITIES`{.AgdaDatatype} Transition System
+
+In Dijkstra, the `ENTITIES`{.AgdaDatatype} rule replaces pre-Dijkstra
+`CERTS`{.AgdaDatatype} rule. This rule processes withdrawals,
+certificates and direct deposits.
+
+## Withdrawal Processing
+
+The `ENTITIES`{.AgdaDatatype} rule applies withdrawals, via
+`applyWithdrawals`{.AgdaFunction} before certificate evaluation.  In
+the Dijkstra era, CIP-159 extends the withdrawal semantics from an
+"all-or-nothing" model (where the withdrawn amount must equal the full
+account balance) to a "partial withdrawal" model (where any amount up
+to the full balance may be withdrawn).
+
+Premise (1) ensures that each withdrawal targets a registered
+account and that the withdrawal amount does not exceed the account's
+current balance.
+
+## Direct Deposit Application (CIP-159)
+
+The `ENTITIES`{.AgdaDatatype} rule applies CIP-159 direct deposits to the
+`CertState`{.AgdaRecord} after all individual `CERT`{.AgdaDatatype} steps
+for the transaction have run, alongside its existing `voteDelegs`{.AgdaField}
+filtering. Specifically:
+
++  `voteDelegs`{.AgdaField} is restricted to credentials that delegate to a
+   currently-registered `DRep`{.AgdaInductiveConstructor} (or to the abstain /
+   no-confidence pseudo-DReps).
++  `rewards`{.AgdaField} is augmented by `directDeposits`{.AgdaField} via
+   `∪⁺`{.AgdaFunction} (union with addition) — equivalently,
+   `applyDirectDeposits directDeposits` is applied to the threaded
+   `DState`{.AgdaRecord}.
+
+Premise (2) ensures that `applyDirectDeposits`{.AgdaFunction} does not
+silently re-introduce a credential into `rewards`{.AgdaField} that was
+deregistered earlier in the same transaction's `CERT`{.AgdaDatatype}
+steps (and is therefore no longer present in `voteDelegs`{.AgdaField},
+`stakeDelegs`{.AgdaField}, or `deposits`{.AgdaField}), which would
+produce an inconsistent `DState`{.AgdaRecord}.
+
+<!--
+```agda
+open GovVote using (voter)
+
+private variable
+  rewards₀ rewards₁ : Rewards
+  dReps : DReps
+  stakeDelegs stakeDelegs₀ stakeDelegs₁ : StakeDelegs
+  ccHotKeys : CCHotKeys
+  voteDelegs₀ voteDelegs₁ : VoteDelegs
+  wdrls : Withdrawals
+  dd : DirectDeposits
+  A : Type
+  depositsᵍ depositsᵈ₀ depositsᵈ₁ : A ⇀ Coin
+
+  dCerts : List DCert
+  e : Epoch
+  vs : List GovVote
+  pp : PParams
+  cc : ℙ Credential
+
+  gState₁ : GState
+  pState₀ pState₁ : PState
+```
+-->
+
+```agda
+data _⊢_⇀⦇_,ENTITIES⦈_ : CertEnv → CertState → List DCert → CertState → Type where
+
+  ENTITIES :
+    let refresh         = mapPartial (isGovVoterDRep ∘ voter) (fromList vs)
+        refreshedDReps  = mapValueRestricted (const (e + pp .drepActivity)) dReps refresh
+        wdrlCreds       = mapˢ stake (dom wdrls)
+        ddCreds         = mapˢ stake (dom dd)
+        activeVDelegs   = mapˢ vDelegCredential (dom (DRepsOf gState₁))
+                               ∪ fromList (vDelegNoConfidence ∷ vDelegAbstain ∷ [])
+    in
+    ∙ filter isKeyHash wdrlCreds ⊆ dom voteDelegs₀
+    ∙ wdrlCreds ⊆ dom rewards₀
+    ∙ ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rewards₀ (stake addr)) -- (1)
+    ∙ ddCreds ⊆ dom rewards₁ -- (2)
+    ∙ ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs₀ , stakeDelegs₀ , applyWithdrawals wdrls rewards₀ , depositsᵈ₀ ⟧ , pState₀ , ⟦ refreshedDReps , ccHotKeys , depositsᵍ ⟧ ⟧ ⇀⦇ dCerts  ,CERTS⦈ ⟦ ⟦ voteDelegs₁ , stakeDelegs₁ , rewards₁ , depositsᵈ₁ ⟧ , pState₁ , gState₁ ⟧
+      ────────────────────────────────
+      ⟦ e , pp , vs , wdrls , cc , dd ⟧ ⊢ ⟦ ⟦ voteDelegs₀ , stakeDelegs₀ , rewards₀ , depositsᵈ₀ ⟧ , pState₀ , ⟦ dReps , ccHotKeys , depositsᵍ ⟧ ⟧ ⇀⦇ dCerts ,ENTITIES⦈ ⟦ ⟦ voteDelegs₁ ∣^ activeVDelegs , stakeDelegs₁ , applyDirectDeposits dd rewards₁ , depositsᵈ₁ ⟧ , pState₁ , gState₁ ⟧
+```

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties.lagda.md
@@ -1,0 +1,17 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Entities/Properties.lagda.md
+---
+
+# Properties Of Entities {#sec:properties-of-entities}
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+module Ledger.Dijkstra.Specification.Entities.Properties where
+```
+-->
+
+```agda
+open import Ledger.Dijkstra.Specification.Entities.Properties.Computational
+```

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/Computational.lagda.md
@@ -1,0 +1,76 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Entitities/Properties/Computational.lagda.md
+---
+
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Gov.Base using (GovStructure)
+
+module Ledger.Dijkstra.Specification.Entities.Properties.Computational
+  (govStructure : GovStructure) where
+
+open import Ledger.Prelude
+open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
+open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Entities govStructure
+open import Ledger.Dijkstra.Specification.Gov govStructure
+
+open import Ledger.Dijkstra.Specification.Certs.Properties.Computational govStructure
+open import stdlib.Data.Maybe
+open import stdlib-meta.Tactic.GenError using (genErrors)
+import Data.Maybe.Relation.Unary.Any as M
+import Data.Maybe.Relation.Unary.All as M
+
+open GovStructure govStructure
+open RewardAddress
+
+open GovVote
+
+module Computational-CERTS = Computational Computational-CERTS
+
+instance
+  Computational-ENTITIES : Computational _⊢_⇀⦇_,ENTITIES⦈_ String
+  Computational-ENTITIES = record {go}
+    where
+      module go (Γ : CertEnv) (s₀ : CertState) (dCerts : List DCert)
+                (let module Γ = CertEnv Γ
+                     refresh  = mapPartial (isGovVoterDRep ∘ voter) (fromList Γ.votes)
+                     refreshedDReps  = mapValueRestricted (const (Γ.epoch  + Γ.pp .PParams.drepActivity)) (DRepsOf s₀) refresh
+                     wdrlCreds       = mapˢ stake (dom Γ.wdrls)
+                     ddCreds         = mapˢ stake (dom Γ.directDeposits)
+                ) where
+        
+        s₁ : CertState
+        s₁ = ⟦ ⟦ VoteDelegsOf s₀ , StakeDelegsOf s₀ , applyWithdrawals Γ.wdrls (RewardsOf s₀) , DepositsOf (DStateOf s₀) ⟧
+               , PStateOf s₀
+               , ⟦ refreshedDReps
+                 , CCHotKeysOf s₀
+                 , DepositsOf (GStateOf s₀) ⟧ ⟧
+
+        computeProof : ComputationResult String (∃-syntax (_⊢_⇀⦇_,ENTITIES⦈_ Γ s₀ dCerts))
+        computeProof with ¿ filterˢ isKeyHash wdrlCreds ⊆ dom (VoteDelegsOf s₀)
+                          × wdrlCreds ⊆ dom (RewardsOf s₀)
+                          × (∀[ (addr , amt) ∈ Γ.wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s₀) (stake addr)))
+                          ¿ | Computational-CERTS.computeProof Γ s₁ dCerts
+        ... | no ¬p | _ = failure ""
+        ... | yes _ | failure e = failure e
+        ... | yes (p₁ , p₂ , p₃) | success (s₂ , p)
+          with ¿ ddCreds ⊆ dom (RewardsOf s₂) ¿
+        ... | no ¬p = failure ""
+        ... | yes p₄ = success (-, (ENTITIES (p₁ , p₂ , p₃ , p , p₄)))
+    
+        completeness : ∀ (s' : CertState) → Γ ⊢ s₀ ⇀⦇ dCerts ,ENTITIES⦈ s' → map proj₁ computeProof ≡ success s'
+        completeness s' (ENTITIES (p₁ , p₂ , p₃ , p , p₄))
+          with ¿ filterˢ isKeyHash wdrlCreds ⊆ dom (VoteDelegsOf s₀)
+               × wdrlCreds ⊆ dom (RewardsOf s₀)
+               × (∀[ (addr , amt) ∈ Γ.wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s₀) (stake addr)))
+               ¿ | Computational-CERTS.computeProof Γ s₁ dCerts | Computational-CERTS.completeness _ _ _ _ p
+        ... | no ¬p | _ | p' = ⊥-elim (¬p (p₁ , p₂ , p₃))
+        ... | yes _ | failure e | ()
+        ... | yes (p₁ , p₂ , p₃) | success (s₂ , p) | refl
+          with ¿ ddCreds ⊆ dom (RewardsOf s₂) ¿ 
+        ... | no ¬p  = ⊥-elim (¬p p₄)
+        ... | yes p₄ = refl
+```

--- a/src/Ledger/Dijkstra/Specification/Gov.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov.lagda.md
@@ -81,10 +81,6 @@ record HasGovState {a} (A : Type a) : Type a where
   field GovStateOf : A → GovState
 open HasGovState ⦃...⦄ public
 
-record HasEpoch {a} (A : Type a) : Type a where
-  field EpochOf : A → Epoch
-open HasEpoch ⦃...⦄ public
-
 record HasRewardCredentials {a} (A : Type a) : Type a where
   field RewardCredentialsOf : A → ℙ Credential
 open HasRewardCredentials ⦃...⦄ public

--- a/src/Ledger/Dijkstra/Specification/Gov/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov/Properties/Computational.lagda.md
@@ -20,6 +20,7 @@ open import Axiom.Set.Properties
 open import Ledger.Core.Specification.ProtocolVersion
 open import Ledger.Dijkstra.Specification.Enact govStructure
 open import Ledger.Dijkstra.Specification.Gov govStructure
+open import Ledger.Dijkstra.Specification.Certs govStructure
 open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
 open import Ledger.Dijkstra.Specification.Ratify govStructure
 

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -27,7 +27,7 @@ open import Ledger.Dijkstra.Specification.Enact govStructure
 open import Ledger.Dijkstra.Specification.Gov govStructure
 open import Ledger.Dijkstra.Specification.Utxo txs abs
 open import Ledger.Dijkstra.Specification.Utxow txs abs
-open import Ledger.Dijkstra.Specification.Cert govStructure
+open import Ledger.Dijkstra.Specification.Certs govStructure
 open import Ledger.Dijkstra.Specification.Entities govStructure
 
 open EnactState using (cc)

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -27,7 +27,8 @@ open import Ledger.Dijkstra.Specification.Enact govStructure
 open import Ledger.Dijkstra.Specification.Gov govStructure
 open import Ledger.Dijkstra.Specification.Utxo txs abs
 open import Ledger.Dijkstra.Specification.Utxow txs abs
-open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Cert govStructure
+open import Ledger.Dijkstra.Specification.Entities govStructure
 
 open EnactState using (cc)
 ```
@@ -286,7 +287,7 @@ data _⊢_⇀⦇_,SUBLEDGER⦈_ : SubLedgerEnv → LedgerState → SubLevelTx �
   SUBLEDGER-V :
       ∙ isTopLevelValid ≡ true
       ∙ ⟦ slot , pp , treasury , utxo₀ , isTopLevelValid , allScripts , accountBalances ⟧ ⊢ utxoState₀ ⇀⦇ stx ,SUBUTXOW⦈ utxoState₁
-      ∙ ⟦ epoch slot , pp , ListOfGovVotesOf stx , WithdrawalsOf stx , allColdCreds govState₀ enactState , DirectDepositsOf stx ⟧ ⊢ certState₀ ⇀⦇ DCertsOf stx ,CERTS⦈ certState₁
+      ∙ ⟦ epoch slot , pp , ListOfGovVotesOf stx , WithdrawalsOf stx , allColdCreds govState₀ enactState , DirectDepositsOf stx ⟧ ⊢ certState₀ ⇀⦇ DCertsOf stx ,ENTITIES⦈ certState₁
       ∙ ⟦ TxIdOf stx , epoch slot , pp , ppolicy , enactState , certState₁ , dom (RewardsOf certState₁) ⟧ ⊢ govState₀ ⇀⦇ GovProposals+Votes stx ,GOVS⦈ govState₁
         ────────────────────────────────
         ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , isTopLevelValid , allScripts , accountBalances ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ stx ,SUBLEDGER⦈ ⟦ utxoState₁ , govState₁ , certState₁ ⟧
@@ -315,7 +316,7 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LedgerEnv → LedgerState → TopLevelTx → Ledg
     in
       ∙ IsValidFlagOf tx ≡ true
       ∙ ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , IsValidFlagOf tx , allScripts , RewardsOf certState₀ ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoState₁ , govState₁ , certState₁ ⟧
-      ∙ ⟦ epoch slot , pp , ListOfGovVotesOf tx , WithdrawalsOf tx , allColdCreds govState₁ enactState , DirectDepositsOf tx ⟧ ⊢ certState₁ ⇀⦇ DCertsOf tx ,CERTS⦈ certState₂
+      ∙ ⟦ epoch slot , pp , ListOfGovVotesOf tx , WithdrawalsOf tx , allColdCreds govState₁ enactState , DirectDepositsOf tx ⟧ ⊢ certState₁ ⇀⦇ DCertsOf tx ,ENTITIES⦈ certState₂
       ∙ ⟦ TxIdOf tx , epoch slot , pp , ppolicy , enactState , certState₂ , dom (RewardsOf certState₂) ⟧ ⊢ govState₁ ⇀⦇ GovProposals+Votes tx ,GOVS⦈ govState₂
       ∙ ⟦ slot , pp , treasury , utxo₀ , depositsChange , allScripts , RewardsOf certState₀ ⟧ ⊢ utxoState₁ ⇀⦇ tx ,UTXOW⦈ utxoState₂
         ────────────────────────────────

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/Computational.lagda.md
@@ -14,15 +14,16 @@ transition rules are computational.
 
 open import Ledger.Dijkstra.Specification.Transaction
 open import Ledger.Dijkstra.Specification.Abstract
-import Ledger.Dijkstra.Specification.Certs
 
 module Ledger.Dijkstra.Specification.Ledger.Properties.Computational
-  (txs : _) (open TransactionStructure txs) (open Ledger.Dijkstra.Specification.Certs govStructure)
+  (txs : _) (open TransactionStructure txs)
   (abs : AbstractFunctions txs) (open AbstractFunctions abs)
   where
 
 open import Ledger.Prelude
-open import Ledger.Dijkstra.Specification.Certs.Properties.Computational govStructure
+open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Entities govStructure
+open import Ledger.Dijkstra.Specification.Entities.Properties.Computational govStructure
 open import Ledger.Dijkstra.Specification.Gov govStructure
 open import Ledger.Dijkstra.Specification.Gov.Properties.Computational txs
 open import Ledger.Dijkstra.Specification.Ledger txs abs
@@ -86,7 +87,7 @@ instance
     where
     open Computational ⦃...⦄ renaming (computeProof to comp; completeness to complete)
     computeSubutxow = comp {STS = _⊢_⇀⦇_,SUBUTXOW⦈_}
-    computeCerts    = comp {STS = _⊢_⇀⦇_,CERTS⦈_}
+    computeEntities = comp {STS = _⊢_⇀⦇_,ENTITIES⦈_}
     computeGov      = comp {STS = _⊢_⇀⦇_,GOVS⦈_}
 
     module go
@@ -114,7 +115,7 @@ instance
       computeProof = case isTopLevelValid ≟ true of λ where
         (yes p) → do
           (utxoSt' , utxoStep) ← computeSubutxow subUtxoΓ utxoSt stx
-          (certSt' , certStep) ← computeCerts certΓ certState (DCertsOf stx)
+          (certSt' , certStep) ← computeEntities certΓ certState (DCertsOf stx)
           (govSt'  , govStep)  ← computeGov (govΓ certSt') govSt (GovProposals+Votes stx)
           success (_ , SUBLEDGER-V (p , utxoStep , certStep , govStep))
         (no ¬p) → do
@@ -137,7 +138,7 @@ instance
       ... | yes refl
         with computeSubutxow subUtxoΓ utxoSt stx | complete _ _ _ _ utxoStep
       ... | success (utxoSt' , _) | refl
-        with computeCerts certΓ certState (DCertsOf stx) | complete _ _ _ _ certStep
+        with computeEntities certΓ certState (DCertsOf stx) | complete _ _ _ _ certStep
       ... | success (certSt' , _) | refl
         with computeGov (govΓ certSt') govSt (GovProposals+Votes stx)
            | complete {STS = _⊢_⇀⦇_,GOVS⦈_} (govΓ certSt') _ _ _ govStep
@@ -168,7 +169,7 @@ instance
     where
     open Computational ⦃...⦄ renaming (computeProof to comp; completeness to complete)
     computeSubledgers = comp {STS = _⊢_⇀⦇_,SUBLEDGERS⦈_}
-    computeCerts      = comp {STS = _⊢_⇀⦇_,CERTS⦈_}
+    computeEntities   = comp {STS = _⊢_⇀⦇_,ENTITIES⦈_}
     computeGov        = comp {STS = _⊢_⇀⦇_,GOVS⦈_}
     computeUtxow      = comp {STS = _⊢_⇀⦇_,UTXOW⦈_}
 
@@ -212,7 +213,7 @@ instance
       computeProof = case IsValidFlagOf txTop ≟ true of λ where
         (yes p) → do
           (s₁      , subStep)  ← computeSubledgers subΓ s (SubTransactionsOf txTop)
-          (certSt₂ , certStep) ← computeCerts (certΓ (GovStateOf s₁)) (CertStateOf s₁) (DCertsOf txTop)
+          (certSt₂ , certStep) ← computeEntities (certΓ (GovStateOf s₁)) (CertStateOf s₁) (DCertsOf txTop)
           (govSt₂  , govStep)  ← computeGov (govΓ certSt₂) (GovStateOf s₁) (GovProposals+Votes txTop)
           (utxoSt₂ , utxoStep) ← computeUtxow (utxoΓ-valid (CertStateOf s₁) certSt₂) (UTxOStateOf s₁) txTop
           success (_ , LEDGER-V (p , subStep , certStep , govStep , utxoStep))
@@ -233,7 +234,7 @@ instance
 ```agda
       completeness ledgerSt
         (LEDGER-V {certState₁ = certSt₁} {certSt₂} {utxoState₁ = utxoSt₁} {govSt₁} {govSt₂} {utxoSt₂}
-                  (v , subStep , certStep , govStep , utxoStep))
+                  (v , subStep , entitiesStep , govStep , utxoStep))
         with IsValidFlagOf txTop ≟ true
       ... | no ¬v = contradiction v ¬v
       ... | yes refl
@@ -241,8 +242,8 @@ instance
            | complete {STS = _⊢_⇀⦇_,SUBLEDGERS⦈_} subΓ s (SubTransactionsOf txTop)
                       (⟦ utxoSt₁ , govSt₁ , certSt₁ ⟧ˡ) subStep
       ... | success (⟦ utxoSt₁ , govSt₁ , certSt₁ ⟧ˡ , _) | refl
-        with computeCerts (certΓ govSt₁) certSt₁ (DCertsOf txTop)
-           | complete {STS = _⊢_⇀⦇_,CERTS⦈_} (certΓ govSt₁) certSt₁ (DCertsOf txTop) certSt₂ certStep
+        with computeEntities (certΓ govSt₁) certSt₁ (DCertsOf txTop)
+           | complete {STS = _⊢_⇀⦇_,ENTITIES⦈_} (certΓ govSt₁) certSt₁ (DCertsOf txTop) certSt₂ entitiesStep
       ... | success (certSt₂ , _) | refl
         with computeGov (govΓ certSt₂) govSt₁ (GovProposals+Votes txTop)
            | complete {STS = _⊢_⇀⦇_,GOVS⦈_} (govΓ certSt₂) govSt₁ (GovProposals+Votes txTop) govSt₂ govStep

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -368,7 +368,7 @@ In the preservation-of-value equation, direct deposits appear on the
 `producedTx`{.AgdaFunction}, sums the ADA of all direct deposits in
 the transaction.
 
-### Phantom Asset Prevention
+### Phantom Asset Prevention {#subsubsec:phantom-asset-prevention}
 
 ```agda
 NoPhantomWithdrawals : Rewards → TopLevelTx → Type


### PR DESCRIPTION
# Description

This PR adds the `ENTITIES` rule which replaces `CERTS` in Dijkstra by inlining PRE/POST-CERT.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
