### PR TITLE
[Dijkstra] CIP-159-11c: Prove LEDGER preservation of value (#1187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,9 @@
 
 ### WIP
 
-- Prove preservation of value for the `LEDGER` rule (`LEDGER-pov`, #1187), in new module
-  `Ledger.Properties.PoV`.  Supporting modules: `Entities.Properties.PoV`
-  (`ENTITIES-pov`, `SUBENTITIES-pov`) and `Entities.Properties.ApplyToRewardsPoV`
-  (`applyWithdrawals-pov`, `applyDirectDeposits-pov`).  The supporting UTxO, Certs, and
-  Gov facts are module parameters, to be discharged by #1186, #1210, and a future
-  `Gov.Properties.PoV`.
+- Add `PoolDepositsRegistered` (every pool-deposit entry belongs to a registered
+  pool) to `Certs`; the deposit accounting genuinely fails without it, since
+  `POOL-reg` adds its deposit with a left-biased union.
 - Count governance-action deposits in `getCoin LedgerState` via a new
   `coinFromGovDeposit : GovState → Coin` (sum of `GovActionState.deposit`).  These
   deposits live in `GovActionState.deposit`, not `GState.deposits`, so the three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 ### WIP
 
-- Prove preservation of value for the `LEDGER` rule (`LEDGER-pov`, #1187), in new module
+- Prove preservation of value for the `LEDGER` rule (`LEDGER-pov`, #1187), under a
+  `PoolDepositsRegistered` hypothesis on the initial state, in new module
   `Ledger.Properties.PoV`.  Supporting modules: `Entities.Properties.PoV`
-  (`ENTITIES-pov`, `SUBENTITIES-pov`) and `Entities.Properties.ApplyToRewardsPoV`
-  (`applyWithdrawals-pov`, `applyDirectDeposits-pov`).  The supporting UTxO, Certs, and
-  Gov facts are module parameters, to be discharged by #1186, #1210, and a future
-  `Gov.Properties.PoV`.
+  (rewards flow `ENTITIES-pov`/`SUBENTITIES-pov`, deposit flow
+  `ENTITIES-deposits-pov`/`SUBENTITIES-deposits-pov`, and their combination
+  `ENTITIES-pov-total`/`SUBENTITIES-pov-total`) and
+  `Entities.Properties.ApplyToRewardsPoV` (`applyWithdrawals-pov`,
+  `applyDirectDeposits-pov`).  The supporting UTxO, Certs, and Gov facts are module
+  parameters, to be discharged by #1186, #1210, and a future `Gov.Properties.PoV`.
+- Add `PoolDepositsRegistered` (every pool-deposit entry belongs to a registered
+  pool) to `Certs`; the deposit accounting genuinely fails without it, since
+  `POOL-reg` adds its deposit with a left-biased union.
 - Count governance-action deposits in `getCoin LedgerState` via a new
   `coinFromGovDeposit : GovState → Coin` (sum of `GovActionState.deposit`).  These
   deposits live in `GovActionState.deposit`, not `GState.deposits`, so the three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,6 @@
 
 ### WIP
 
-- Add `PoolDepositsRegistered` (every pool-deposit entry belongs to a registered
-  pool) to `Certs`; the deposit accounting genuinely fails without it, since
-  `POOL-reg` adds its deposit with a left-biased union.
-- Count governance-action deposits in `getCoin LedgerState` via a new
-  `coinFromGovDeposit : GovState → Coin` (sum of `GovActionState.deposit`).  These
-  deposits live in `GovActionState.deposit`, not `GState.deposits`, so the three
-  `CertState` deposit pots alone do not account for them.
-- Make `getCoin` on `CertState` total (rewards balance plus the three deposit pots) and
-  add the `coinFromRewards`/`coinFromDeposits` projections in `Certs`.
 - Move cert-deposit helpers from `Utxo` to `Certs`.
 - Fix `updateCertDeposits`: use `foldl` (CERTS is head-first).
 - Add `HasCoin-UTxOState` and `HasCoin-LedgerState` instances; the latter sums UTxO total, rewards balance, and all three deposit fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### WIP
 
+- Prove preservation of value for the `LEDGER` rule (`LEDGER-pov`, #1187), in new module
+  `Ledger.Properties.PoV`.  Supporting modules: `Entities.Properties.PoV`
+  (`ENTITIES-pov`, `SUBENTITIES-pov`) and `Entities.Properties.ApplyToRewardsPoV`
+  (`applyWithdrawals-pov`, `applyDirectDeposits-pov`).  The supporting UTxO, Certs, and
+  Gov facts are module parameters, to be discharged by #1186, #1210, and a future
+  `Gov.Properties.PoV`.
+- Count governance-action deposits in `getCoin LedgerState` via a new
+  `coinFromGovDeposit : GovState → Coin` (sum of `GovActionState.deposit`).  These
+  deposits live in `GovActionState.deposit`, not `GState.deposits`, so the three
+  `CertState` deposit pots alone do not account for them.
+- Make `getCoin` on `CertState` total (rewards balance plus the three deposit pots) and
+  add the `coinFromRewards`/`coinFromDeposits` projections in `Certs`.
 - Move cert-deposit helpers from `Utxo` to `Certs`.
 - Fix `updateCertDeposits`: use `foldl` (CERTS is head-first).
 - Add `HasCoin-UTxOState` and `HasCoin-LedgerState` instances; the latter sums UTxO total, rewards balance, and all three deposit fields.

--- a/build-tools/static/mkdocs/mkdocs.yml
+++ b/build-tools/static/mkdocs/mkdocs.yml
@@ -242,7 +242,9 @@ nav:
     - Entities/:
       - Properties: Ledger.Dijkstra.Specification.Entities.Properties.md
       - Properties/:
+        - ApplyToRewardsPoV: Ledger.Dijkstra.Specification.Entities.Properties.ApplyToRewardsPoV.md
         - Computational: Ledger.Dijkstra.Specification.Entities.Properties.Computational.md
+        - PoV: Ledger.Dijkstra.Specification.Entities.Properties.PoV.md
     - Epoch: Ledger.Dijkstra.Specification.Epoch.md
     - Epoch/:
       - Properties: Ledger.Dijkstra.Specification.Epoch.Properties.md
@@ -261,6 +263,7 @@ nav:
       - Properties: Ledger.Dijkstra.Specification.Ledger.Properties.md
       - Properties/:
         - Computational: Ledger.Dijkstra.Specification.Ledger.Properties.Computational.md
+        - PoV: Ledger.Dijkstra.Specification.Ledger.Properties.PoV.md
     - PoolReap: Ledger.Dijkstra.Specification.PoolReap.md
     - PoolReap/:
       - Properties: Ledger.Dijkstra.Specification.PoolReap.Properties.md

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -393,6 +393,18 @@ coinFromDeposits cs =
   getCoin (DepositsOf (DStateOf cs)) + getCoin (DepositsOf (PStateOf cs)) + getCoin (DepositsOf (GStateOf cs))
 ```
 
+A `CertState`{.AgdaRecord} is *pool-deposit registered* when every entry of the pool
+deposit pot belongs to a registered pool.  Deposit accounting relies on this:
+`POOL-reg`{.AgdaInductiveConstructor} adds the pool deposit with a left-biased union,
+so a stale pot entry for an unregistered pool would silently swallow the added
+deposit.  The property is preserved by `CERTS`{.AgdaDatatype} (both maps gain exactly
+the new pool's key, and no rule removes a pool without its deposit).
+
+```agda
+PoolDepositsRegistered : CertState → Type
+PoolDepositsRegistered cs = dom (DepositsOf (PStateOf cs)) ⊆ dom (PoolsOf cs)
+```
+
 <!--
 ```agda
 instance

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -377,6 +377,18 @@ coinFromDeposits cs =
   getCoin (DepositsOf (DStateOf cs)) + getCoin (DepositsOf (PStateOf cs)) + getCoin (DepositsOf (GStateOf cs))
 ```
 
+A `CertState`{.AgdaRecord} is *pool-deposit registered* when every entry of the pool
+deposit pot belongs to a registered pool.  Deposit accounting relies on this:
+`POOL-reg`{.AgdaInductiveConstructor} adds the pool deposit with a left-biased union,
+so a stale pot entry for an unregistered pool would silently swallow the added
+deposit.  The property is preserved by `CERTS`{.AgdaDatatype} (both maps gain exactly
+the new pool's key, and no rule removes a pool without its deposit).
+
+```agda
+PoolDepositsRegistered : CertState → Type
+PoolDepositsRegistered cs = dom (DepositsOf (PStateOf cs)) ⊆ dom (PoolsOf cs)
+```
+
 <!--
 ```agda
 instance

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -394,11 +394,7 @@ coinFromDeposits cs =
 ```
 
 A `CertState`{.AgdaRecord} is *pool-deposit registered* when every entry of the pool
-deposit pot belongs to a registered pool.  Deposit accounting relies on this:
-`POOL-reg`{.AgdaInductiveConstructor} adds the pool deposit with a left-biased union,
-so a stale pot entry for an unregistered pool would silently swallow the added
-deposit.  The property is preserved by `CERTS`{.AgdaDatatype} (both maps gain exactly
-the new pool's key, and no rule removes a pool without its deposit).
+deposit pot belongs to a registered pool.
 
 ```agda
 PoolDepositsRegistered : CertState → Type

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -378,11 +378,27 @@ module _ (pp : PParams) where
       addRefundCertDeposit acc _               = acc
 ```
 
+The two coin-bearing components of a `CertState`{.AgdaRecord} are the rewards
+(account) balances and the three deposit pots.  `coinFromRewards`{.AgdaFunction} and
+`coinFromDeposits`{.AgdaFunction} project their totals; `getCoin`{.AgdaFunction} on a
+`CertState`{.AgdaRecord} is their sum, so preservation-of-value statements can be
+phrased at the `CertState`{.AgdaRecord} level.
+
+```agda
+coinFromRewards : CertState → Coin
+coinFromRewards = rewardsBalance ∘ DStateOf
+
+coinFromDeposits : CertState → Coin
+coinFromDeposits cs =
+  getCoin (DepositsOf (DStateOf cs)) + getCoin (DepositsOf (PStateOf cs)) + getCoin (DepositsOf (GStateOf cs))
+```
+
 <!--
 ```agda
 instance
   HasCoin-CertState : HasCoin CertState
-  HasCoin-CertState .getCoin = rewardsBalance ∘ DStateOf
+  -- Total coin held in a CertState: the rewards balance plus the deposit pots.
+  HasCoin-CertState .getCoin = λ cs → coinFromRewards cs + coinFromDeposits cs
 
   unquoteDecl DecEq-StakePoolParams = derive-DecEq
     ((quote StakePoolParams , DecEq-StakePoolParams) ∷ [])

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -362,11 +362,27 @@ module _ (pp : PParams) where
       addRefundCertDeposit acc _               = acc
 ```
 
+The two coin-bearing components of a `CertState`{.AgdaRecord} are the rewards
+(account) balances and the three deposit pots.  `coinFromRewards`{.AgdaFunction} and
+`coinFromDeposits`{.AgdaFunction} project their totals; `getCoin`{.AgdaFunction} on a
+`CertState`{.AgdaRecord} is their sum, so preservation-of-value statements can be
+phrased at the `CertState`{.AgdaRecord} level.
+
+```agda
+coinFromRewards : CertState → Coin
+coinFromRewards = rewardsBalance ∘ DStateOf
+
+coinFromDeposits : CertState → Coin
+coinFromDeposits cs =
+  getCoin (DepositsOf (DStateOf cs)) + getCoin (DepositsOf (PStateOf cs)) + getCoin (DepositsOf (GStateOf cs))
+```
+
 <!--
 ```agda
 instance
   HasCoin-CertState : HasCoin CertState
-  HasCoin-CertState .getCoin = rewardsBalance ∘ DStateOf
+  -- Total coin held in a CertState: the rewards balance plus the deposit pots.
+  HasCoin-CertState .getCoin = λ cs → coinFromRewards cs + coinFromDeposits cs
 
   unquoteDecl DecEq-StakePoolParams = derive-DecEq
     ((quote StakePoolParams , DecEq-StakePoolParams) ∷ [])

--- a/src/Ledger/Dijkstra/Specification/Entities.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities.lagda.md
@@ -22,7 +22,7 @@ open PParams
 ```
 -->
 
-# Auxiliary Types and Functions
+## Auxiliary Types and Functions
 
 ```agda
 record EntitiesEnv : Type where
@@ -89,7 +89,7 @@ applyWithdrawals : Withdrawals → Rewards → Rewards
 applyWithdrawals = applyToRewards _∸_
 ```
 
-# `ENTITIES`{.AgdaDatatype} Transition System
+## `ENTITIES`{.AgdaDatatype} Transition System
 
 In Dijkstra, the new `ENTITIES`{.AgdaDatatype} rule subsumes the
 pre-Dijkstra `CERTS`{.AgdaDatatype} rule. This rule in addition to
@@ -101,7 +101,7 @@ and `balanceIntervals`. Direct deposits represent value that flows
 from the transaction into account addresses. Balance intervals enable
 transactions to assert predicates about account balances.
 
-## Withdrawals 
+### Withdrawals
 
 The `ENTITIES`{.AgdaDatatype} rule applies withdrawals, via
 `applyWithdrawals`{.AgdaFunction} before certificate evaluation.  In
@@ -111,7 +111,7 @@ rule (via `isLegacyMode`{.AgdaFunction}, defined in the
 `Utxow`{.AgdaModule} module) and provided here through the
 `legacyMode`{.AgdaField} field of `EntitiesEnv`{.AgdaRecord}.
 
-## Direct Deposits
+### Direct Deposits
 
 The `ENTITIES`{.AgdaDatatype} rule applies direct deposits to the
 `CertState`{.AgdaRecord} after  `CERTS`{.AgdaDatatype}.
@@ -168,9 +168,7 @@ data _⊢_⇀⦇_,SUBENTITIES⦈_ : SubEntitiesEnv → CertState → SubLevelTx 
     ∙ directDepositsCredentials ⊆ dom rewards'
       ────────────────────────────────
       ⟦ e , pp , cc , rewards₀ ⟧ ⊢ ⟦ ⟦ voteDelegs , stakeDelegs , rewards , depositsᵈ ⟧ , pState , ⟦ dReps , ccHotKeys , depositsᵍ ⟧ ⟧ ⇀⦇ txSub ,SUBENTITIES⦈ ⟦ ⟦ voteDelegs' , stakeDelegs' , applyDirectDeposits directDeposits rewards' , depositsᵈ' ⟧ , pState' , gState' ⟧
-```
 
-```agda
 data _⊢_⇀⦇_,ENTITIES⦈_ : EntitiesEnv → CertState → TopLevelTx → CertState → Type where
 
   ENTITIES :

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties.lagda.md
@@ -13,5 +13,7 @@ module Ledger.Dijkstra.Specification.Entities.Properties where
 -->
 
 ```agda
+open import Ledger.Dijkstra.Specification.Entities.Properties.ApplyToRewardsPoV
 open import Ledger.Dijkstra.Specification.Entities.Properties.Computational
+open import Ledger.Dijkstra.Specification.Entities.Properties.PoV
 ```

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
@@ -3,14 +3,14 @@ source_branch: master
 source_path: src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
 ---
 
-## `applyToRewards` Preservation of Value {#sec:apply-to-rewards-pov}
+# <span class="AgdaFunction">applyToRewards</span> Preservation of Value {#sec:apply-to-rewards-pov}
 
 This module proves preservation of value for the two specializations of
 `applyToRewards`{.AgdaFunction} used inside the `ENTITIES`{.AgdaDatatype} rule.
 
 +  `applyWithdrawals-pov`{.AgdaFunction}.
 
-   `applyWithdrawals`{.AgdaFunction} *decreases* the total rewards balance by exactly
+   `applyWithdrawals`{.AgdaFunction} decreases the total rewards balance by exactly
    the sum of withdrawal amounts.  Truncating subtraction (`_∸_`) means the per-step
    lemma requires `amt ≤ bal`, and the fold induction requires a
    `Unique`{.AgdaDatatype} witness on the stake-projected withdrawal list so that no
@@ -18,7 +18,7 @@ This module proves preservation of value for the two specializations of
 
 +  `applyDirectDeposits-pov`{.AgdaFunction}.
 
-   `applyDirectDeposits`{.AgdaFunction} *increases* the total rewards balance by
+   `applyDirectDeposits`{.AgdaFunction} increases the total rewards balance by
    exactly the sum of direct-deposit amounts.  Because `_+_` is total and
    commutative, revisiting a credential is harmless, so neither the
    `NetworkId`{.AgdaFunction} witness nor the `Unique`{.AgdaDatatype} premise is
@@ -27,7 +27,7 @@ This module proves preservation of value for the two specializations of
 Both lemmas share a common backbone: a per-step result about
 `applyOne`{.AgdaFunction} (the lambda body of `applyToRewards`{.AgdaFunction})
 together with a `foldl`-induction lemma over `setToList (m ˢ)`.  They are consumed
-directly by `ENTITIES-pov`{.AgdaFunction} in `Entities.Properties.PoV`.
+directly by `ENTITIES-pov`{.AgdaFunction} in `Entities.Properties.PoV`{.AgdaModule}.
 
 <!--
 ```agda
@@ -60,7 +60,7 @@ open ≡-Reasoning
 ```
 -->
 
-### Shared helpers
+## Shared helpers
 
 ```agda
 getCoin-∪ˡ-overwrite : (acc : Rewards) (c : Credential) (v : Coin)
@@ -139,11 +139,10 @@ split-by-lookup acc c bal lookup-eq =
 ```
 -->
 
-### The `ApplyToRewards-PoV` module
+## The <span class="AgdaModule">ApplyToRewards-PoV</span> module
 
 The three assumed identities below are the same set/map identities used by the Conway
-PoV proofs; they are stated as module parameters here, to be discharged in a
-follow-up against the `agda-sets` library.
+PoV proofs; they are stated as module parameters here.
 
 +  `∪ˡ-lookup-preserve`: lookup in a left-biased union with a singleton at `c` agrees
    with lookup in the right map for any key `c' ≠ c`.
@@ -223,8 +222,8 @@ The fold invariant tracks three things through the induction.
 3.  No credential is revisited (the `Unique`{.AgdaDatatype} witness on the
     stake-projected list).
 
-Uniqueness is essential here precisely because `applyOne _∸_` *modifies* the balance
-at the targeted credential — without it, a re-visit could attempt to subtract from an
+Uniqueness is essential here precisely because `applyOne _∸_` modifies the balance
+at the targeted credential; without it, a re-visit could attempt to subtract from an
 already-reduced balance for which the caller's original `amt ≤ bal` bound no longer
 holds.
 
@@ -291,7 +290,7 @@ holds.
 ```
 -->
 
-### `applyWithdrawals-pov`
+#### `applyWithdrawals-pov`
 
 ```agda
   applyWithdrawals-pov : (wdrls : Withdrawals) (rwds : Rewards)
@@ -328,9 +327,9 @@ holds.
 ```
 -->
 
-## Direct-deposit preservation of value
+### Direct-deposit preservation of value
 
-### `applyOne-pov-add` (one direct-deposit step increases `getCoin` by `amt`)
+#### `applyOne-pov-add` (one direct-deposit step increases `getCoin` by `amt`)
 
 For addition, no `amt ≤ bal` premise is needed (the operation is total),
 and the per-step equation is `getCoin (...) ≡ getCoin acc + amt`
@@ -361,10 +360,10 @@ balance.
 ```
 -->
 
-### `foldl-applyOne-pov-add` (fold induction, no `Unique` needed)
+#### `foldl-applyOne-pov-add` (fold induction, no `Unique` needed)
 
 Unlike the withdrawal version, the additive fold induction needs only
-domain preservation — the `Unique`{.AgdaDatatype} witness drops out.
+domain preservation; the `Unique`{.AgdaDatatype} witness drops out.
 The reason: `applyOne _+_` modifies the balance at the targeted
 credential, but since the per-step lemma `applyOne-pov-add` is
 unconditional on the prior balance and `_+_` is commutative, revisiting
@@ -406,7 +405,7 @@ the same credential simply accumulates additions correctly.
 ```
 -->
 
-### `applyDirectDeposits-pov`
+#### `applyDirectDeposits-pov`
 
 Note the slimmed-down signature relative to `applyWithdrawals-pov`: no
 `NetworkId`{.AgdaFunction} premise (none is needed), no

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
@@ -1,0 +1,443 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
+---
+
+## `applyToRewards` Preservation of Value {#sec:apply-to-rewards-pov}
+
+This module proves preservation of value for the two specializations of
+`applyToRewards`{.AgdaFunction} used inside the `ENTITIES`{.AgdaDatatype} rule.
+
++  `applyWithdrawals-pov`{.AgdaFunction}.
+
+   `applyWithdrawals`{.AgdaFunction} *decreases* the total rewards balance by exactly
+   the sum of withdrawal amounts.  Truncating subtraction (`_∸_`) means the per-step
+   lemma requires `amt ≤ bal`, and the fold induction requires a
+   `Unique`{.AgdaDatatype} witness on the stake-projected withdrawal list so that no
+   already-reduced balance is revisited.
+
++  `applyDirectDeposits-pov`{.AgdaFunction}.
+
+   `applyDirectDeposits`{.AgdaFunction} *increases* the total rewards balance by
+   exactly the sum of direct-deposit amounts.  Because `_+_` is total and
+   commutative, revisiting a credential is harmless, so neither the
+   `NetworkId`{.AgdaFunction} witness nor the `Unique`{.AgdaDatatype} premise is
+   needed.
+
+Both lemmas share a common backbone: a per-step result about
+`applyOne`{.AgdaFunction} (the lambda body of `applyToRewards`{.AgdaFunction})
+together with a `foldl`-induction lemma over `setToList (m ˢ)`.  They are consumed
+directly by `ENTITIES-pov`{.AgdaFunction} in `Entities.Properties.PoV`.
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Transaction using (TransactionStructure)
+
+module Ledger.Dijkstra.Specification.Entities.Properties.ApplyToRewardsPoV
+  (txs : TransactionStructure) (open TransactionStructure txs) where
+
+open import Data.List.Membership.Propositional.Properties using (∈-map⁺)
+open import Data.List.Relation.Unary.Any using (Any)
+open import Data.List.Relation.Unary.All using (lookup)
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique) renaming (_∷_ to _::_)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Nat.Properties using (+-identityʳ; +-comm; +-assoc; m∸n+n≡m; n≤0⇒n≡0)
+open import Relation.Binary using (IsEquivalence)
+
+open import Ledger.Prelude hiding (lookup)
+
+open import Ledger.Dijkstra.Specification.Certs govStructure using (Rewards)
+open import Ledger.Dijkstra.Specification.Entities txs
+  using (applyWithdrawals; applyDirectDeposits)
+
+open import Axiom.Set.Properties th
+
+open RewardAddress
+open Any
+open ≡-Reasoning
+```
+-->
+
+### Shared helpers
+
+```agda
+getCoin-∪ˡ-overwrite : (acc : Rewards) (c : Credential) (v : Coin)
+  → getCoin (❴ c , v ❵ ∪ˡ acc) ≡ v + getCoin (acc ∣ ❴ c ❵ ᶜ)
+```
+
+<!--
+```agda
+getCoin-∪ˡ-overwrite acc c v =
+  begin
+    getCoin (❴ c , v ❵ ∪ˡ acc)
+      ≡⟨ ≡ᵉ-getCoin (❴ c , v ❵ ∪ˡ acc) (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) bridge ⟩
+    getCoin (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ))
+      ≡⟨ indexedSumᵛ'-∪ ❴ c , v ❵ᵐ (acc ∣ ❴ c ❵ ᶜ) disj ⟩
+    getCoin ❴ c , v ❵ᵐ + getCoin (acc ∣ ❴ c ❵ ᶜ)
+      ≡⟨ cong (_+ getCoin (acc ∣ ❴ c ❵ ᶜ)) getCoin-singleton ⟩
+    v + getCoin (acc ∣ ❴ c ❵ ᶜ)
+      ∎
+  where
+  open Equivalence
+  module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+
+  restrict-cong-∪ˡ :
+    (❴ c , v ❵ᵐ ∪ˡ acc ∣ dom ❴ c , v ❵ᵐ ᶜ) ˢ ≡ᵉ (❴ c , v ❵ᵐ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) ˢ
+  restrict-cong-∪ˡ =
+    ∪ˡ-cong {m   = ❴ c , v ❵ᵐ} {m'  = acc ∣ dom (❴ c , v ❵ᵐ ˢ) ᶜ}
+            {m'' = ❴ c , v ❵ᵐ} {m''' = acc ∣ ❴ c ❵ ᶜ}
+      (≡ᵉ.refl {x = ❴ c , v ❵ᵐ ˢ}) (res-comp-cong dom-single≡single)
+
+  bridge : (❴ c , v ❵ ∪ˡ acc) ˢ ≡ᵉ (❴ c , v ❵ ∪ˡ (acc ∣ ❴ c ❵ ᶜ)) ˢ
+  bridge = ≡ᵉ.trans (res-decomp ❴ c , v ❵ᵐ acc) restrict-cong-∪ˡ
+
+  disj : disjoint (dom ❴ c , v ❵ᵐ) (dom (acc ∣ ❴ c ❵ ᶜ))
+  disj x y = res-comp-dom y (dom-single→single x)
+```
+-->
+
+```agda
+split-by-lookup : (acc : Rewards) (c : Credential) (bal : Coin)
+  → lookupᵐ? acc c ≡ just bal → getCoin acc ≡ getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
+```
+
+<!--
+```agda
+-- When lookupᵐ? acc c ≡ just bal, we can decompose getCoin acc into the contribution
+-- of c (which is bal) plus the contribution of every other credential, getCoin (acc ∣ ❴ c ❵ ᶜ).
+split-by-lookup acc c bal lookup-eq =
+  begin
+    getCoin acc
+      ≡˘⟨ ≡ᵉ-getCoin decomp acc ( ≡ᵉ.trans  (disjoint-∪ˡ-∪ (disjoint-sym res-ex-disjoint))
+                                            (≡ᵉ.trans ∪-sym (res-ex-∪ Dec-∈-singleton)) ) ⟩
+    getCoin decomp
+      ≡⟨ indexedSumᵛ'-∪ (acc ∣ ❴ c ❵ ᶜ) (acc ∣ ❴ c ❵) (disjoint-sym res-ex-disjoint) ⟩
+    getCoin (acc ∣ ❴ c ❵ ᶜ) + getCoin (acc ∣ ❴ c ❵)
+      ≡⟨ cong (getCoin (acc ∣ ❴ c ❵ ᶜ) +_) acc∣c≡bal ⟩
+    getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
+      ∎
+  where
+  module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential × Coin})
+  open Equivalence
+
+  decomp : Credential ⇀ Coin
+  decomp = (acc ∣ ❴ c ❵ ᶜ) ∪ˡ (acc ∣ ❴ c ❵)
+
+  c∈acc : (c , bal) ∈ acc ˢ
+  c∈acc with c ∈? dom (acc ˢ)
+  ... | yes c∈dom = subst  (λ v → (c , v) ∈ acc ˢ)
+                           (just-injective lookup-eq)
+                           (lookupᵐ-∈ acc c c∈dom)
+  ... | no _ = case lookup-eq of λ ()
+
+  acc∣c≡bal : getCoin (acc ∣ ❴ c ❵) ≡ bal
+  acc∣c≡bal =
+    trans (getCoin-cong (acc ∣ ❴ c ❵) ❴ (c , bal) ❵ (res-singleton' {m = acc} c∈acc))
+          getCoin-singleton
+```
+-->
+
+### The `ApplyToRewards-PoV` module
+
+The three assumed identities below are the same set/map identities used by the Conway
+PoV proofs; they are stated as module parameters here, to be discharged in a
+follow-up against the `agda-sets` library.
+
++  `∪ˡ-lookup-preserve`: lookup in a left-biased union with a singleton at `c` agrees
+   with lookup in the right map for any key `c' ≠ c`.
++  `sum-map-proj₂≡getCoin`: the `getCoin`{.AgdaFunction} representation of a
+   `(RewardAddress ⇀ Coin)` map equals the list-sum of its second projections.
++  `setToList-Unique`: stake-projection of a withdrawal/direct-deposit list is
+   `Unique`{.AgdaDatatype}, assuming the per-batch `NetworkId`{.AgdaFunction}
+   constraint.  (Used only by `applyWithdrawals-pov`.)
+
+```agda
+module ApplyToRewards-PoV
+  ( ∪ˡ-lookup-preserve :
+      (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
+
+  ( sum-map-proj₂≡getCoin :
+      (m : RewardAddress ⇀ Coin)
+      → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  ( setToList-Unique :
+      (m : RewardAddress ⇀ Coin)
+      → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+  where
+```
+
+The `applyOne`{.AgdaFunction} is a local convenience definitionally equal to the
+lambda body of `applyToRewards f`.
+
+```agda
+  applyOne : (Coin → Coin → Coin) → Rewards → RewardAddress × Coin → Rewards
+  applyOne f acc (addr , amt) =
+    maybe (λ bal → ❴ stake addr , f bal amt ❵ ∪ˡ acc) acc (lookupᵐ? acc (stake addr))
+```
+
+### Withdrawal preservation of value
+
+#### `applyOne-pov`: one withdrawal step decreases `getCoin` by `amt`
+
+When `lookupᵐ? acc (stake addr) ≡ just bal` and `amt ≤ bal`, applying a single
+withdrawal reduces the total by exactly `amt`.
+
+```agda
+  applyOne-pov : (acc : Rewards) (addr : RewardAddress) (amt bal : Coin)
+    → lookupᵐ? acc (stake addr) ≡ just bal
+    → amt ≤ bal
+    → getCoin acc ≡ getCoin (❴ stake addr , bal ∸ amt ❵ ∪ˡ acc) + amt
+```
+
+<!--
+```agda
+  applyOne-pov acc addr amt bal lookup-eq amt≤bal = let c = stake addr in
+    begin
+      getCoin acc
+        ≡⟨ split-by-lookup acc c bal lookup-eq ⟩
+      getCoin (acc ∣ ❴ c ❵ ᶜ) + bal
+        ≡˘⟨ cong (getCoin (acc ∣ ❴ c ❵ ᶜ) +_) (m∸n+n≡m amt≤bal) ⟩
+      getCoin (acc ∣ ❴ c ❵ ᶜ) + (bal ∸ amt + amt)
+        ≡⟨ trans  (sym (+-assoc (getCoin (acc ∣ ❴ c ❵ ᶜ)) (bal ∸ amt) amt))
+                  (cong (_+ amt) (+-comm (getCoin (acc ∣ ❴ c ❵ ᶜ)) (bal ∸ amt))) ⟩
+      (bal ∸ amt) + getCoin (acc ∣ ❴ c ❵ ᶜ) + amt
+        ≡˘⟨ cong (_+ amt) (getCoin-∪ˡ-overwrite acc c (bal ∸ amt)) ⟩
+      getCoin (❴ c , bal ∸ amt ❵ ∪ˡ acc) + amt
+        ∎
+```
+-->
+
+#### `foldl-applyOne-pov` (fold induction)
+
+The fold invariant tracks three things through the induction.
+
+1.  Every remaining withdrawal credential is in the current accumulator's domain.
+
+2.  Every remaining withdrawal amount is bounded by the current balance at that
+    credential.
+
+3.  No credential is revisited (the `Unique`{.AgdaDatatype} witness on the
+    stake-projected list).
+
+Uniqueness is essential here precisely because `applyOne _∸_` *modifies* the balance
+at the targeted credential — without it, a re-visit could attempt to subtract from an
+already-reduced balance for which the caller's original `amt ≤ bal` bound no longer
+holds.
+
+```agda
+  foldl-applyOne-pov : (acc : Rewards) (entries : List (RewardAddress × Coin))
+    → ( ∀ {addr amt} → (addr , amt) ∈ˡ entries
+        →  stake addr ∈ dom acc × amt ≤ maybe id 0 (lookupᵐ? acc (stake addr)) )
+    → Unique (map (stake ∘ proj₁) entries)
+    → getCoin acc ≡ getCoin (foldl (applyOne _∸_) acc entries) + sum (map proj₂ entries)
+```
+
+<!--
+```agda
+  foldl-applyOne-pov acc [] _ _ = sym (+-identityʳ (indexedSumᵛ' id acc))
+  foldl-applyOne-pov acc ((addr , amt) ∷ xs) h (c∉xs :: uniq-xs)
+    with lookupᵐ? acc (stake addr) in eq
+  -- Nothing case: applyOne is the identity; the bound `h (here refl) .proj₂` forces
+  -- `amt ≡ 0`, which makes the recursive call's right-hand side equal to ours.
+  ... | nothing =
+    let amt≤0 = subst (amt ≤_) (cong (maybe id 0) eq) (h (here refl) .proj₂)
+    in
+    subst (λ a → getCoin acc ≡ getCoin (foldl (applyOne _∸_) acc xs) + (a + sum (map proj₂ xs)))
+          (sym (n≤0⇒n≡0 amt≤0))
+          (foldl-applyOne-pov acc xs (λ mem → h (there mem)) uniq-xs)
+  -- Just case: per-step decrease via `applyOne-pov`, then chain with the IH.
+  ... | just bal = begin
+        getCoin acc
+          ≡⟨ applyOne-pov acc addr amt bal eq amt≤bal ⟩
+        getCoin acc' + amt
+          ≡⟨ cong (_+ amt) (foldl-applyOne-pov acc' xs h' uniq-xs) ⟩
+        (getCoin (foldl (applyOne _∸_) acc' xs) + sum (map proj₂ xs)) + amt
+          ≡⟨ +-assoc (getCoin (foldl (applyOne _∸_) acc' xs)) (sum (map proj₂ xs)) amt ⟩
+        getCoin (foldl (applyOne _∸_) acc' xs) + (sum (map proj₂ xs) + amt)
+          ≡⟨ cong (getCoin (foldl (applyOne _∸_) acc' xs) +_)
+                  (+-comm (sum (map proj₂ xs)) amt) ⟩
+        getCoin (foldl (applyOne _∸_) acc' xs) + (amt + sum (map proj₂ xs))
+          ∎
+    where
+    c : Credential
+    c = stake addr
+
+    acc' : Rewards
+    acc' = ❴ c , bal ∸ amt ❵ ∪ˡ acc
+
+    amt≤bal : amt ≤ bal
+    amt≤bal = subst (amt ≤_) (cong (maybe id 0) eq) (h (here refl) .proj₂)
+
+    -- Invariant transfer.  For each (addr' , amt') ∈ xs, the Unique witness c∉xs
+    -- gives stake addr' ≢ c, which, together with ∪ˡ-lookup-preserve, shows that the
+    -- balance bound at stake addr' in acc' agrees with the bound in acc, so the
+    -- amount inequality transfers.  Domain preservation is just dom∪ˡʳ.
+    h' : ∀ {addr' amt'} → (addr' , amt') ∈ˡ xs
+      → stake addr' ∈ dom acc' × amt' ≤ maybe id 0 (lookupᵐ? acc' (stake addr'))
+    h' {addr'} {amt'} mem = dom' , subst (amt' ≤_) (cong (maybe id 0) (sym bal')) (proj₂ ξ)
+      where
+        ξ : stake addr' ∈ dom (acc ˢ) × amt' ≤ (maybe id 0 (lookupᵐ? acc (stake addr')))
+        ξ = h (there mem)
+        c'≢c : stake addr' ≢ c
+        c'≢c = ≢-sym (lookup c∉xs (∈-map⁺ (stake ∘ proj₁) mem))
+        dom' : stake addr' ∈ dom acc'
+        dom' = dom∪ˡʳ {m = ❴ c , bal ∸ amt ❵} {m' = acc} (proj₁ ξ)
+        bal' : lookupᵐ? acc' (stake addr') ≡ lookupᵐ? acc (stake addr')
+        bal' = ∪ˡ-lookup-preserve acc c (bal ∸ amt) (stake addr') c'≢c
+```
+-->
+
+### `applyWithdrawals-pov`
+
+```agda
+  applyWithdrawals-pov : (wdrls : Withdrawals) (rwds : Rewards)
+    → mapˢ stake (dom wdrls) ⊆ dom rwds
+    → ∀[ a ∈ dom wdrls ] NetworkIdOf a ≡ NetworkId
+    → ∀[ (addr , amt) ∈ wdrls ˢ ] amt ≤ maybe id 0 (lookupᵐ? rwds (stake addr))
+    → getCoin rwds ≡ getCoin (applyWithdrawals wdrls rwds) + getCoin wdrls
+```
+
+<!--
+```agda
+  applyWithdrawals-pov wdrls rwds creds∈ netIds amts≤ =
+    begin
+      getCoin rwds
+        ≡⟨ foldl-applyOne-pov rwds (setToList (wdrls ˢ)) inv
+                              (setToList-Unique wdrls netIds) ⟩
+      getCoin (foldl (applyOne _∸_) rwds (setToList (wdrls ˢ)))
+        + sum (map proj₂ (setToList (wdrls ˢ)))
+        ≡⟨ cong (getCoin (foldl (applyOne _∸_) rwds (setToList (wdrls ˢ))) +_)
+                (sum-map-proj₂≡getCoin wdrls) ⟩
+      getCoin (applyWithdrawals wdrls rwds) + getCoin wdrls
+        ∎
+    where
+    open Equivalence
+    inv : ∀ {addr amt} → (addr , amt) ∈ˡ setToList (wdrls ˢ)
+        → stake addr ∈ dom rwds
+        × amt ≤ maybe id 0 (lookupᵐ? rwds (stake addr))
+    inv {addr} {amt} mem = creds∈ c∈dom-wdrls , amts≤ addr-amt∈wdrls
+      where
+      addr-amt∈wdrls : (addr , amt) ∈ wdrls ˢ
+      addr-amt∈wdrls = setToList-∈ mem
+      c∈dom-wdrls : stake addr ∈ mapˢ stake (dom wdrls)
+      c∈dom-wdrls = to ∈-map (addr , refl , to dom∈ (amt , addr-amt∈wdrls))
+```
+-->
+
+## Direct-deposit preservation of value
+
+### `applyOne-pov-add` (one direct-deposit step increases `getCoin` by `amt`)
+
+For addition, no `amt ≤ bal` premise is needed (the operation is total),
+and the per-step equation is `getCoin (...) ≡ getCoin acc + amt`
+unconditionally on the relationship between `amt` and the current
+balance.
+
+```agda
+  applyOne-pov-add :
+    (acc : Rewards) (addr : RewardAddress) (amt bal : Coin)
+    → lookupᵐ? acc (stake addr) ≡ just bal
+    → getCoin (❴ stake addr , bal + amt ❵ ∪ˡ acc) ≡ getCoin acc + amt
+```
+
+<!--
+```agda
+  applyOne-pov-add acc addr amt bal lookup-eq = let c = stake addr in
+    begin
+      getCoin (❴ c , bal + amt ❵ ∪ˡ acc)
+        ≡⟨ getCoin-∪ˡ-overwrite acc c (bal + amt) ⟩
+      (bal + amt) + getCoin (acc ∣ ❴ c ❵ ᶜ)
+        ≡⟨ +-comm (bal + amt) (getCoin (acc ∣ ❴ c ❵ ᶜ)) ⟩
+      getCoin (acc ∣ ❴ c ❵ ᶜ) + (bal + amt)
+        ≡˘⟨ +-assoc (getCoin (acc ∣ ❴ c ❵ ᶜ)) bal amt ⟩
+      getCoin (acc ∣ ❴ c ❵ ᶜ) + bal + amt
+        ≡˘⟨ cong (_+ amt) (split-by-lookup acc c bal lookup-eq) ⟩
+      getCoin acc + amt
+        ∎
+```
+-->
+
+### `foldl-applyOne-pov-add` (fold induction, no `Unique` needed)
+
+Unlike the withdrawal version, the additive fold induction needs only
+domain preservation — the `Unique`{.AgdaDatatype} witness drops out.
+The reason: `applyOne _+_` modifies the balance at the targeted
+credential, but since the per-step lemma `applyOne-pov-add` is
+unconditional on the prior balance and `_+_` is commutative, revisiting
+the same credential simply accumulates additions correctly.
+
+```agda
+  foldl-applyOne-pov-add :
+    (acc : Rewards) (entries : List (RewardAddress × Coin))
+    → (∀ {addr amt} → (addr , amt) ∈ˡ entries → stake addr ∈ dom acc)
+    → getCoin (foldl (applyOne _+_) acc entries)
+      ≡ getCoin acc + sum (map proj₂ entries)
+```
+
+<!--
+```agda
+  foldl-applyOne-pov-add acc [] _ = sym (+-identityʳ (indexedSumᵛ' id acc))
+  foldl-applyOne-pov-add acc ((addr , amt) ∷ xs) h
+    with lookupᵐ? acc (stake addr) in eq
+  ... | just bal = begin
+        getCoin (foldl (applyOne _+_) acc' xs)
+          ≡⟨ foldl-applyOne-pov-add acc' xs h' ⟩
+        getCoin acc' + sum (map proj₂ xs)
+          ≡⟨ cong (_+ sum (map proj₂ xs))
+                  (applyOne-pov-add acc addr amt bal eq) ⟩
+        (getCoin acc + amt) + sum (map proj₂ xs)
+          ≡⟨ +-assoc (getCoin acc) amt (sum (map proj₂ xs)) ⟩
+        getCoin acc + (amt + sum (map proj₂ xs))
+          ∎
+    where
+    c = stake addr
+    acc' = ❴ c , bal + amt ❵ ∪ˡ acc
+
+    h' : ∀ {addr' amt'} → (addr' , amt') ∈ˡ xs → stake addr' ∈ dom acc'
+    h' mem = dom∪ˡʳ {m = ❴ c , bal + amt ❵} {m' = acc} (h (there mem))
+  -- Defensive `nothing` case: ruled out by the domain hypothesis.
+  ... | nothing with stake addr ∈? dom (acc ˢ)
+  ... | yes _  = case eq of λ ()
+  ... | no a∉ = ⊥-elim (a∉ (h (here refl)))
+```
+-->
+
+### `applyDirectDeposits-pov`
+
+Note the slimmed-down signature relative to `applyWithdrawals-pov`: no
+`NetworkId`{.AgdaFunction} premise (none is needed), no
+`amt ≤ balance` premise (addition doesn't truncate).
+
+```agda
+  applyDirectDeposits-pov : (dd : DirectDeposits) (rwds : Rewards)
+    → mapˢ stake (dom dd) ⊆ dom rwds
+    → getCoin (applyDirectDeposits dd rwds) ≡ getCoin rwds + getCoin dd
+```
+
+<!--
+```agda
+  applyDirectDeposits-pov dd rwds creds∈ =
+    begin
+      getCoin (applyDirectDeposits dd rwds)
+        ≡⟨ refl ⟩
+      getCoin (foldl (applyOne _+_) rwds (setToList (dd ˢ)))
+        ≡⟨ foldl-applyOne-pov-add rwds (setToList (dd ˢ)) inv ⟩
+      getCoin rwds + sum (map proj₂ (setToList (dd ˢ)))
+        ≡⟨ cong (getCoin rwds +_) (sum-map-proj₂≡getCoin dd) ⟩
+      getCoin rwds + getCoin dd
+        ∎
+    where
+    open Equivalence
+    inv : ∀ {addr amt} → (addr , amt) ∈ˡ setToList (dd ˢ) → stake addr ∈ dom rwds
+    inv {addr} {amt} mem = creds∈ c∈dom-dd
+      where
+      addr-amt∈dd : (addr , amt) ∈ dd ˢ
+      addr-amt∈dd = setToList-∈ mem
+      c∈dom-dd : stake addr ∈ mapˢ stake (dom dd)
+      c∈dom-dd = to ∈-map (addr , refl , to dom∈ (amt , addr-amt∈dd))
+```
+-->

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
@@ -142,8 +142,7 @@ split-by-lookup acc c bal lookup-eq =
 ### The `ApplyToRewards-PoV` module
 
 The three assumed identities below are the same set/map identities used by the Conway
-PoV proofs; they are stated as module parameters here, to be discharged in a
-follow-up against the `agda-sets` library.
+PoV proofs; they are stated as module parameters here.
 
 +  `∪ˡ-lookup-preserve`: lookup in a left-biased union with a singleton at `c` agrees
    with lookup in the right map for any key `c' ≠ c`.

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
@@ -3,7 +3,7 @@ source_branch: master
 source_path: src/Ledger/Dijkstra/Specification/Entities/Properties/ApplyToRewardsPoV.lagda.md
 ---
 
-## `applyToRewards` Preservation of Value {#sec:apply-to-rewards-pov}
+# `applyToRewards` Preservation of Value {#sec:apply-to-rewards-pov}
 
 This module proves preservation of value for the two specializations of
 `applyToRewards`{.AgdaFunction} used inside the `ENTITIES`{.AgdaDatatype} rule.
@@ -60,7 +60,7 @@ open ≡-Reasoning
 ```
 -->
 
-### Shared helpers
+## Shared helpers
 
 ```agda
 getCoin-∪ˡ-overwrite : (acc : Rewards) (c : Credential) (v : Coin)
@@ -139,7 +139,7 @@ split-by-lookup acc c bal lookup-eq =
 ```
 -->
 
-### The `ApplyToRewards-PoV` module
+## The <span class="AgdaModule">ApplyToRewards-PoV</span> module
 
 The three assumed identities below are the same set/map identities used by the Conway
 PoV proofs; they are stated as module parameters here.
@@ -290,7 +290,7 @@ holds.
 ```
 -->
 
-### `applyWithdrawals-pov`
+#### `applyWithdrawals-pov`
 
 ```agda
   applyWithdrawals-pov : (wdrls : Withdrawals) (rwds : Rewards)
@@ -327,9 +327,9 @@ holds.
 ```
 -->
 
-## Direct-deposit preservation of value
+### Direct-deposit preservation of value
 
-### `applyOne-pov-add` (one direct-deposit step increases `getCoin` by `amt`)
+#### `applyOne-pov-add` (one direct-deposit step increases `getCoin` by `amt`)
 
 For addition, no `amt ≤ bal` premise is needed (the operation is total),
 and the per-step equation is `getCoin (...) ≡ getCoin acc + amt`
@@ -360,7 +360,7 @@ balance.
 ```
 -->
 
-### `foldl-applyOne-pov-add` (fold induction, no `Unique` needed)
+#### `foldl-applyOne-pov-add` (fold induction, no `Unique` needed)
 
 Unlike the withdrawal version, the additive fold induction needs only
 domain preservation — the `Unique`{.AgdaDatatype} witness drops out.
@@ -405,7 +405,7 @@ the same credential simply accumulates additions correctly.
 ```
 -->
 
-### `applyDirectDeposits-pov`
+#### `applyDirectDeposits-pov`
 
 Note the slimmed-down signature relative to `applyWithdrawals-pov`: no
 `NetworkId`{.AgdaFunction} premise (none is needed), no

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
@@ -6,26 +6,38 @@ source_path: src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
 ## Properties of `ENTITIES`: Preservation of Value {#thm:ENTITIES-PoV}
 
 This module proves preservation of value for the `ENTITIES`{.AgdaDatatype} and
-`SUBENTITIES`{.AgdaDatatype} rules.
+`SUBENTITIES`{.AgdaDatatype} rules.  Each rule wraps the inner `CERTS`{.AgdaDatatype}
+step with the withdrawal and direct-deposit handling of the transaction given as the
+signal, and its value accounting splits into the two components of
+`getCoin`{.AgdaFunction} on a `CertState`{.AgdaRecord}:
 
-In the Dijkstra era, `ENTITIES`{.AgdaDatatype} (resp. `SUBENTITIES`{.AgdaDatatype})
-wraps the inner `CERTS`{.AgdaDatatype} step with the withdrawal and direct-deposit
-handling of the top-level (resp. sub-level) transaction given as the signal.
-Withdrawals and deposits are applied to the rewards balance before and after
-`CERTS`{.AgdaDatatype}, respectively.  The "value-flow" equation proved below captures
-the net effect of all three components on the cert-state rewards balance
-(`coinFromRewards`{.AgdaFunction}; the deposit pots are accounted separately).
++  **rewards flow** (`SUBENTITIES-pov`{.AgdaFunction}, `ENTITIES-pov`{.AgdaFunction}):
+   the rewards balance grows by the transaction's direct deposits and shrinks by its
+   withdrawals — `CERTS`{.AgdaDatatype} itself preserves it;
 
-Both lemmas take an explicit *no-truncation* hypothesis `amts≤`{.AgdaBound}: each
-withdrawal amount is bounded by the account's balance in the rule's *input* state.
-Since `applyWithdrawals`{.AgdaFunction} uses truncating subtraction (`_∸_`), without
-this bound a withdrawal could claim more coin than actually leaves the rewards pot and
-the value-flow equation would fail.  The spec's own premises bound withdrawals against
-the *pre-batch* snapshot `rewards₀`{.AgdaField} (exactly, per account, in legacy mode),
-which does not by itself bound them against the input state of a later step in the
-batch; see the discussion of the phantom-withdrawal gap in the review of #1256.  The
-hypothesis is discharged at the call site (`Ledger.Properties.PoV`) by dedicated
-module parameters.
++  **deposit flow** (`SUBENTITIES-deposits-pov`{.AgdaFunction},
+   `ENTITIES-deposits-pov`{.AgdaFunction}): the deposit pots change by exactly the
+   new deposits minus the refunds of the transaction's certificates, in the closed
+   form (`newCertDeposits`{.AgdaFunction}/`refundCertDeposits`{.AgdaFunction}) used
+   by the `UTXO`{.AgdaDatatype} batch-balance equation.
+
+`SUBENTITIES-pov-total`{.AgdaFunction} and `ENTITIES-pov-total`{.AgdaFunction}
+combine the two into a single equation for the full `CertState`{.AgdaRecord} coin.
+
+Two hypotheses appear, both about the rule's *input* state:
+
++  a *no-truncation* bound `amts≤`{.AgdaBound}: each withdrawal amount is bounded by
+   the account's balance.  `applyWithdrawals`{.AgdaFunction} uses truncating
+   subtraction (`_∸_`), so without this bound a withdrawal could claim more coin than
+   actually leaves the rewards pot.  The rules' own premises bound withdrawals
+   against the *pre-batch* snapshot `rewards₀`{.AgdaField} (exactly, per account, in
+   top-level legacy mode), which does not by itself bound them against the input
+   state of a later step in the batch, so the bound is taken as a hypothesis here.
+
++  `PoolDepositsRegistered`{.AgdaFunction}: every pool-deposit entry belongs to a
+   registered pool (see `Certs`{.AgdaModule}).  Without it,
+   `POOL-reg`{.AgdaInductiveConstructor}'s left-biased pot update can swallow a
+   deposit that the closed form counts.
 
 <!--
 ```agda
@@ -58,8 +70,18 @@ private variable
 ## The `ENTITIES-PoV` module
 
 `ENTITIES-PoV`{.AgdaModule} inherits the three module parameters of
-`ApplyToRewards-PoV`{.AgdaModule} (which are "obvious" facts which probably ought to
-be proved upstream in the `agda-sets` library).
+`ApplyToRewards-PoV`{.AgdaModule} and assumes four facts about the inner
+`CERTS`{.AgdaDatatype} relation:
+
++  `CERTS-rewards-pov`: `CERTS` preserves the rewards balance;
++  `CERTS-deposits-pov`: over a `CERTS` run, the deposit pots satisfy the closed-form
+   accounting *pre + new ≡ post + refunds*, with `newCertDeposits`{.AgdaFunction}
+   threading the run's initial registered-pool set;
++  `CERTS-deposits-registered`: `CERTS` preserves
+   `PoolDepositsRegistered`{.AgdaFunction};
++  `CERTS-new-thread`: `newCertDeposits`{.AgdaFunction} over an appended certificate
+   list splits at a `CERTS` run boundary, the second half against the run's *final*
+   pool set — this is what lets per-step accounting compose across a batch.
 
 ```agda
 module ENTITIES-PoV
@@ -75,20 +97,39 @@ module ENTITIES-PoV
       → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
       → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
 
-  -- Value preservation of the `CERTS` rule to be proved in `Certs.Properties.PoV` (#1210).
-  ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+  -- Value preservation of the `CERTS` rule --
+
+  ( CERTS-rewards-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
       → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
+
+  ( CERTS-deposits-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → coinFromDeposits s  + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+      ≡ coinFromDeposits s' + refundCertDeposits (PParamsOf Γ) dCerts )
+
+  ( CERTS-deposits-registered : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → PoolDepositsRegistered s' )
+
+  ( CERTS-new-thread : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → (ys : List DCert)
+      → newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) (dCerts ++ ys)
+      ≡ newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+        + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s')) ys )
   where
   open ApplyToRewards-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique public
 ```
 
-## The `SUBENTITIES-pov` theorem
+## Rewards flow
 
 **Informally**.  Let `s`{.AgdaBound}, `s'`{.AgdaBound} be `CertStates`{.AgdaRecord}
 related by `SUBENTITIES`{.AgdaDatatype} with signal `txSub`{.AgdaBound}, and suppose
 each of `txSub`{.AgdaBound}'s withdrawal amounts is bounded by the corresponding
-account balance in `s`{.AgdaBound} (the `amts≤`{.AgdaBound} no-truncation hypothesis).
-Then,
+account balance in `s`{.AgdaBound} (the `amts≤`{.AgdaBound} no-truncation
+hypothesis).  Then,
 
     coinFromRewards s + getCoin (DirectDepositsOf txSub)
       ≡ coinFromRewards s' + getCoin (WithdrawalsOf txSub)
@@ -123,7 +164,7 @@ conditions — are premises of the rule itself.
       getCoin aw + (dd + wdrls)
         ≡˘⟨ +-assoc (getCoin  aw) dd wdrls ⟩
       getCoin aw + dd + wdrls
-        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-pov certsStep) ⟩
+        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-rewards-pov certsStep) ⟩
       (getCoin r₁ + dd) + wdrls
         ≡˘⟨ cong (_+ wdrls) (applyDirectDeposits-pov (DirectDepositsOf txSub) r₁ ddCreds⊆) ⟩
       getCoin (applyDirectDeposits (DirectDepositsOf txSub) r₁) + wdrls
@@ -136,12 +177,10 @@ conditions — are premises of the rule itself.
     aw = applyWithdrawals (WithdrawalsOf txSub) r₀
 ```
 
-## The `ENTITIES-pov` theorem
-
-The top-level analogue, with signal `txTop`{.AgdaBound}: the same value-flow equation,
-by the same argument.  (In legacy mode the rule's own premise forces each top-level
-withdrawal to equal the account's current balance, which implies the `amts≤`{.AgdaBound}
-hypothesis; in normal mode the rule bounds withdrawals only against the pre-batch
+The top-level analogue, with signal `txTop`{.AgdaBound}, by the same argument.  (In
+legacy mode the rule's own premise forces each top-level withdrawal to equal the
+account's current balance, which implies the `amts≤`{.AgdaBound} hypothesis; in
+normal mode the rule bounds withdrawals only against the pre-batch
 `rewards₀`{.AgdaField}, so the hypothesis is genuinely extra information.)
 
 ```agda
@@ -151,11 +190,7 @@ hypothesis; in normal mode the rule bounds withdrawals only against the pre-batc
     → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
     → coinFromRewards s  + getCoin (DirectDepositsOf txTop)
       ≡ coinFromRewards s' + getCoin (WithdrawalsOf txTop)
-```
 
-**Proof**.
-
-```agda
   ENTITIES-pov {txTop = txTop} {s = ⟦ ⟦ _ , _ , r₀ , _ ⟧ᵈ , _ , _ ⟧ᶜˢ}
     amts≤
     (ENTITIES {rewards' = r₁} (wd-netId , wdrls⊆ , _ , _ , _ , _ , certsStep , _ , ddCreds⊆)) =
@@ -169,7 +204,7 @@ hypothesis; in normal mode the rule bounds withdrawals only against the pre-batc
       getCoin aw + (dd + wdrls)
         ≡˘⟨ +-assoc (getCoin  aw) dd wdrls ⟩
       getCoin aw + dd + wdrls
-        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-pov certsStep) ⟩
+        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-rewards-pov certsStep) ⟩
       (getCoin r₁ + dd) + wdrls
         ≡˘⟨ cong (_+ wdrls) (applyDirectDeposits-pov (DirectDepositsOf txTop) r₁ ddCreds⊆) ⟩
       getCoin (applyDirectDeposits (DirectDepositsOf txTop) r₁) + wdrls
@@ -180,4 +215,107 @@ hypothesis; in normal mode the rule bounds withdrawals only against the pre-batc
     wdrls = getCoin (WithdrawalsOf txTop)
     aw : Rewards
     aw = applyWithdrawals (WithdrawalsOf txTop) r₀
+```
+
+## Deposit flow
+
+Withdrawals, direct deposits, and the vote-delegation restriction only touch the
+rewards map, so a `SUBENTITIES`{.AgdaDatatype}/`ENTITIES`{.AgdaDatatype} step changes
+the deposit pots exactly as its inner `CERTS`{.AgdaDatatype} run does: the closed-form
+accounting, the preservation of `PoolDepositsRegistered`{.AgdaFunction}, and the
+`newCertDeposits`{.AgdaFunction} split all transport from the corresponding `CERTS`
+assumptions, definitionally.
+
+```agda
+  SUBENTITIES-deposits-pov : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → coinFromDeposits s
+        + newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub)
+      ≡ coinFromDeposits s'
+        + refundCertDeposits (SubEntitiesEnv.pp Γ) (DCertsOf txSub)
+  SUBENTITIES-deposits-pov registered (SUBENTITIES (_ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-pov registered certsStep
+
+  ENTITIES-deposits-pov : {Γ : EntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
+    → coinFromDeposits s
+        + newCertDeposits (EntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txTop)
+      ≡ coinFromDeposits s'
+        + refundCertDeposits (EntitiesEnv.pp Γ) (DCertsOf txTop)
+  ENTITIES-deposits-pov registered (ENTITIES (_ , _ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-pov registered certsStep
+
+  SUBENTITIES-deposits-registered : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → PoolDepositsRegistered s'
+  SUBENTITIES-deposits-registered registered (SUBENTITIES (_ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-registered registered certsStep
+
+  ENTITIES-deposits-registered : {Γ : EntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
+    → PoolDepositsRegistered s'
+  ENTITIES-deposits-registered registered (ENTITIES (_ , _ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-registered registered certsStep
+
+  SUBENTITIES-new-thread : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → (ys : List DCert)
+    → newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub ++ ys)
+      ≡ newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub)
+        + newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s')) ys
+  SUBENTITIES-new-thread (SUBENTITIES (_ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-new-thread certsStep
+```
+
+## Full value flow
+
+Adding the two flows gives preservation of value for the full `CertState`{.AgdaRecord}
+coin (recall `getCoin`{.AgdaFunction} on a `CertState`{.AgdaRecord} is
+`coinFromRewards`{.AgdaFunction} plus `coinFromDeposits`{.AgdaFunction}): the input
+coin, plus the value flowing in (direct deposits and new certificate deposits),
+equals the output coin, plus the value flowing out (withdrawals and refunds).
+
+```agda
+  private
+    combine-flows : (r d r' d' : Coin) {i₁ i₂ o₁ o₂ : Coin}
+      → r + i₁ ≡ r' + o₁
+      → d + i₂ ≡ d' + o₂
+      → (r + d) + i₁ + i₂ ≡ (r' + d') + o₁ + o₂
+    combine-flows r d r' d' {i₁} {i₂} {o₁} {o₂} eq₁ eq₂ = begin
+      (r + d) + i₁ + i₂     ≡⟨ +-assoc (r + d) i₁ i₂ ⟩
+      (r + d) + (i₁ + i₂)   ≡⟨ +-interleave {r} ⟩
+      (r + i₁) + (d + i₂)   ≡⟨ cong₂ _+_ eq₁ eq₂ ⟩
+      (r' + o₁) + (d' + o₂) ≡˘⟨ +-interleave {r'} ⟩
+      (r' + d') + (o₁ + o₂) ≡˘⟨ +-assoc (r' + d') o₁ o₂ ⟩
+      (r' + d') + o₁ + o₂   ∎
+
+  SUBENTITIES-pov-total : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → ∀[ (addr , amt) ∈ (WithdrawalsOf txSub) ˢ ]
+        amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s) (stake addr))
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → getCoin s + getCoin (DirectDepositsOf txSub)
+        + newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub)
+      ≡ getCoin s' + getCoin (WithdrawalsOf txSub)
+        + refundCertDeposits (SubEntitiesEnv.pp Γ) (DCertsOf txSub)
+  SUBENTITIES-pov-total {s = s} {s' = s'} registered amts≤ step =
+    combine-flows (coinFromRewards s) (coinFromDeposits s) (coinFromRewards s') (coinFromDeposits s')
+                  (SUBENTITIES-pov amts≤ step) (SUBENTITIES-deposits-pov registered step)
+
+  ENTITIES-pov-total : {Γ : EntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → ∀[ (addr , amt) ∈ (WithdrawalsOf txTop) ˢ ]
+        amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s) (stake addr))
+    → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
+    → getCoin s + getCoin (DirectDepositsOf txTop)
+        + newCertDeposits (EntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txTop)
+      ≡ getCoin s' + getCoin (WithdrawalsOf txTop)
+        + refundCertDeposits (EntitiesEnv.pp Γ) (DCertsOf txTop)
+  ENTITIES-pov-total {s = s} {s' = s'} registered amts≤ step =
+    combine-flows (coinFromRewards s) (coinFromDeposits s) (coinFromRewards s') (coinFromDeposits s')
+                  (ENTITIES-pov amts≤ step) (ENTITIES-deposits-pov registered step)
 ```

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
@@ -1,0 +1,183 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
+---
+
+## Properties of `ENTITIES`: Preservation of Value {#thm:ENTITIES-PoV}
+
+This module proves preservation of value for the `ENTITIES`{.AgdaDatatype} and
+`SUBENTITIES`{.AgdaDatatype} rules.
+
+In the Dijkstra era, `ENTITIES`{.AgdaDatatype} (resp. `SUBENTITIES`{.AgdaDatatype})
+wraps the inner `CERTS`{.AgdaDatatype} step with the withdrawal and direct-deposit
+handling of the top-level (resp. sub-level) transaction given as the signal.
+Withdrawals and deposits are applied to the rewards balance before and after
+`CERTS`{.AgdaDatatype}, respectively.  The "value-flow" equation proved below captures
+the net effect of all three components on the cert-state rewards balance
+(`coinFromRewards`{.AgdaFunction}; the deposit pots are accounted separately).
+
+Both lemmas take an explicit *no-truncation* hypothesis `amts≤`{.AgdaBound}: each
+withdrawal amount is bounded by the account's balance in the rule's *input* state.
+Since `applyWithdrawals`{.AgdaFunction} uses truncating subtraction (`_∸_`), without
+this bound a withdrawal could claim more coin than actually leaves the rewards pot and
+the value-flow equation would fail.  The spec's own premises bound withdrawals against
+the *pre-batch* snapshot `rewards₀`{.AgdaField} (exactly, per account, in legacy mode),
+which does not by itself bound them against the input state of a later step in the
+batch; see the discussion of the phantom-withdrawal gap in the review of #1256.  The
+hypothesis is discharged at the call site (`Ledger.Properties.PoV`) by dedicated
+module parameters.
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Transaction using (TransactionStructure)
+
+module Ledger.Dijkstra.Specification.Entities.Properties.PoV
+  (txs : TransactionStructure) (open TransactionStructure txs) where
+
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
+open import Data.Nat.Properties using (+-comm; +-assoc)
+
+open import Ledger.Prelude
+
+open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Entities txs
+open import Ledger.Dijkstra.Specification.Entities.Properties.ApplyToRewardsPoV txs
+  using (module ApplyToRewards-PoV)
+
+open RewardAddress
+open ≡-Reasoning
+
+private variable
+  txTop : TopLevelTx
+  txSub : SubLevelTx
+```
+-->
+
+## The `ENTITIES-PoV` module
+
+`ENTITIES-PoV`{.AgdaModule} inherits the three module parameters of
+`ApplyToRewards-PoV`{.AgdaModule} (which are "obvious" facts which probably ought to
+be proved upstream in the `agda-sets` library).
+
+```agda
+module ENTITIES-PoV
+  ( ∪ˡ-lookup-preserve :
+      (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
+
+  ( sum-map-proj₂≡getCoin :
+    (m : RewardAddress ⇀ Coin) → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  ( setToList-Unique :
+      (m : RewardAddress ⇀ Coin)
+      → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
+  -- Value preservation of the `CERTS` rule to be proved in `Certs.Properties.PoV` (#1210).
+  ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
+  where
+  open ApplyToRewards-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique public
+```
+
+## The `SUBENTITIES-pov` theorem
+
+**Informally**.  Let `s`{.AgdaBound}, `s'`{.AgdaBound} be `CertStates`{.AgdaRecord}
+related by `SUBENTITIES`{.AgdaDatatype} with signal `txSub`{.AgdaBound}, and suppose
+each of `txSub`{.AgdaBound}'s withdrawal amounts is bounded by the corresponding
+account balance in `s`{.AgdaBound} (the `amts≤`{.AgdaBound} no-truncation hypothesis).
+Then,
+
+    coinFromRewards s + getCoin (DirectDepositsOf txSub)
+      ≡ coinFromRewards s' + getCoin (WithdrawalsOf txSub)
+
+All other ingredients — the `NetworkId`{.AgdaFunction} witnesses and the two domain
+conditions — are premises of the rule itself.
+
+**Formally**.
+
+```agda
+  SUBENTITIES-pov : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → ∀[ (addr , amt) ∈ (WithdrawalsOf txSub) ˢ ]
+        amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s) (stake addr))
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → coinFromRewards s  + getCoin (DirectDepositsOf txSub)
+      ≡ coinFromRewards s' + getCoin (WithdrawalsOf txSub)
+```
+
+**Proof**.
+
+```agda
+  SUBENTITIES-pov {txSub = txSub} {s = ⟦ ⟦ _ , _ , r₀ , _ ⟧ᵈ , _ , _ ⟧ᶜˢ}
+    amts≤
+    (SUBENTITIES {rewards' = r₁} (wd-netId , _ , wdrls⊆ , _ , _ , certsStep , _ , ddCreds⊆)) =
+    begin
+      getCoin r₀ + dd
+        ≡⟨ cong (_+ dd) (applyWithdrawals-pov (WithdrawalsOf txSub) r₀ wdrls⊆ wd-netId amts≤) ⟩
+      getCoin aw + wdrls + dd
+        ≡⟨ +-assoc (getCoin aw) wdrls dd ⟩
+      getCoin aw + (wdrls + dd)
+        ≡⟨ cong (getCoin aw +_) (+-comm wdrls dd) ⟩
+      getCoin aw + (dd + wdrls)
+        ≡˘⟨ +-assoc (getCoin  aw) dd wdrls ⟩
+      getCoin aw + dd + wdrls
+        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-pov certsStep) ⟩
+      (getCoin r₁ + dd) + wdrls
+        ≡˘⟨ cong (_+ wdrls) (applyDirectDeposits-pov (DirectDepositsOf txSub) r₁ ddCreds⊆) ⟩
+      getCoin (applyDirectDeposits (DirectDepositsOf txSub) r₁) + wdrls
+        ∎
+    where
+    dd  wdrls : Coin
+    dd = getCoin (DirectDepositsOf txSub)
+    wdrls = getCoin (WithdrawalsOf txSub)
+    aw : Rewards
+    aw = applyWithdrawals (WithdrawalsOf txSub) r₀
+```
+
+## The `ENTITIES-pov` theorem
+
+The top-level analogue, with signal `txTop`{.AgdaBound}: the same value-flow equation,
+by the same argument.  (In legacy mode the rule's own premise forces each top-level
+withdrawal to equal the account's current balance, which implies the `amts≤`{.AgdaBound}
+hypothesis; in normal mode the rule bounds withdrawals only against the pre-batch
+`rewards₀`{.AgdaField}, so the hypothesis is genuinely extra information.)
+
+```agda
+  ENTITIES-pov : {Γ : EntitiesEnv} {s s' : CertState}
+    → ∀[ (addr , amt) ∈ (WithdrawalsOf txTop) ˢ ]
+        amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s) (stake addr))
+    → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
+    → coinFromRewards s  + getCoin (DirectDepositsOf txTop)
+      ≡ coinFromRewards s' + getCoin (WithdrawalsOf txTop)
+```
+
+**Proof**.
+
+```agda
+  ENTITIES-pov {txTop = txTop} {s = ⟦ ⟦ _ , _ , r₀ , _ ⟧ᵈ , _ , _ ⟧ᶜˢ}
+    amts≤
+    (ENTITIES {rewards' = r₁} (wd-netId , wdrls⊆ , _ , _ , _ , _ , certsStep , _ , ddCreds⊆)) =
+    begin
+      getCoin r₀ + dd
+        ≡⟨ cong (_+ dd) (applyWithdrawals-pov (WithdrawalsOf txTop) r₀ wdrls⊆ wd-netId amts≤) ⟩
+      getCoin aw + wdrls + dd
+        ≡⟨ +-assoc (getCoin aw) wdrls dd ⟩
+      getCoin aw + (wdrls + dd)
+        ≡⟨ cong (getCoin aw +_) (+-comm wdrls dd) ⟩
+      getCoin aw + (dd + wdrls)
+        ≡˘⟨ +-assoc (getCoin  aw) dd wdrls ⟩
+      getCoin aw + dd + wdrls
+        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-pov certsStep) ⟩
+      (getCoin r₁ + dd) + wdrls
+        ≡˘⟨ cong (_+ wdrls) (applyDirectDeposits-pov (DirectDepositsOf txTop) r₁ ddCreds⊆) ⟩
+      getCoin (applyDirectDeposits (DirectDepositsOf txTop) r₁) + wdrls
+        ∎
+    where
+    dd  wdrls : Coin
+    dd = getCoin (DirectDepositsOf txTop)
+    wdrls = getCoin (WithdrawalsOf txTop)
+    aw : Rewards
+    aw = applyWithdrawals (WithdrawalsOf txTop) r₀
+```

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
@@ -3,29 +3,45 @@ source_branch: master
 source_path: src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
 ---
 
-## Properties of `ENTITIES`: Preservation of Value {#thm:ENTITIES-PoV}
+# <span class="AgdaDatatype">ENTITIES</span> Preservation of Value {#thm:ENTITIES-PoV}
 
 This module proves preservation of value for the `ENTITIES`{.AgdaDatatype} and
 `SUBENTITIES`{.AgdaDatatype} rules.
 
-In the Dijkstra era, `ENTITIES`{.AgdaDatatype} (resp. `SUBENTITIES`{.AgdaDatatype})
-wraps the inner `CERTS`{.AgdaDatatype} step with the withdrawal and direct-deposit
-handling of the top-level (resp. sub-level) transaction given as the signal.
-Withdrawals and deposits are applied to the rewards balance before and after
-`CERTS`{.AgdaDatatype}, respectively.  The "value-flow" equation proved below captures
-the net effect of all three components on the cert-state rewards balance
-(`coinFromRewards`{.AgdaFunction}; the deposit pots are accounted separately).
+Each rule wraps the inner `CERTS`{.AgdaDatatype} step with the withdrawal and
+direct-deposit handling of the transaction.  Each rule's value accounting splits into
+the following two components of `getCoin`{.AgdaFunction} on a `CertState`{.AgdaRecord}:
 
-Both lemmas take an explicit *no-truncation* hypothesis `amts≤`{.AgdaBound}: each
-withdrawal amount is bounded by the account's balance in the rule's *input* state.
-Since `applyWithdrawals`{.AgdaFunction} uses truncating subtraction (`_∸_`), without
-this bound a withdrawal could claim more coin than actually leaves the rewards pot and
-the value-flow equation would fail.  The spec's own premises bound withdrawals against
-the *pre-batch* snapshot `rewards₀`{.AgdaField} (exactly, per account, in legacy mode),
-which does not by itself bound them against the input state of a later step in the
-batch; see the discussion of the phantom-withdrawal gap in the review of #1256.  The
-hypothesis is discharged at the call site (`Ledger.Properties.PoV`) by dedicated
-module parameters.
++  **rewards flow** (`SUBENTITIES-pov`{.AgdaFunction}, `ENTITIES-pov`{.AgdaFunction}):
+   the rewards balance grows by the transaction's direct deposits and shrinks by its
+   withdrawals, whereas `CERTS`{.AgdaDatatype} preserves rewards balance;
+
++  **deposit flow**
+   (`SUBENTITIES-deposits-pov`{.AgdaFunction}, `ENTITIES-deposits-pov`{.AgdaFunction}):
+   the deposit pots change by exactly the new deposits minus the refunds of the
+   transaction's certificates, in the closed form
+   (`newCertDeposits`{.AgdaFunction}/`refundCertDeposits`{.AgdaFunction}) used by the
+   batch-balance equation of `UTXO`{.AgdaDatatype}.
+
+`SUBENTITIES-pov-total`{.AgdaFunction} and `ENTITIES-pov-total`{.AgdaFunction}
+combine the two into a single equation for the full `CertState`{.AgdaRecord} coin.
+
+Two hypotheses appear, both about the rule's *input* state.
+
+1.  *no-truncation* bound `amts≤`{.AgdaBound}.
+    Each withdrawal amount is bounded by the account's balance.
+    `applyWithdrawals`{.AgdaFunction} uses truncating subtraction (`_∸_`), so without
+    this bound a withdrawal could claim more coin than actually leaves the rewards pot.
+    The rule's own premises bound withdrawals against the pre-batch snapshot
+    `rewards₀`{.AgdaField}, which does not by itself bound them against the input
+    state of a later step in the batch, so the bound is taken as a hypothesis here.
+    In legacy mode, however, the equality premise checks against the rule's current
+    input rewards, not `rewards₀`{.AgdaField}.
+
+2.  `PoolDepositsRegistered`{.AgdaFunction}.
+    Every pool-deposit entry belongs to a registered pool.  Without it,
+    `POOL-reg`{.AgdaInductiveConstructor}'s left-biased pot update can swallow a
+    deposit that the closed form counts.
 
 <!--
 ```agda
@@ -55,11 +71,20 @@ private variable
 ```
 -->
 
-## The `ENTITIES-PoV` module
+## The <span class="AgdaModule">ENTITIES-PoV</span> module
 
 `ENTITIES-PoV`{.AgdaModule} inherits the three module parameters of
-`ApplyToRewards-PoV`{.AgdaModule} (which are "obvious" facts which probably ought to
-be proved upstream in the `agda-sets` library).
+`ApplyToRewards-PoV`{.AgdaModule} and assumes four facts about the inner
+`CERTS`{.AgdaDatatype} relation.
+
+1.  `CERTS-rewards-pov`: `CERTS` preserves the rewards balance;
+2.  `CERTS-deposits-pov`: over a `CERTS` run, the deposit pots satisfy the closed-form
+    accounting *pre + new ≡ post + refunds*, with `newCertDeposits`{.AgdaFunction}
+    threading the run's initial registered-pool set;
+3.  `CERTS-deposits-registered`: `CERTS` preserves `PoolDepositsRegistered`{.AgdaFunction};
+4.  `CERTS-new-thread`: `newCertDeposits`{.AgdaFunction} over an appended certificate
+    list splits at a `CERTS` run boundary, the second half against the run's *final*
+    pool set; this is what lets per-step accounting compose across a batch.
 
 ```agda
 module ENTITIES-PoV
@@ -75,26 +100,45 @@ module ENTITIES-PoV
       → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
       → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
 
-  -- Value preservation of the `CERTS` rule to be proved in `Certs.Properties.PoV` (#1210).
-  ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+  -- Value preservation of the `CERTS` rule --
+
+  ( CERTS-rewards-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
       → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
+
+  ( CERTS-deposits-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → coinFromDeposits s  + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+      ≡ coinFromDeposits s' + refundCertDeposits (PParamsOf Γ) dCerts )
+
+  ( CERTS-deposits-registered : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → PoolDepositsRegistered s' )
+
+  ( CERTS-new-thread : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → (ys : List DCert)
+      → newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) (dCerts ++ ys)
+      ≡ newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+        + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s')) ys )
   where
   open ApplyToRewards-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique public
 ```
 
-## The `SUBENTITIES-pov` theorem
+## Rewards flow
 
 **Informally**.  Let `s`{.AgdaBound}, `s'`{.AgdaBound} be `CertStates`{.AgdaRecord}
 related by `SUBENTITIES`{.AgdaDatatype} with signal `txSub`{.AgdaBound}, and suppose
 each of `txSub`{.AgdaBound}'s withdrawal amounts is bounded by the corresponding
-account balance in `s`{.AgdaBound} (the `amts≤`{.AgdaBound} no-truncation hypothesis).
-Then,
+account balance in `s`{.AgdaBound} (the `amts≤`{.AgdaBound} no-truncation
+hypothesis).  Then,
 
     coinFromRewards s + getCoin (DirectDepositsOf txSub)
-      ≡ coinFromRewards s' + getCoin (WithdrawalsOf txSub)
+    ≡ coinFromRewards s' + getCoin (WithdrawalsOf txSub)
 
-All other ingredients — the `NetworkId`{.AgdaFunction} witnesses and the two domain
-conditions — are premises of the rule itself.
+All other ingredients (the `NetworkId`{.AgdaFunction} witnesses and the two domain
+conditions) are premises of the rule itself.
 
 **Formally**.
 
@@ -123,7 +167,7 @@ conditions — are premises of the rule itself.
       getCoin aw + (dd + wdrls)
         ≡˘⟨ +-assoc (getCoin  aw) dd wdrls ⟩
       getCoin aw + dd + wdrls
-        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-pov certsStep) ⟩
+        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-rewards-pov certsStep) ⟩
       (getCoin r₁ + dd) + wdrls
         ≡˘⟨ cong (_+ wdrls) (applyDirectDeposits-pov (DirectDepositsOf txSub) r₁ ddCreds⊆) ⟩
       getCoin (applyDirectDeposits (DirectDepositsOf txSub) r₁) + wdrls
@@ -132,16 +176,15 @@ conditions — are premises of the rule itself.
     dd  wdrls : Coin
     dd = getCoin (DirectDepositsOf txSub)
     wdrls = getCoin (WithdrawalsOf txSub)
+
     aw : Rewards
     aw = applyWithdrawals (WithdrawalsOf txSub) r₀
 ```
 
-## The `ENTITIES-pov` theorem
-
-The top-level analogue, with signal `txTop`{.AgdaBound}: the same value-flow equation,
-by the same argument.  (In legacy mode the rule's own premise forces each top-level
-withdrawal to equal the account's current balance, which implies the `amts≤`{.AgdaBound}
-hypothesis; in normal mode the rule bounds withdrawals only against the pre-batch
+The top-level analogue, with signal `txTop`{.AgdaBound}, by the same argument.  (In
+legacy mode the rule's own premise forces each top-level withdrawal to equal the
+account's current balance, which implies the `amts≤`{.AgdaBound} hypothesis; in
+normal mode the rule bounds withdrawals only against the pre-batch
 `rewards₀`{.AgdaField}, so the hypothesis is genuinely extra information.)
 
 ```agda
@@ -151,11 +194,7 @@ hypothesis; in normal mode the rule bounds withdrawals only against the pre-batc
     → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
     → coinFromRewards s  + getCoin (DirectDepositsOf txTop)
       ≡ coinFromRewards s' + getCoin (WithdrawalsOf txTop)
-```
 
-**Proof**.
-
-```agda
   ENTITIES-pov {txTop = txTop} {s = ⟦ ⟦ _ , _ , r₀ , _ ⟧ᵈ , _ , _ ⟧ᶜˢ}
     amts≤
     (ENTITIES {rewards' = r₁} (wd-netId , wdrls⊆ , _ , _ , _ , _ , certsStep , _ , ddCreds⊆)) =
@@ -169,7 +208,7 @@ hypothesis; in normal mode the rule bounds withdrawals only against the pre-batc
       getCoin aw + (dd + wdrls)
         ≡˘⟨ +-assoc (getCoin  aw) dd wdrls ⟩
       getCoin aw + dd + wdrls
-        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-pov certsStep) ⟩
+        ≡⟨ cong (λ x → (x + dd) + wdrls) (CERTS-rewards-pov certsStep) ⟩
       (getCoin r₁ + dd) + wdrls
         ≡˘⟨ cong (_+ wdrls) (applyDirectDeposits-pov (DirectDepositsOf txTop) r₁ ddCreds⊆) ⟩
       getCoin (applyDirectDeposits (DirectDepositsOf txTop) r₁) + wdrls
@@ -180,4 +219,108 @@ hypothesis; in normal mode the rule bounds withdrawals only against the pre-batc
     wdrls = getCoin (WithdrawalsOf txTop)
     aw : Rewards
     aw = applyWithdrawals (WithdrawalsOf txTop) r₀
+```
+
+## Deposit flow
+
+Outside the inner CERTS run, a `SUBENTITIES`{.AgdaDatatype}/`ENTITIES`{.AgdaDatatype}
+step touches only the rewards map (withdrawals and direct deposits), and the DRep
+activity refresh, never the deposit pots.  So deposit pots change exactly as the
+inner `CERTS`{.AgdaDatatype} run does, that is, the closed-form accounting, the
+preservation of `PoolDepositsRegistered`{.AgdaFunction}, and the
+`newCertDeposits`{.AgdaFunction} split all transport from the corresponding
+`CERTS`{.AgdaDatatype} assumptions, definitionally.
+
+```agda
+  SUBENTITIES-deposits-pov : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → coinFromDeposits s
+        + newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub)
+      ≡ coinFromDeposits s'
+        + refundCertDeposits (SubEntitiesEnv.pp Γ) (DCertsOf txSub)
+  SUBENTITIES-deposits-pov registered (SUBENTITIES (_ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-pov registered certsStep
+
+  ENTITIES-deposits-pov : {Γ : EntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
+    → coinFromDeposits s
+        + newCertDeposits (EntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txTop)
+      ≡ coinFromDeposits s'
+        + refundCertDeposits (EntitiesEnv.pp Γ) (DCertsOf txTop)
+  ENTITIES-deposits-pov registered (ENTITIES (_ , _ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-pov registered certsStep
+
+  SUBENTITIES-deposits-registered : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → PoolDepositsRegistered s'
+  SUBENTITIES-deposits-registered registered (SUBENTITIES (_ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-registered registered certsStep
+
+  ENTITIES-deposits-registered : {Γ : EntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
+    → PoolDepositsRegistered s'
+  ENTITIES-deposits-registered registered (ENTITIES (_ , _ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-deposits-registered registered certsStep
+
+  SUBENTITIES-new-thread : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → (ys : List DCert)
+    → newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub ++ ys)
+      ≡ newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub)
+        + newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s')) ys
+  SUBENTITIES-new-thread (SUBENTITIES (_ , _ , _ , _ , _ , certsStep , _ , _)) =
+    CERTS-new-thread certsStep
+```
+
+## Full value flow
+
+Adding the two flows gives preservation of value for the full `CertState`{.AgdaRecord}
+coin (recall `getCoin`{.AgdaFunction} on a `CertState`{.AgdaRecord} is
+`coinFromRewards`{.AgdaFunction} plus `coinFromDeposits`{.AgdaFunction}): the input
+coin, plus the value flowing in (direct deposits and new certificate deposits),
+equals the output coin, plus the value flowing out (withdrawals and refunds).
+
+```agda
+  private
+    combine-flows : (r d r' d' : Coin) {i₁ i₂ o₁ o₂ : Coin}
+      → r + i₁ ≡ r' + o₁
+      → d + i₂ ≡ d' + o₂
+      → (r + d) + i₁ + i₂ ≡ (r' + d') + o₁ + o₂
+    combine-flows r d r' d' {i₁} {i₂} {o₁} {o₂} eq₁ eq₂ = begin
+      (r + d) + i₁ + i₂     ≡⟨ +-assoc (r + d) i₁ i₂ ⟩
+      (r + d) + (i₁ + i₂)   ≡⟨ +-interleave {r} ⟩
+      (r + i₁) + (d + i₂)   ≡⟨ cong₂ _+_ eq₁ eq₂ ⟩
+      (r' + o₁) + (d' + o₂) ≡˘⟨ +-interleave {r'} ⟩
+      (r' + d') + (o₁ + o₂) ≡˘⟨ +-assoc (r' + d') o₁ o₂ ⟩
+      (r' + d') + o₁ + o₂   ∎
+
+  SUBENTITIES-pov-total : {Γ : SubEntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → ∀[ (addr , amt) ∈ (WithdrawalsOf txSub) ˢ ]
+        amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s) (stake addr))
+    → Γ ⊢ s ⇀⦇ txSub ,SUBENTITIES⦈ s'
+    → getCoin s + getCoin (DirectDepositsOf txSub)
+        + newCertDeposits (SubEntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txSub)
+      ≡ getCoin s' + getCoin (WithdrawalsOf txSub)
+        + refundCertDeposits (SubEntitiesEnv.pp Γ) (DCertsOf txSub)
+  SUBENTITIES-pov-total {s = s} {s' = s'} registered amts≤ step =
+    combine-flows (coinFromRewards s) (coinFromDeposits s) (coinFromRewards s') (coinFromDeposits s')
+                  (SUBENTITIES-pov amts≤ step) (SUBENTITIES-deposits-pov registered step)
+
+  ENTITIES-pov-total : {Γ : EntitiesEnv} {s s' : CertState}
+    → PoolDepositsRegistered s
+    → ∀[ (addr , amt) ∈ (WithdrawalsOf txTop) ˢ ]
+        amt ≤ maybe id 0 (lookupᵐ? (RewardsOf s) (stake addr))
+    → Γ ⊢ s ⇀⦇ txTop ,ENTITIES⦈ s'
+    → getCoin s + getCoin (DirectDepositsOf txTop)
+        + newCertDeposits (EntitiesEnv.pp Γ) (dom (PoolsOf s)) (DCertsOf txTop)
+      ≡ getCoin s' + getCoin (WithdrawalsOf txTop)
+        + refundCertDeposits (EntitiesEnv.pp Γ) (DCertsOf txTop)
+  ENTITIES-pov-total {s = s} {s' = s'} registered amts≤ step =
+    combine-flows (coinFromRewards s) (coinFromDeposits s) (coinFromRewards s') (coinFromDeposits s')
+                  (ENTITIES-pov amts≤ step) (ENTITIES-deposits-pov registered step)
 ```

--- a/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
@@ -6,20 +6,21 @@ source_path: src/Ledger/Dijkstra/Specification/Entities/Properties/PoV.lagda.md
 ## Properties of `ENTITIES`: Preservation of Value {#thm:ENTITIES-PoV}
 
 This module proves preservation of value for the `ENTITIES`{.AgdaDatatype} and
-`SUBENTITIES`{.AgdaDatatype} rules.  Each rule wraps the inner `CERTS`{.AgdaDatatype}
-step with the withdrawal and direct-deposit handling of the transaction given as the
-signal, and its value accounting splits into the two components of
-`getCoin`{.AgdaFunction} on a `CertState`{.AgdaRecord}:
+`SUBENTITIES`{.AgdaDatatype} rules.
+
+Each rule wraps the inner `CERTS`{.AgdaDatatype} step with the withdrawal and
+direct-deposit handling of the transaction.  Each rule's value accounting splits into
+the following two components of `getCoin`{.AgdaFunction} on a `CertState`{.AgdaRecord}:
 
 +  **rewards flow** (`SUBENTITIES-pov`{.AgdaFunction}, `ENTITIES-pov`{.AgdaFunction}):
    the rewards balance grows by the transaction's direct deposits and shrinks by its
-   withdrawals — `CERTS`{.AgdaDatatype} itself preserves it;
+   withdrawals, whereas `CERTS`{.AgdaDatatype} preserves rewards balance;
 
 +  **deposit flow** (`SUBENTITIES-deposits-pov`{.AgdaFunction},
    `ENTITIES-deposits-pov`{.AgdaFunction}): the deposit pots change by exactly the
    new deposits minus the refunds of the transaction's certificates, in the closed
    form (`newCertDeposits`{.AgdaFunction}/`refundCertDeposits`{.AgdaFunction}) used
-   by the `UTXO`{.AgdaDatatype} batch-balance equation.
+   by the batch-balance equation of `UTXO`{.AgdaDatatype}.
 
 `SUBENTITIES-pov-total`{.AgdaFunction} and `ENTITIES-pov-total`{.AgdaFunction}
 combine the two into a single equation for the full `CertState`{.AgdaRecord} coin.
@@ -30,9 +31,10 @@ Two hypotheses appear, both about the rule's *input* state:
    the account's balance.  `applyWithdrawals`{.AgdaFunction} uses truncating
    subtraction (`_∸_`), so without this bound a withdrawal could claim more coin than
    actually leaves the rewards pot.  The rules' own premises bound withdrawals
-   against the *pre-batch* snapshot `rewards₀`{.AgdaField} (exactly, per account, in
-   top-level legacy mode), which does not by itself bound them against the input
-   state of a later step in the batch, so the bound is taken as a hypothesis here.
+   against the *pre-batch* snapshot `rewards₀`{.AgdaField}, which does not by itself
+   bound them against the input state of a later step in the batch, so the bound is
+   taken as a hypothesis here.  In legacy mode, however, the equality premise checks
+   against the rule's current input rewards, not `rewards₀`{.AgdaField}.
 
 +  `PoolDepositsRegistered`{.AgdaFunction}: every pool-deposit entry belongs to a
    registered pool (see `Certs`{.AgdaModule}).  Without it,
@@ -77,11 +79,10 @@ private variable
 +  `CERTS-deposits-pov`: over a `CERTS` run, the deposit pots satisfy the closed-form
    accounting *pre + new ≡ post + refunds*, with `newCertDeposits`{.AgdaFunction}
    threading the run's initial registered-pool set;
-+  `CERTS-deposits-registered`: `CERTS` preserves
-   `PoolDepositsRegistered`{.AgdaFunction};
++  `CERTS-deposits-registered`: `CERTS` preserves `PoolDepositsRegistered`{.AgdaFunction};
 +  `CERTS-new-thread`: `newCertDeposits`{.AgdaFunction} over an appended certificate
    list splits at a `CERTS` run boundary, the second half against the run's *final*
-   pool set — this is what lets per-step accounting compose across a batch.
+   pool set; this is what lets per-step accounting compose across a batch.
 
 ```agda
 module ENTITIES-PoV
@@ -132,10 +133,10 @@ account balance in `s`{.AgdaBound} (the `amts≤`{.AgdaBound} no-truncation
 hypothesis).  Then,
 
     coinFromRewards s + getCoin (DirectDepositsOf txSub)
-      ≡ coinFromRewards s' + getCoin (WithdrawalsOf txSub)
+    ≡ coinFromRewards s' + getCoin (WithdrawalsOf txSub)
 
-All other ingredients — the `NetworkId`{.AgdaFunction} witnesses and the two domain
-conditions — are premises of the rule itself.
+All other ingredients (the `NetworkId`{.AgdaFunction} witnesses and the two domain
+conditions) are premises of the rule itself.
 
 **Formally**.
 
@@ -173,6 +174,7 @@ conditions — are premises of the rule itself.
     dd  wdrls : Coin
     dd = getCoin (DirectDepositsOf txSub)
     wdrls = getCoin (WithdrawalsOf txSub)
+
     aw : Rewards
     aw = applyWithdrawals (WithdrawalsOf txSub) r₀
 ```

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -172,23 +172,43 @@ allColdCreds govSt es =
   ccCreds (es .cc) ∪ concatMapˢ (λ (_ , st) → proposedCC (GovActionOf st)) (fromList govSt)
 ```
 
-`LedgerState`{.AgdaRecord} holds three coin-bearing components:
+`LedgerState`{.AgdaRecord} holds four coin-bearing components:
 
-1. UTxO state (UTxO balance plus fees plus donations)
-2. the rewards balance in `DState.rewards`{.AgdaField};
-3. The three `CertState`{.AgdaRecord} deposit fields, via `getCoin`{.AgdaFunction}:
+1. UTxO state (UTxO balance plus fees plus donations);
+2. the rewards balance in `DState.rewards`{.AgdaField}, summed by
+   `coinFromRewards`{.AgdaFunction};
+3. the three `CertState`{.AgdaRecord} deposit pots, summed by
+   `coinFromDeposits`{.AgdaFunction}:
 
    + `DState.deposits`{.AgdaField} (stake-key deposits, `Credential ⇀ Coin`)
    + `PState.deposits`{.AgdaField} (pool deposits, `KeyHash ⇀ Coin`)
-   + `GState.deposits`{.AgdaField} (governance action deposits, `Credential ⇀ Coin`)
+   + `GState.deposits`{.AgdaField} (`DRep` deposits, `Credential ⇀ Coin`);
+
+4. the governance-action deposits, summed by `coinFromGovDeposit`{.AgdaFunction} over
+   `GovActionState.deposit`{.AgdaField} for each action in the current
+   `GovState`{.AgdaRecord}.
+
+Components 2 and 3 are exactly `getCoin`{.AgdaFunction} of the
+`CertState`{.AgdaRecord}.  Component 4 is needed because the `UTXO`{.AgdaDatatype}
+batch-balance equation charges `govProposalsDeposits`{.AgdaFunction} on the
+*produced* side: the deposit leaves the UTxO pot when a proposal is submitted and is
+recorded in `GovActionState.deposit`{.AgdaField} by the `GOV`{.AgdaDatatype} rule —
+it is not kept in `GState.deposits`{.AgdaField}, so `coinFromDeposits`{.AgdaFunction}
+alone does not account for it.
+
+```agda
+coinFromGovDeposit : GovState → Coin
+coinFromGovDeposit = foldr (λ (_ , gaSt) acc → GovActionState.deposit gaSt + acc) 0
+```
 
 <!--
 ```agda
 instance
   HasCoin-LedgerState : HasCoin LedgerState
   HasCoin-LedgerState .getCoin s =  getCoin (UTxOStateOf s)
-                                    + rewardsBalance (DStateOf (CertStateOf s))
-                                    + getCoin (DepositsOf (DStateOf s)) + getCoin (DepositsOf (PStateOf s)) + getCoin (DepositsOf (GStateOf s))
+                                    + coinFromRewards (CertStateOf s)
+                                    + coinFromDeposits (CertStateOf s)
+                                    + coinFromGovDeposit (GovStateOf s)
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties.lagda.md
@@ -14,4 +14,5 @@ module Ledger.Dijkstra.Specification.Ledger.Properties where
 
 ```agda
 open import Ledger.Dijkstra.Specification.Ledger.Properties.Computational
+open import Ledger.Dijkstra.Specification.Ledger.Properties.PoV
 ```

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -39,7 +39,7 @@ gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (
 
 ??? note "**Status: complete**"
 
-    `LEDGER-pov`{.AgdaFunction}n typechecks end-to-end under `--safe` (no
+    `LEDGER-pov`{.AgdaFunction} typechecks end-to-end under `--safe` (no
     postulates or holes).  Following the top-down plan, this module proves only the
     top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
     as *module parameters*, discharged downstream:

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -116,10 +116,12 @@ module Ledger.Dijkstra.Specification.Ledger.Properties.PoV
   (abs : AbstractFunctions txs) (open AbstractFunctions abs)
   where
 
+open import Data.Nat.Base using () renaming (_+_ to infixl 6 _+ᴺ_)
 open import Data.Nat.Properties
   using (+-comm; +-assoc; +-0-monoid; +-identityʳ; +-cancelʳ-≡)
-open import Data.Integer using (ℤ; 0ℤ; _-_; _⊖_)
-open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n) renaming (+-comm to +ℤ-comm)
+open import Data.Nat.Tactic.RingSolver using (solve-∀; solve)
+open import Data.Integer using (ℤ; _⊖_)
+open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n)
 open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
 
 open import Ledger.Prelude
@@ -348,10 +350,24 @@ the `left-unique` field as an unresolved meta.
 
 ## Small arithmetic helpers
 
+The pure `+`-rearrangement lemmas in this module are discharged by the reflective
+ring solver over the commutative semiring of naturals
+(`Data.Nat.Tactic.RingSolver`): `solve-∀`{.AgdaMacro} proves a closed, universally
+quantified equation outright, and the in-context `solve`{.AgdaMacro} (applied to the
+list of atoms) proves an equation whose variables are already in scope — needed
+where a lemma's trailing variables are implicit, since `solve-∀`{.AgdaMacro} only
+handles visible binders.  Only the statements remain, which keeps the equational
+chains readable.
+
+One wrinkle: the solver recognises the ring's operations *syntactically*, so the
+`Ledger.Prelude` overloaded `_+_` (a `HasAdd`{.AgdaRecord} method, which merely
+*reduces* to `Data.Nat._+_`) defeats it.  The solver-facing statements are therefore
+written with the raw natural-number addition, imported as `_+ᴺ_` — definitionally
+equal to `_+_` at `Coin`, so the lemmas discharge `_+_` goals unchanged.
+
 ```agda
-  swap-right : ∀ a b c → a + b + c ≡ a + c + b
-  swap-right a b c = trans (+-assoc a b c)
-                           (trans (cong (a +_) (+-comm b c)) (sym (+-assoc a c b)))
+  swap-right : ∀ a b c → a +ᴺ b +ᴺ c ≡ a +ᴺ c +ᴺ b
+  swap-right = solve-∀
 
   -- Per-sub-tx withdrawal and direct-deposit totals.
   wdrwl : SubLevelTx → Coin
@@ -652,20 +668,11 @@ the gov-deposit accounting).
 
 The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
 `arithmetic-N` helpers, and `mid-extract`/`rearr3`/`outer-rearr` (for the gov summand)
-— all pure `+`-monoid rearrangements.  Commutative steps go through `swap-right`, so
-`solve-macro` (a *non-normalising* monoid solver) cannot discharge them directly; they
-are stated explicitly to keep the chain readable.
+— all pure `+`-rearrangements, discharged by the ring solver.
 
 ```agda
-      abcd-to-acdb : ∀ a b c d → a + b + c + d ≡ a + c + d + b
-      abcd-to-acdb a b c d = begin
-        a + b + c + d     ≡⟨ cong (_+ d) (+-assoc a b c) ⟩
-        a + (b + c) + d   ≡⟨ cong (λ x → a + x + d) (+-comm b c) ⟩
-        a + (c + b) + d   ≡⟨ cong (_+ d) (sym (+-assoc a c b)) ⟩
-        a + c + b + d     ≡⟨ +-assoc (a + c) b d ⟩
-        a + c + (b + d)   ≡⟨ cong ((a + c) +_) (+-comm b d) ⟩
-        a + c + (d + b)   ≡⟨ sym (+-assoc (a + c) d b) ⟩
-        a + c + d + b     ∎
+      abcd-to-acdb : ∀ a b c d → a +ᴺ b +ᴺ c +ᴺ d ≡ a +ᴺ c +ᴺ d +ᴺ b
+      abcd-to-acdb = solve-∀
 
       U₀ U₁ U₂ : Coin
       U₀ = getCoin (UTxOStateOf s)
@@ -709,26 +716,15 @@ are stated explicitly to keep the chain readable.
                            (SubTransactionsOf tx))
       totGov    = topGov + subGovSum
 
-      -- Pure +-monoid rearrangements for threading the gov summand.
-      mid-extract : ∀ a b c d → a + (b + d) + c ≡ a + b + c + d
-      mid-extract a b c d = trans (cong (_+ c) (sym (+-assoc a b d)))
-                                  (swap-right (a + b) d c)
+      -- Pure +-rearrangements for threading the gov summand.
+      mid-extract : ∀ a b c d → a +ᴺ (b +ᴺ d) +ᴺ c ≡ a +ᴺ b +ᴺ c +ᴺ d
+      mid-extract = solve-∀
 
-      rearr3 : ∀ a b c → a + b + c ≡ c + b + a
-      rearr3 a b c = begin
-        a + b + c   ≡⟨ swap-right a b c ⟩
-        a + c + b   ≡⟨ cong (_+ b) (+-comm a c) ⟩
-        c + a + b   ≡⟨ swap-right c a b ⟩
-        c + b + a   ∎
+      rearr3 : ∀ a b c → a +ᴺ b +ᴺ c ≡ c +ᴺ b +ᴺ a
+      rearr3 = solve-∀
 
-      outer-rearr : ∀ u a d g r → u + a + d + g + r ≡ u + r + d + g + a
-      outer-rearr u a d g r = begin
-        u + a + d + g + r   ≡⟨ swap-right (u + a + d) g r ⟩
-        u + a + d + r + g   ≡⟨ cong (_+ g) (swap-right (u + a) d r) ⟩
-        u + a + r + d + g   ≡⟨ cong (λ x → x + d + g) (swap-right u a r) ⟩
-        u + r + a + d + g   ≡⟨ cong (_+ g) (swap-right (u + r) a d) ⟩
-        u + r + d + a + g   ≡⟨ swap-right (u + r + d) a g ⟩
-        u + r + d + g + a   ∎
+      outer-rearr : ∀ u a d g r → u +ᴺ a +ᴺ d +ᴺ g +ᴺ r ≡ u +ᴺ r +ᴺ d +ᴺ g +ᴺ a
+      outer-rearr = solve-∀
 ```
 
 The "combined" `ENTITIES-pov` invocation: pre-batch `certState` + all direct deposits
@@ -868,32 +864,12 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
         net-arith A B G PZ NZ Pt Ps Nt Ns D0 D2 bal sf pn =
           +-cancelʳ-≡ (D0 + PZ) (A + Nt + Ns) (B + Pt + Ps + G) big
           where
-          rearr-X : (A + Nt + Ns) + (D2 + NZ) ≡ (A + NZ) + (Nt + Ns + D2)
-          rearr-X = begin
-            (A + Nt + Ns) + (D2 + NZ)   ≡˘⟨ +-assoc (A + Nt + Ns) D2 NZ ⟩
-            A + Nt + Ns + D2 + NZ        ≡⟨ swap-right (A + Nt + Ns) D2 NZ ⟩
-            A + Nt + Ns + NZ + D2        ≡⟨ cong (_+ D2) (swap-right (A + Nt) Ns NZ) ⟩
-            A + Nt + NZ + Ns + D2        ≡⟨ cong (λ w → w + Ns + D2) (swap-right A Nt NZ) ⟩
-            A + NZ + Nt + Ns + D2        ≡⟨ +-assoc (A + NZ + Nt) Ns D2 ⟩
-            A + NZ + Nt + (Ns + D2)      ≡⟨ +-assoc (A + NZ) Nt (Ns + D2) ⟩
-            A + NZ + (Nt + (Ns + D2))    ≡⟨ cong (A + NZ +_) (sym (+-assoc Nt Ns D2)) ⟩
-            (A + NZ) + (Nt + Ns + D2)    ∎
-          rearr-Y : Nt + Ns + D2 ≡ D2 + Nt + Ns
-          rearr-Y = trans (+-comm (Nt + Ns) D2) (sym (+-assoc D2 Nt Ns))
-          rearr-Z : (B + PZ + G) + (D0 + Pt + Ps) ≡ (B + Pt + Ps + G) + (D0 + PZ)
-          rearr-Z = begin
-            (B + PZ + G) + (D0 + Pt + Ps)   ≡˘⟨ +-assoc (B + PZ + G) (D0 + Pt) Ps ⟩
-            (B + PZ + G) + (D0 + Pt) + Ps    ≡˘⟨ cong (_+ Ps) (+-assoc (B + PZ + G) D0 Pt) ⟩
-            (B + PZ + G) + D0 + Pt + Ps      ≡⟨ cong (λ w → w + D0 + Pt + Ps) (swap-right B PZ G) ⟩
-            B + G + PZ + D0 + Pt + Ps        ≡⟨ cong (λ w → w + Pt + Ps) (swap-right (B + G) PZ D0) ⟩
-            B + G + D0 + PZ + Pt + Ps        ≡⟨ cong (_+ Ps) (swap-right (B + G + D0) PZ Pt) ⟩
-            B + G + D0 + Pt + PZ + Ps        ≡⟨ swap-right (B + G + D0 + Pt) PZ Ps ⟩
-            B + G + D0 + Pt + Ps + PZ        ≡⟨ cong (λ w → w + Ps + PZ) (swap-right (B + G) D0 Pt) ⟩
-            B + G + Pt + D0 + Ps + PZ        ≡⟨ cong (λ w → w + PZ) (swap-right (B + G + Pt) D0 Ps) ⟩
-            B + G + Pt + Ps + D0 + PZ        ≡⟨ cong (λ w → w + Ps + D0 + PZ) (swap-right B G Pt) ⟩
-            B + Pt + G + Ps + D0 + PZ        ≡⟨ cong (λ w → w + D0 + PZ) (swap-right (B + Pt) G Ps) ⟩
-            B + Pt + Ps + G + D0 + PZ        ≡⟨ +-assoc (B + Pt + Ps + G) D0 PZ ⟩
-            (B + Pt + Ps + G) + (D0 + PZ)    ∎
+          rearr-X : (A +ᴺ Nt +ᴺ Ns) +ᴺ (D2 +ᴺ NZ) ≡ (A +ᴺ NZ) +ᴺ (Nt +ᴺ Ns +ᴺ D2)
+          rearr-X = solve (A ∷ Nt ∷ Ns ∷ D2 ∷ NZ ∷ [])
+          rearr-Y : Nt +ᴺ Ns +ᴺ D2 ≡ D2 +ᴺ Nt +ᴺ Ns
+          rearr-Y = solve (Nt ∷ Ns ∷ D2 ∷ [])
+          rearr-Z : (B +ᴺ PZ +ᴺ G) +ᴺ (D0 +ᴺ Pt +ᴺ Ps) ≡ (B +ᴺ Pt +ᴺ Ps +ᴺ G) +ᴺ (D0 +ᴺ PZ)
+          rearr-Z = solve (B ∷ PZ ∷ G ∷ D0 ∷ Pt ∷ Ps ∷ [])
           big : (A + Nt + Ns) + (D0 + PZ) ≡ (B + Pt + Ps + G) + (D0 + PZ)
           big = begin
             (A + Nt + Ns) + (D0 + PZ)     ≡⟨ cong (A + Nt + Ns +_) sf ⟩
@@ -938,19 +914,15 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
         reshuffle-to-DD :
             O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
           ≡ O + F + DN + (DDtop + subDirectDepsCoin) + Psub + posPart dct + posPart dcs
-        reshuffle-to-DD = begin
-          O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
-            ≡⟨ cong (_+ posPart dcs) (sym (+-assoc (O + F + DN + DDtop + posPart dct) Psub subDirectDepsCoin)) ⟩
-          O + F + DN + DDtop + posPart dct + Psub + subDirectDepsCoin + posPart dcs
-            ≡⟨ cong (_+ posPart dcs) (swap-right (O + F + DN + DDtop + posPart dct) Psub subDirectDepsCoin) ⟩
-          O + F + DN + DDtop + posPart dct + subDirectDepsCoin + Psub + posPart dcs
-            ≡⟨ cong (λ x → x + Psub + posPart dcs) (swap-right (O + F + DN + DDtop) (posPart dct) subDirectDepsCoin) ⟩
-          O + F + DN + DDtop + subDirectDepsCoin + posPart dct + Psub + posPart dcs
-            ≡⟨ cong (_+ posPart dcs) (swap-right (O + F + DN + DDtop + subDirectDepsCoin) (posPart dct) Psub) ⟩
-          O + F + DN + DDtop + subDirectDepsCoin + Psub + posPart dct + posPart dcs
-            ≡⟨ cong (λ x → x + Psub + posPart dct + posPart dcs) (+-assoc (O + F + DN) DDtop subDirectDepsCoin) ⟩
-          O + F + DN + (DDtop + subDirectDepsCoin) + Psub + posPart dct + posPart dcs
-            ∎
+        reshuffle-to-DD =
+          go O F DN DDtop (posPart dct) Psub subDirectDepsCoin (posPart dcs)
+          where
+          -- `solve` matches its atoms syntactically, which the `where`-bound
+          -- abbreviations above defeat; generalise to a closed ∀-goal instead.
+          go : ∀ o f dn dd pt psub sdd pcs
+             → o +ᴺ f +ᴺ dn +ᴺ dd +ᴺ pt +ᴺ (psub +ᴺ sdd) +ᴺ pcs
+             ≡ o +ᴺ f +ᴺ dn +ᴺ (dd +ᴺ sdd) +ᴺ psub +ᴺ pt +ᴺ pcs
+          go = solve-∀
 ```
 
 The main inner chain, showing LHS + E ≡ RHS + E:
@@ -999,74 +971,32 @@ The main inner chain, showing LHS + E ≡ RHS + E:
         where
 ```
 
-The five `arithmetic-N` helpers are pure `+`-monoid rearrangements, each unfolded
-explicitly:
+The five `arithmetic-N` helpers are pure `+`-rearrangements.  Their trailing
+variables are implicit (each is determined by the goal at the call site), so they are
+discharged by the in-context `solve`{.AgdaMacro} rather than `solve-∀`{.AgdaMacro}:
 
 ```agda
         arithmetic-1 : ∀ a b c {d}{e}{f}{g}
-          → a + b + c + (d + e + f + g) ≡ a + b + c + d + e + f + g
-        arithmetic-1 a b c {d}{e}{f}{g} = begin
-          a + b + c + (d + e + f + g)  ≡˘⟨ +-assoc (a + b + c) (d + e + f) g ⟩
-          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
-          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
-          a + b + c + d + e + f + g    ∎
+          → a +ᴺ b +ᴺ c +ᴺ (d +ᴺ e +ᴺ f +ᴺ g) ≡ a +ᴺ b +ᴺ c +ᴺ d +ᴺ e +ᴺ f +ᴺ g
+        arithmetic-1 a b c {d}{e}{f}{g} = solve (a ∷ b ∷ c ∷ d ∷ e ∷ f ∷ g ∷ [])
 
         arithmetic-2 : ∀ a b c {d}{e}{f}{g}
-          → a + b + c + d + e + f + g ≡ a + e + b + (c + f + g) + d
-        arithmetic-2 a b c {d}{e}{f}{g} = begin
-          a + b + c + d + e + f + g    ≡⟨ cong (λ x → x + f + g) (swap-right (a + b + c) d e) ⟩
-          a + b + c + e + d + f + g    ≡⟨ cong (_+ g) (swap-right (a + b + c + e) d f) ⟩
-          a + b + c + e + f + d + g    ≡⟨ swap-right (a + b + c + e + f) d g ⟩
-          a + b + c + e + f + g + d    ≡⟨ cong (λ x → x + f + g + d) (swap-right (a + b) c e) ⟩
-          a + b + e + c + f + g + d    ≡⟨ cong (λ x → x + c + f + g + d) (swap-right a b e) ⟩
-          a + e + b + c + f + g + d    ≡⟨ cong (_+ d) reassoc-middle ⟩
-          a + e + b + (c + f + g) + d  ∎
-          where
-          reassoc-middle : a + e + b + c + f + g ≡ a + e + b + (c + f + g)
-          reassoc-middle = trans (+-assoc (a + e + b + c) f g)
-                                 (trans (+-assoc (a + e + b) c (f + g))
-                                        (cong (a + e + b +_) (sym (+-assoc c f g))))
+          → a +ᴺ b +ᴺ c +ᴺ d +ᴺ e +ᴺ f +ᴺ g ≡ a +ᴺ e +ᴺ b +ᴺ (c +ᴺ f +ᴺ g) +ᴺ d
+        arithmetic-2 a b c {d}{e}{f}{g} = solve (a ∷ b ∷ c ∷ d ∷ e ∷ f ∷ g ∷ [])
 
         arithmetic-3 : ∀ a b c {d}{e}{f}{g}
-          → a + b + c + (d + e + f) + g ≡ a + (g + c + b + e + f) + d
-        arithmetic-3 a b c {d}{e}{f}{g} = begin
-          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
-          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
-          a + b + c + d + e + f + g    ≡⟨ swap-right (a + b + c + d + e) f g ⟩
-          a + b + c + d + e + g + f    ≡⟨ cong (_+ f) (swap-right (a + b + c + d) e g) ⟩
-          a + b + c + d + g + e + f    ≡⟨ cong (λ x → x + e + f) (swap-right (a + b + c) d g) ⟩
-          a + b + c + g + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + b) c g) ⟩
-          a + b + g + c + d + e + f    ≡⟨ cong (λ x → x + c + d + e + f) (swap-right a b g) ⟩
-          a + g + b + c + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + g) b c) ⟩
-          a + g + c + b + d + e + f    ≡⟨ cong (_+ f) (swap-right (a + g + c + b) d e) ⟩
-          a + g + c + b + e + d + f    ≡⟨ swap-right (a + g + c + b + e) d f ⟩
-          a + g + c + b + e + f + d    ≡⟨ cong (λ x → x + b + e + f + d) (+-assoc a g c) ⟩
-          a + (g + c) + b + e + f + d  ≡⟨ cong (λ x → x + e + f + d) (+-assoc a (g + c) b) ⟩
-          a + (g + c + b) + e + f + d  ≡⟨ cong (λ x → x + f + d) (+-assoc a (g + c + b) e) ⟩
-          a + (g + c + b + e) + f + d  ≡⟨ cong (_+ d) (+-assoc a (g + c + b + e) f) ⟩
-          a + (g + c + b + e + f) + d  ∎
+          → a +ᴺ b +ᴺ c +ᴺ (d +ᴺ e +ᴺ f) +ᴺ g ≡ a +ᴺ (g +ᴺ c +ᴺ b +ᴺ e +ᴺ f) +ᴺ d
+        arithmetic-3 a b c {d}{e}{f}{g} = solve (a ∷ b ∷ c ∷ d ∷ e ∷ f ∷ g ∷ [])
 
         arithmetic-4 : ∀ a b c {d}{e}{f}{g}{h}{i}
-          → a + (b + c + d + e + f + g + h) + i ≡ a + b + c + d + e + f + g + h + i
-        arithmetic-4 a b c {d}{e}{f}{g}{h}{i} = cong (_+ i) $
-          begin
-          a + (b + c + d + e + f + g + h)  ≡˘⟨ +-assoc a _ h ⟩
-          a + (b + c + d + e + f + g) + h  ≡˘⟨ cong (_+ h) (+-assoc a _ g) ⟩
-          a + (b + c + d + e + f) + g + h  ≡˘⟨ cong (λ x → x + g + h) (+-assoc a _ f) ⟩
-          a + (b + c + d + e) + f + g + h  ≡˘⟨ cong (λ x → x + f + g + h) (+-assoc a _ e) ⟩
-          a + (b + c + d) + e + f + g + h  ≡˘⟨ cong (λ x → x + e + f + g + h) (+-assoc a _ d) ⟩
-          a + (b + c) + d + e + f + g + h  ≡˘⟨ cong (λ x → x + d + e + f + g + h) (+-assoc a b c) ⟩
-          a + b + c + d + e + f + g + h    ∎
+          → a +ᴺ (b +ᴺ c +ᴺ d +ᴺ e +ᴺ f +ᴺ g +ᴺ h) +ᴺ i
+          ≡ a +ᴺ b +ᴺ c +ᴺ d +ᴺ e +ᴺ f +ᴺ g +ᴺ h +ᴺ i
+        arithmetic-4 a b c {d}{e}{f}{g}{h}{i} =
+          solve (a ∷ b ∷ c ∷ d ∷ e ∷ f ∷ g ∷ h ∷ i ∷ [])
 
         arithmetic-5 : ∀ a b c {d}{e}{f}{g}
-          → a + b + c + d + e + f + g ≡ a + c + g + b + d + e + f
-        arithmetic-5 a b c {d}{e}{f}{g} = begin
-          a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + d + e + f + g) (swap-right a b c) ⟩
-          a + c + b + d + e + f + g  ≡⟨ swap-right (a + c + b + d + e) f g ⟩
-          a + c + b + d + e + g + f  ≡⟨ cong (_+ f) (swap-right (a + c + b + d) e g) ⟩
-          a + c + b + d + g + e + f  ≡⟨ cong (λ x → x + e + f) (swap-right (a + c + b) d g) ⟩
-          a + c + b + g + d + e + f  ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + c) b g) ⟩
-          a + c + g + b + d + e + f  ∎
+          → a +ᴺ b +ᴺ c +ᴺ d +ᴺ e +ᴺ f +ᴺ g ≡ a +ᴺ c +ᴺ g +ᴺ b +ᴺ d +ᴺ e +ᴺ f
+        arithmetic-5 a b c {d}{e}{f}{g} = solve (a ∷ b ∷ c ∷ d ∷ e ∷ f ∷ g ∷ [])
 ```
 
 Finally, `step-ii`: extract the actual equation from `LHS+E≡RHS+E` by cancelling `E`

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -9,8 +9,9 @@ This module proves the top-level preservation-of-value (PoV) theorem for the Dij
 `LEDGER`{.AgdaDatatype} rule.  If
 
 +  `Γ` is a ledger environment,
-+  `tx` is top-level transaction, and
-+  `s` and `s'` are ledger states related by `LEDGER`{.AgdaDatatype},
++  `tx` is a top-level transaction,
++  `s` and `s'` are ledger states related by `LEDGER`{.AgdaDatatype}, and
++  `s` satisfies `PoolDepositsRegistered`{.AgdaFunction} (see `Certs`{.AgdaModule}),
 
 then `getCoin s ≡ getCoin s'`.
 
@@ -24,56 +25,20 @@ Recall (from `Ledger.lagda.md`) that `getCoin (LedgerState)` is
 This is the sum of UTxO coin, the cert-state rewards balance
 (`coinFromRewards`{.AgdaFunction}), the deposits from `DState`{.AgdaRecord},
 `PState`{.AgdaRecord}, and `GState`{.AgdaRecord} (`coinFromDeposits`{.AgdaFunction}),
-and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}).
+and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}); the two
+middle summands are exactly `getCoin (CertStateOf s)`.
 
-Note `getCoin (CertState)` itself now sums the rewards balance *and* the deposit pots
-(`coinFromRewards + coinFromDeposits`), so the two middle summands are exactly
-`getCoin (CertStateOf s)`.
+The `LEDGER-V` chain accounts for all four summands.  The cert deposits cancel via
+the direct-deposit trick (see *Proof Strategy*), and the gov-deposit growth
+`G' − G₀` is matched against the produced-side `totGov` (the `gov-acc` lemma, from
+`SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
 
-`getCoin` on a `LedgerState` has the four summands above — UTxO coin, rewards
-balance, the cert-deposit pots (`coinFromDeposits`), and the gov-action deposits
-(`coinFromGovDeposit`) — and the `LEDGER-V` chain accounts for all four.  The cert
-deposits cancel via the direct-deposit trick (see *Proof Strategy*), and the
-gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (the
-`gov-acc` lemma, from `SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
-
-??? note "**Status: complete**"
-
-    `LEDGER-pov`{.AgdaFunction} typechecks end-to-end under `--safe` (no
-    postulates or holes).  Following the top-down plan, this module proves only the
-    top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
-    as *module parameters*, discharged downstream:
-
-    +  **Certs-PoV** (`CERTS-pov`, `batch-cert-deposits-bridge`).
-
-    +  **Utxo/Utxow-PoV** (`utxow-pov-invalid`, `UTXOW-V-mechanical`,
-       `UTXOW-batch-balance-coin`, and the UTxO algebra `balance-∪`, `split-balance`,
-       `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`, etc.).
-
-       `UTXOW-batch-balance-coin` is the coin projection of the spec's
-       `consumedBatch ≡ producedBatch` premise, with the produced-side
-       `govProposalsDeposits` collected into a single trailing `totGov` term.
-       Its cert-deposit summands are obtained from `refundCertDeposits` and
-       `newCertDeposits` over `allDCerts tx`, against the pre-batch registered-pool
-       set, keeping it a pure UTxO obligation; `bat'` converts these to the chain's
-       top/sub two-level form using the `batch-cert-deposits-bridge` and
-       `posNeg-deposits`.
-
-    +  **Gov-deposit accounting** (`rmOrphanDRepVotes-coinFromGovDeposit`,
-       `GOVS-coinFromGovDeposit`), to be supplied by a future `Gov.Properties.PoV`.
-
-    +  **No-truncation bounds** (`ENTITIES-wdrls-bounded`, `SUBENTITIES-wdrls-bounded`).
-
-       Each withdrawal amount is bounded by the account's balance in the input state of
-       the `ENTITIES`/`SUBENTITIES` step that consumes it.
-
-       **N.B.**  The premises of the spec transition rules bound withdrawals only
-       against the *pre-batch* snapshot `rewards₀` (except top-level legacy mode,
-       which forces exact-balance withdrawals), which does not by itself bound them
-       against the input state of a later step in the batch. This is the
-       phantom-withdrawal gap.[^1] As such, these module parameters should be
-       discharged in the follow-up to that discussion, either by spec rule premises
-       or by a batch-threading invariant.
+The `PoolDepositsRegistered`{.AgdaFunction} hypothesis is necessary, not an artifact
+of the proof: the batch balance charges `newCertDeposits`{.AgdaFunction} against the
+registered-pool set, while `POOL-reg`{.AgdaInductiveConstructor}'s left-biased pot
+update silently keeps a stale entry for an unregistered pool — at a state with such
+an entry, a pool registration destroys the charged deposit and the theorem is false.
+On-chain states satisfy the hypothesis by construction.
 
 ## Proof Strategy
 
@@ -89,14 +54,18 @@ the central trick — direct-deposit value appears both on the UTxO side (via
 `producedBatch`) and on the CertState side (via `applyDirectDeposits` inside
 `ENTITIES`) and cancels in the total.
 
-Concretely, the proof uses three helper lemmas.
+Concretely, the proof composes four inductions over the `SUBLEDGERS`{.AgdaDatatype}
+reflexive-transitive closure, plus one arithmetic identity.
 
-+  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** inducts over the `SUBLEDGERS`{.AgdaDatatype}
-   reflexive-transitive closure, threading the per-`SUBUTXOW` coin equation
++  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** threads the per-`SUBUTXOW` coin equation
    (`subutxow-step-coin`).
-+  **`SUBLEDGERS-certs-pov`{.AgdaFunction}** is parallel induction over
-   `SUBLEDGERS`{.AgdaDatatype}, composing per-sub-transaction
-   `SUBENTITIES-pov`{.AgdaFunction} invocations.
++  **`SUBLEDGERS-certs-pov`{.AgdaFunction}** composes per-sub-transaction
+   `SUBENTITIES-pov`{.AgdaFunction} invocations (the rewards flow).
++  **`SUBLEDGERS-deposits`{.AgdaFunction}** (with `SUBLEDGERS-registered`{.AgdaFunction})
+   telescopes the per-step closed-form deposit accounting into the batch-wide
+   equation consumed by `bat'`.
++  **`SUBLEDGERS-gov-coin`{.AgdaFunction}** accumulates the per-`GOVS` gov-deposit
+   growth.
 +  **`posNeg-deposits`{.AgdaFunction}** equationally relates the pre-/post-batch deposit
    totals to the `posPart`/`negPart` of `calculateDepositsChange`.
 
@@ -122,6 +91,7 @@ open import Data.Nat.Properties
 open import Data.Nat.Tactic.RingSolver using (solve-∀; solve)
 open import Data.Integer using (ℤ; _⊖_)
 open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n)
+open import Data.List.Properties using (++-assoc)
 open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
 
 open import Ledger.Prelude
@@ -152,25 +122,24 @@ instance
 
 ## The `LEDGER-PoV` module
 
-`LEDGER-pov`{.AgdaFunction} currently depends on module parameters from the following
-groups:
+The supporting facts about the auxiliary transition systems are module parameters,
+in five groups:
 
-+  the three set/map identities from `ApplyToRewards-PoV`{.AgdaModule}
++  the set/map identities consumed by `ApplyToRewards-PoV`{.AgdaModule}
    (`∪ˡ-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique`);
-+  the UTxO arithmetic / freshness assumptions and batch-wide invariants
++  the UTxO facts: coin equations for the `UTXOW`/`SUBUTXOW` steps and batch-wide
+   freshness/disjointness invariants
    (`balance-∪`, `split-balance`, `noMintTx`, `noMintSubTx`, `outs-disjoint`,
    `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`,
    `utxow-pov-invalid`, `UTXOW-V-mechanical`, `UTXOW-batch-balance-coin`);
-+  the Certs facts (`CERTS-pov`, `batch-cert-deposits-bridge`);
++  the Certs facts: value accounting for a single `CERTS`{.AgdaDatatype} run
+   (`CERTS-rewards-pov`, `CERTS-deposits-pov`, `CERTS-deposits-registered`,
+   `CERTS-new-thread`, `refundCertDeposits-++`);
 +  the governance-deposit facts (`rmOrphanDRepVotes-coinFromGovDeposit`,
-   `GOVS-coinFromGovDeposit`) from a future `Gov.Properties.PoV`;
+   `GOVS-coinFromGovDeposit`);
 +  the no-truncation withdrawal bounds (`ENTITIES-wdrls-bounded`,
-   `SUBENTITIES-wdrls-bounded`), the phantom-withdrawal gap,[^1]
-   to be discharged by a spec-side premise or a batch-threading invariant.
-
-All are stated with detailed provenance notes in comments and are to be discharged in
-follow-up work.  This parameter list is the frozen interface between this proof and
-the follow-ups.
+   `SUBENTITIES-wdrls-bounded`); see `Entities.Properties.PoV`{.AgdaModule} for why
+   these are not consequences of the rules' own premises.
 
 ```agda
 noMintingSubTxs : TopLevelTx → Type
@@ -237,37 +206,41 @@ module LEDGER-PoV
       → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
 
-  -- Certs-PoV stubs to be discharged in follow-up PR
-  ( CERTS-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+  -- Value accounting for a single CERTS run (consumed via `ENTITIES-PoV`):
+  -- rewards preservation; closed-form deposit accounting (which needs the
+  -- pool-deposit registration invariant, see `PoolDepositsRegistered` in `Certs`);
+  -- preservation of that invariant; and the `newCertDeposits` split at a CERTS-run
+  -- boundary, against the run's final pool set — what lets per-step accounting
+  -- compose across a batch.
+  ( CERTS-rewards-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
       → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
 
-  -- Batch-wide cert-deposit bridge (discharged later).  The closed-form
-  -- deposit accounting over *all* batch certs balances against actual
-  -- `coinFromDeposits` evolution from pre-batch cert state `CertStateOf ls₀` to
-  -- post-`ENTITIES` cert state `cs₂`:
-  --
-  --     D₀ + newCertDeposits ≡ D₂ + refundCertDeposits
-  --
-  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over sub-txs,
-  -- then top-level `ENTITIES`); composing per-step cert bridges across the batch is
-  -- follow-up (CERTS PoV) work.
-  ( batch-cert-deposits-bridge :
-      {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
-      → SubLedgerEnv.isTopLevelValid Γsub ≡ true
-      → Γsub ⊢ ls₀ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ls₁
-      → Γe ⊢ CertStateOf ls₁ ⇀⦇ tx ,ENTITIES⦈ cs₂
-      → coinFromDeposits (CertStateOf ls₀)
-          + newCertDeposits (PParamsOf Γe) (dom (PoolsOf (CertStateOf ls₀))) (allDCerts tx)
-        ≡ coinFromDeposits cs₂
-          + refundCertDeposits (PParamsOf Γe) (allDCerts tx) )
+  ( CERTS-deposits-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → coinFromDeposits s  + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+      ≡ coinFromDeposits s' + refundCertDeposits (PParamsOf Γ) dCerts )
 
-  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see review of #1256).
-  -- `applyWithdrawals` subtracts with `_∸_`, so ENTITIES/SUBENTITIES value-flow
-  -- equations need each withdrawal amount bounded by account's balance in the
-  -- *input* state of the step that consumes it.  Premises bound withdrawals only
-  -- against the pre-batch `rewards₀` (except top-level legacy mode), so these facts
-  -- are assumed here, to be discharged by a spec-side premise or a batch-threading
-  -- invariant in follow-up to that discussion.
+  ( CERTS-deposits-registered : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → PoolDepositsRegistered s' )
+
+  ( CERTS-new-thread : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → (ys : List DCert)
+      → newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) (dCerts ++ ys)
+      ≡ newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+        + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s')) ys )
+
+  -- `refundCertDeposits` is a plain fold over the certificate list; it distributes
+  -- over concatenation.
+  ( refundCertDeposits-++ : (pp' : PParams) (xs ys : List DCert)
+      → refundCertDeposits pp' (xs ++ ys)
+      ≡ refundCertDeposits pp' xs + refundCertDeposits pp' ys )
+
+  -- No-truncation withdrawal bounds; see `Entities.Properties.PoV` for why these
+  -- are hypotheses rather than consequences of the rules' own premises.
   ( ENTITIES-wdrls-bounded : {Γe : EntitiesEnv} {cs cs' : CertState}
       → Γe ⊢ cs ⇀⦇ tx ,ENTITIES⦈ cs'
       → ∀[ (addr , amt) ∈ (WithdrawalsOf tx) ˢ ]
@@ -277,9 +250,9 @@ module LEDGER-PoV
       → ∀[ (addr , amt) ∈ (WithdrawalsOf stx) ˢ ]
           amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
 
-  -- Governance-deposit accounting (to be discharged by future `Gov.Properties.PoV`).
-  -- `rmOrphanDRepVotes` only rewrites `votes.gvDRep`, never `GovActionState.deposit`,
-  -- so it leaves `coinFromGovDeposit` unchanged.
+  -- Governance-deposit accounting.  `rmOrphanDRepVotes` only rewrites
+  -- `votes.gvDRep`, never `GovActionState.deposit`, so it leaves
+  -- `coinFromGovDeposit` unchanged.
   ( rmOrphanDRepVotes-coinFromGovDeposit :
       (cs : CertState) (g : GovState)
       → coinFromGovDeposit (rmOrphanDRepVotes cs g) ≡ coinFromGovDeposit g )
@@ -292,7 +265,7 @@ module LEDGER-PoV
       → coinFromGovDeposit govSt′
         ≡ coinFromGovDeposit govSt + govProposalsDeposits (PParamsOf Γ) (proposalsOf props) )
 
-  -- Utxo/Utxow-PoV facts (discharged later) --
+  -- Utxo/Utxow-PoV facts --
 
   -- Invalid top-level tx: the UTXOW step preserves UTxO coin.
   ( utxow-pov-invalid : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
@@ -308,11 +281,11 @@ module LEDGER-PoV
         ≡ getCoin s₁ + cbalance (UTxOOf s₀ ∣ SpendInputsOf tx) )
 
   -- Closed-form coin projection of the batch balance `consumedBatch ≡ producedBatch`
-  -- (discharged by UTXO/UTXOW PoV; minted terms drop by `noMintTx`/`noMintSubTx`).
-  -- cert-deposit summands are in spec's *closed form*:
-  -- `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with pool set drawn
-  -- from environment's pre-batch `pools₀`, keeping this a pure UTxO obligation.
-  -- governance-deposit summands sit on produced side, matching `producedTx`.
+  -- (the minted terms drop by `noMintTx`/`noMintSubTx`).  The cert-deposit summands
+  -- are in the spec's *closed form* — `refundCertDeposits`/`newCertDeposits` over
+  -- `allDCerts tx`, with the pool set drawn from the environment's pre-batch
+  -- `pools₀` — keeping this a pure UTxO obligation.  The governance-deposit summands
+  -- sit on the produced side, matching `producedTx`.
   ( UTXOW-batch-balance-coin : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
       → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
       → cbalance (UTxOOf Γ' ∣ SpendInputsOf tx) + getCoin (WithdrawalsOf tx)
@@ -328,10 +301,9 @@ module LEDGER-PoV
                        (SubTransactionsOf tx)) ) )
   where
 
-  open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique CERTS-pov
-
-  -- When UTXOW PoV proof lands, we'll uncomment the following line, adding appropriate args.
-  -- open UTXOW-PoV ...
+  open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+                    CERTS-rewards-pov CERTS-deposits-pov CERTS-deposits-registered
+                    CERTS-new-thread
 ```
 
 ## Small arithmetic helpers
@@ -341,7 +313,7 @@ ring solver over the commutative semiring of naturals (`Data.Nat.Tactic.RingSolv
 `solve-∀`{.AgdaMacro} proves a closed, universally quantified equation outright, and
 the in-context `solve`{.AgdaMacro} (applied to the list of atoms) proves an equation
 whose variables are already in scope; this is needed where a lemma's trailing
-variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binders.[^2]
+variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binders.[^1]
 
 ```agda
   swap-right : ∀ a b c → a +ᴺ b +ᴺ c ≡ a +ᴺ c +ᴺ b
@@ -360,8 +332,9 @@ variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binde
 The cert-deposit change is the integer delta of `coinFromDeposits`{.AgdaFunction} at
 the top and sub levels.  The `LEDGER-V` chain tracks the deposit pots in this
 two-level `posPart`/`negPart` form; `bat'` obtains it from the closed-form
-`UTXOW-batch-balance-coin`{.AgdaFunction} parameter via the
-`batch-cert-deposits-bridge`{.AgdaFunction} and `posNeg-deposits`{.AgdaFunction}.
+`UTXOW-batch-balance-coin`{.AgdaFunction} parameter via the batch-wide deposit
+accounting (`bridgeEq`, composed by `SUBLEDGERS-deposits`{.AgdaFunction}) and
+`posNeg-deposits`{.AgdaFunction}.
 
 ```agda
   DepositsChange : Type
@@ -525,6 +498,109 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     ih = SUBLEDGERS-certs-pov isV rest
 ```
 
+## `SUBLEDGERS-deposits`
+
+Composing the per-step deposit accounting across the batch.
+`refund-concatMap`{.AgdaFunction} distributes `refundCertDeposits`{.AgdaFunction}
+over the batch's certificate lists; `SUBLEDGERS-registered`{.AgdaFunction} threads
+the pool-deposit registration invariant; and `SUBLEDGERS-deposits`{.AgdaFunction}
+telescopes the per-step closed forms, using
+`SUBENTITIES-new-thread`{.AgdaFunction} to split `newCertDeposits`{.AgdaFunction} at
+each step boundary — necessary because the pool set a `regpool` is charged against
+evolves through the batch.  The trailing certificate list `ys`{.AgdaBound}
+generalises the statement so the induction goes through; the `LEDGER-V` proof
+instantiates it with the top-level transaction's certificates.
+
+```agda
+  refund-concatMap : (pp' : PParams) (stxs : List SubLevelTx)
+    → refundCertDeposits pp' (concatMap DCertsOf stxs)
+    ≡ sum (map (refundCertDeposits pp' ∘ DCertsOf) stxs)
+  refund-concatMap pp' []           = refl
+  refund-concatMap pp' (stx ∷ stxs) =
+    trans (refundCertDeposits-++ pp' (DCertsOf stx) (concatMap DCertsOf stxs))
+          (cong (refundCertDeposits pp' (DCertsOf stx) +_) (refund-concatMap pp' stxs))
+
+  SUBLEDGERS-registered :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
+    → Γ .isTopLevelValid ≡ true
+    → PoolDepositsRegistered (CertStateOf s₀)
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → PoolDepositsRegistered (CertStateOf s₁)
+
+  SUBLEDGERS-registered _ registered (BS-base Id-nop) = registered
+
+  SUBLEDGERS-registered isV _ (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-registered isV registered (BS-ind (SUBLEDGER-V (_ , _ , entitiesStep , _)) rest) =
+    SUBLEDGERS-registered isV (SUBENTITIES-deposits-registered registered entitiesStep) rest
+
+  SUBLEDGERS-deposits :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
+    → Γ .isTopLevelValid ≡ true
+    → PoolDepositsRegistered (CertStateOf s₀)
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → (ys : List DCert)
+    → coinFromDeposits (CertStateOf s₀)
+        + newCertDeposits (Γ .pparams) (dom (PoolsOf (CertStateOf s₀))) (concatMap DCertsOf stxs ++ ys)
+    ≡ coinFromDeposits (CertStateOf s₁)
+        + sum (map (refundCertDeposits (Γ .pparams) ∘ DCertsOf) stxs)
+        + newCertDeposits (Γ .pparams) (dom (PoolsOf (CertStateOf s₁))) ys
+
+  SUBLEDGERS-deposits {Γ} {s₀ = s₀} _ _ (BS-base Id-nop) ys =
+    cong (_+ newCertDeposits (Γ .pparams) (dom (PoolsOf (CertStateOf s₀))) ys)
+         (sym (+-identityʳ (coinFromDeposits (CertStateOf s₀))))
+
+  SUBLEDGERS-deposits isV _ (BS-ind (SUBLEDGER-I (isI , _)) _) ys =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-deposits {Γ} isV registered (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) ys =
+    begin
+      D₀ + new P₀ ((DCertsOf stx ++ concatMap DCertsOf sigs) ++ ys)
+        ≡⟨ cong (λ l → D₀ + new P₀ l) (++-assoc (DCertsOf stx) (concatMap DCertsOf sigs) ys) ⟩
+      D₀ + new P₀ (DCertsOf stx ++ (concatMap DCertsOf sigs ++ ys))
+        ≡⟨ cong (D₀ +_) (SUBENTITIES-new-thread entitiesStep (concatMap DCertsOf sigs ++ ys)) ⟩
+      D₀ + (new P₀ (DCertsOf stx) + new P₁ (concatMap DCertsOf sigs ++ ys))
+        ≡˘⟨ +-assoc D₀ (new P₀ (DCertsOf stx)) (new P₁ (concatMap DCertsOf sigs ++ ys)) ⟩
+      D₀ + new P₀ (DCertsOf stx) + new P₁ (concatMap DCertsOf sigs ++ ys)
+        ≡⟨ cong (_+ new P₁ (concatMap DCertsOf sigs ++ ys))
+                (SUBENTITIES-deposits-pov registered entitiesStep) ⟩
+      D₁ + refund₀ + new P₁ (concatMap DCertsOf sigs ++ ys)
+        ≡⟨ swap-right D₁ refund₀ (new P₁ (concatMap DCertsOf sigs ++ ys)) ⟩
+      D₁ + new P₁ (concatMap DCertsOf sigs ++ ys) + refund₀
+        ≡⟨ cong (_+ refund₀) (SUBLEDGERS-deposits isV registered₁ rest ys) ⟩
+      Dₙ + refundSum + new Pₙ ys + refund₀
+        ≡⟨ resh Dₙ refundSum (new Pₙ ys) refund₀ ⟩
+      Dₙ + (refund₀ + refundSum) + new Pₙ ys
+        ∎
+    where
+    new : ℙ KeyHash → List DCert → Coin
+    new = newCertDeposits (Γ .pparams)
+
+    D₀ D₁ Dₙ refund₀ refundSum : Coin
+    D₀ = coinFromDeposits (CertStateOf s₀)
+    D₁ = coinFromDeposits (CertStateOf s₁)
+    Dₙ = coinFromDeposits (CertStateOf sₙ)
+    refund₀   = refundCertDeposits (Γ .pparams) (DCertsOf stx)
+    refundSum = sum (map (refundCertDeposits (Γ .pparams) ∘ DCertsOf) sigs)
+
+    P₀ P₁ Pₙ : ℙ KeyHash
+    P₀ = dom (PoolsOf (CertStateOf s₀))
+    P₁ = dom (PoolsOf (CertStateOf s₁))
+    Pₙ = dom (PoolsOf (CertStateOf sₙ))
+
+    registered₁ : PoolDepositsRegistered (CertStateOf s₁)
+    registered₁ = SUBENTITIES-deposits-registered registered entitiesStep
+
+    resh : ∀ a b c d → a +ᴺ b +ᴺ c +ᴺ d ≡ a +ᴺ (d +ᴺ b) +ᴺ c
+    resh = solve-∀
+```
+
 ## `SUBLEDGERS-gov-coin`
 
 Induct over `SUBLEDGERS`, threading the per-`GOVS` gov-deposit growth: each
@@ -593,8 +669,12 @@ premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
 
 ## `LEDGER-pov`
 
+The pool-deposit registration hypothesis concerns the initial state only; it is
+threaded through the batch by `SUBLEDGERS-registered`{.AgdaFunction} where needed.
+
 ```agda
   LEDGER-pov : {Γ : LedgerEnv} {s s' : LedgerState}
+    → PoolDepositsRegistered (CertStateOf s)
     → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
 ```
 
@@ -605,7 +685,7 @@ are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
 `utxow-pov-invalid`.
 
 ```agda
-  LEDGER-pov {Γ} {s} (LEDGER-I (invalid , _ , utxoStep)) =
+  LEDGER-pov {Γ} {s} _ (LEDGER-I (invalid , _ , utxoStep)) =
     cong  ( λ u → u  + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
                      + coinFromGovDeposit (GovStateOf s) )
           ( utxow-pov-invalid utxoStep invalid )
@@ -634,7 +714,7 @@ The body assembles the four-summand goal from two `where`-lemmas.
 +  **`gov-acc`**: `totGov+G₀ ≡ G'`, the gov-deposit accounting.
 
 ```agda
-  LEDGER-pov {Γ} {s}
+  LEDGER-pov {Γ} {s} registered₀
     (LEDGER-V {utxoState₁ = us₁} {govState₁ = govSt₁} {certState₁ = cs₁}
               {certState₂ = cs₂} {govState₂ = govSt₂} {utxoState₂ = us₂}
               (valid , subStep , entitiesStep , govStep , utxoStep)) =
@@ -865,18 +945,53 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
             (B + PZ + G) + (D0 + Pt + Ps) ≡⟨ rearr-Z ⟩
             (B + Pt + Ps + G) + (D0 + PZ) ∎
 
-        -- The #1186 closed-form batch balance (cert deposits in the spec's closed
-        -- form, over `allDCerts tx` against the pre-batch registered-pool set).
+        -- The closed-form batch balance (cert deposits in the spec's closed form,
+        -- over `allDCerts tx` against the pre-batch registered-pool set).
         closedEq : Ctop + Wtop + CsubW + refundCertDeposits pp (allDCerts tx)
                  ≡ O + F + DN + DDtop + PsubDD
                    + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx) + totGov
         closedEq = UTXOW-batch-balance-coin utxoStep
 
-        -- The #1210 batch cert-deposit bridge, in ℕ form:
-        -- pre-batch deposits + new deposits ≡ post-batch deposits + refunds.
+        -- Batch-wide cert-deposit accounting, in ℕ form: pre-batch deposits + new
+        -- deposits ≡ post-batch deposits + refunds.  Composed from the per-step
+        -- SUBENTITIES/ENTITIES deposit equations: `SUBLEDGERS-deposits` telescopes
+        -- the sub-transactions (leaving the top-level certificates as the trailing
+        -- list), `ENTITIES-deposits-pov` accounts for the top-level step, and the
+        -- refunds recombine via `refund-concatMap`/`refundCertDeposits-++`.
         bridgeEq : D₀ + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx)
                  ≡ D₂ + refundCertDeposits pp (allDCerts tx)
-        bridgeEq = batch-cert-deposits-bridge valid subStep entitiesStep
+        bridgeEq = begin
+          D₀ + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx)
+            ≡⟨ SUBLEDGERS-deposits valid registered₀ subStep (DCertsOf tx) ⟩
+          D₁' + refundSubs + newCertDeposits pp P₁ (DCertsOf tx)
+            ≡⟨ swap-right D₁' refundSubs (newCertDeposits pp P₁ (DCertsOf tx)) ⟩
+          D₁' + newCertDeposits pp P₁ (DCertsOf tx) + refundSubs
+            ≡⟨ cong (_+ refundSubs) (ENTITIES-deposits-pov registered₁ entitiesStep) ⟩
+          D₂ + refundCertDeposits pp (DCertsOf tx) + refundSubs
+            ≡⟨ swap-right D₂ (refundCertDeposits pp (DCertsOf tx)) refundSubs ⟩
+          D₂ + refundSubs + refundCertDeposits pp (DCertsOf tx)
+            ≡˘⟨ cong (λ x → D₂ + x + refundCertDeposits pp (DCertsOf tx))
+                     (refund-concatMap pp (SubTransactionsOf tx)) ⟩
+          D₂ + refundCertDeposits pp (concatMap DCertsOf (SubTransactionsOf tx))
+             + refundCertDeposits pp (DCertsOf tx)
+            ≡⟨ +-assoc D₂ (refundCertDeposits pp (concatMap DCertsOf (SubTransactionsOf tx)))
+                          (refundCertDeposits pp (DCertsOf tx)) ⟩
+          D₂ + ( refundCertDeposits pp (concatMap DCertsOf (SubTransactionsOf tx))
+               + refundCertDeposits pp (DCertsOf tx) )
+            ≡˘⟨ cong (D₂ +_)
+                     (refundCertDeposits-++ pp (concatMap DCertsOf (SubTransactionsOf tx)) (DCertsOf tx)) ⟩
+          D₂ + refundCertDeposits pp (allDCerts tx)
+            ∎
+          where
+          D₁' refundSubs : Coin
+          D₁' = coinFromDeposits cs₁
+          refundSubs = sum (map (refundCertDeposits pp ∘ DCertsOf) (SubTransactionsOf tx))
+
+          P₁ : ℙ KeyHash
+          P₁ = dom (PoolsOf cs₁)
+
+          registered₁ : PoolDepositsRegistered cs₁
+          registered₁ = SUBLEDGERS-registered valid registered₀ subStep
 
         -- Convert the closed-form balance to the chain's two-level posPart/negPart
         -- form, via `net-arith` fed the bridge (`bridgeEq`) and the two-level
@@ -1021,9 +1136,7 @@ on both sides:
                                   (proposalsOf-Proposals+Votes tx))
 ```
 
-[^1]: See the review of PR #1256.
-
-[^2]: One wrinkle: the solver recognises the ring's operations *syntactically*, so
+[^1]: One wrinkle: the solver recognises the ring's operations *syntactically*, so
       the `Ledger.Prelude` overloaded `_+_` (a `HasAdd`{.AgdaRecord} method, which merely
       *reduces* to `Data.Nat._+_`) defeats it.  The solver-facing statements are therefore
       written with the raw natural-number addition, imported as `_+ᴺ_` — definitionally

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -3,9 +3,9 @@ source_branch: master
 source_path: src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
 ---
 
-# Properties of `LEDGER`: Preservation of Value {#thm:LEDGER-PoV}
+# Properties of <span class="AgdaDatatype">LEDGER</span>: Preservation of Value {#thm:LEDGER-PoV}
 
-This module proves the top-level preservation-of-value (PoV) theorem for the Dijkstra
+This module proves the top-level preservation-of-value theorem for the Dijkstra
 `LEDGER`{.AgdaDatatype} rule.  If
 
 +  `Γ` is a ledger environment,
@@ -15,62 +15,70 @@ This module proves the top-level preservation-of-value (PoV) theorem for the Dij
 
 then `getCoin s ≡ getCoin s'`.
 
-Recall (from `Ledger.lagda.md`) that `getCoin (LedgerState)` is
+Recall from the `Ledger`{.AgdaModule} module that `getCoin (LedgerState)` is
 
     getCoin (UTxOStateOf s)
     + coinFromRewards (CertStateOf s)
     + coinFromDeposits (CertStateOf s)
     + coinFromGovDeposit (GovStateOf s)
 
-This is the sum of UTxO coin, the `CertState`{.AgdaRecord} rewards balance
-(`coinFromRewards`{.AgdaFunction}), the deposits from `DState`{.AgdaRecord},
-`PState`{.AgdaRecord}, and `GState`{.AgdaRecord} (`coinFromDeposits`{.AgdaFunction}),
-and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}); the two
-middle summands are exactly `getCoin (CertStateOf s)`.
+The summands are the following:
 
-The `LEDGER-V` chain accounts for all four summands.  The cert deposits cancel via
-the direct-deposit trick (see *Proof Strategy*), and the gov-deposit growth
-`G' − G₀` is matched against the produced-side `totGov` (the `gov-acc` lemma, from
-`SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
++  **UTxO coin** (`getCoin (UTxOStateOf s)`);
++  **Rewards** (`coinFromRewards`{.AgdaFunction}): the `CertState`{.AgdaRecord} rewards balance;
++  **Cert deposits** (`coinFromDeposits`{.AgdaFunction}): deposits from `DState`{.AgdaRecord},
+   `PState`{.AgdaRecord}, and `GState`{.AgdaRecord};
++  **Gov deposits** (`coinFromGovDeposit`{.AgdaFunction}): the governance-action deposits.
+
+The two middle summands are exactly `getCoin (CertStateOf s)`.
+
+The `LEDGER-V`{.AgdaInductiveConstructor} chain accounts for all four summands.
+The cert deposits cancel via direct deposit cancellation (as explained in the
+Proof Strategy section below), and the gov deposit growth `G' − G₀` is matched
+against the produced-side `totGov`{.AgdaFunction} (by the gov deposit accounting
+lemma, `gov-acc`).
 
 The `PoolDepositsRegistered`{.AgdaFunction} hypothesis is necessary, not an artifact
-of the proof: the batch balance charges `newCertDeposits`{.AgdaFunction} against the
-registered-pool set, while `POOL-reg`{.AgdaInductiveConstructor}'s left-biased update
-silently keeps a stale entry for an unregistered pool; at a state with such an entry,
-a pool registration destroys the charged deposit and the theorem is false.  On-chain
-states satisfy the hypothesis by construction.
+of the proof.  Indeed, the batch balance charges `newCertDeposits`{.AgdaFunction}
+against the set of registered pools, while `POOL-reg`{.AgdaInductiveConstructor}'s
+left-biased update silently keeps a stale entry for an unregistered pool; at a
+state with such an entry, a pool registration destroys the charged deposit and the
+theorem is false.  On-chain states satisfy the hypothesis by construction.
 
 ## Proof Strategy
 
 The Dijkstra `LEDGER-pov`{.AgdaFunction} does not decompose into independent
-`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces; individual
-`SUBUTXO`{.AgdaDatatype} rules have no balance equation (only the *batch-level*
-`consumedBatch ≡ producedBatch` equation constrains the total), and sub-transactions
-may individually transfer value between UTxO and CertState without local balancing.
+`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces.  Individual
+`SUBUTXO`{.AgdaDatatype} rules have no balance equation.  A balance equation is
+only available at the batch level: `consumedBatch ≡ producedBatch`.
+Subtransactions may individually transfer value between UTxO and
+`CertState`{.AgdaRecord} without local balancing.
 
-Instead, the `LEDGER-V` proof is a single equational chain at the
-`LedgerState`{.AgdaRecord} level, and cancellation of the *total* direct deposits is
-the key to the proof.  Direct-deposit value appears both on the UTxO side (via
-`producedBatch`) and on the CertState side (via `applyDirectDeposits` inside
-`ENTITIES`) and cancels in the total.
+The `LEDGER-V`{.AgdaInductiveConstructor} proof is a single equational chain at
+the `LedgerState`{.AgdaRecord} level.  Direct deposits appear on both the UTxO
+side (via `producedBatch`{.AgdaFunction}) and on the `CertState`{.AgdaRecord} side
+(via `applyDirectDeposits`{.AgdaFunction} inside `ENTITIES`{.AgdaDatatype}), and
+cancel each other out.
 
 Concretely, the proof composes four inductions over the `SUBLEDGERS`{.AgdaDatatype}
 reflexive-transitive closure, plus one arithmetic identity.
 
-+  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** inducts over the subtransaction list,
-   applying the per-`SUBUTXOW` coin equation (`subutxow-step-coin`) at each step.
-+  **`SUBLEDGERS-rewards-pov`{.AgdaFunction}** composes per-sub-transaction
++  `SUBLEDGERS-utxo-coin`{.AgdaFunction} inducts over the subtransaction list,
+   applying the per-`SUBUTXOW`{.AgdaDatatype} coin equation
+   (`subutxow-step-coin`{.AgdaFunction}) at each step.
++  `SUBLEDGERS-rewards-pov`{.AgdaFunction} composes per-sub-transaction
    `SUBENTITIES-pov`{.AgdaFunction} invocations (the rewards flow).
-+  **`SUBLEDGERS-deposits`{.AgdaFunction}** (with `SUBLEDGERS-registered`{.AgdaFunction})
++  `SUBLEDGERS-deposits`{.AgdaFunction} (with `SUBLEDGERS-registered`{.AgdaFunction})
    telescopes the per-step closed-form deposit accounting into the batch-wide
-   equation consumed by `bat'`.
-+  **`SUBLEDGERS-gov-coin`{.AgdaFunction}** accumulates the per-`GOVS` gov-deposit growth.
-+  **`posNeg-deposits`{.AgdaFunction}** relates the pre-/post-batch deposit totals to
+   equation consumed by `bat'`{.AgdaFunction}.
++  `SUBLEDGERS-gov-coin`{.AgdaFunction} accumulates the per-`GOVS` gov-deposit growth.
++  `posNeg-deposits`{.AgdaFunction} relates the pre-/post-batch deposit totals to
    the `posPart`/`negPart` of `calculateDepositsChange`.
 
-The `LEDGER-I` case is straightforward; `certState` and `govSt` are unchanged,
-`SUBLEDGERS` is a no-op, and only the `UTXOW` step affects `getCoin`, which it
-preserves via `utxow-pov-invalid`.
+The `LEDGER-I`{.AgdaInductiveConstructor} case is straightforward; `certState` and
+`govSt` are unchanged, `SUBLEDGERS`{.AgdaDatatype} is a no-op, and only the
+`UTXOW`{.AgdaDatatype} step affects `getCoin`{.AgdaFunction}, which it preserves
+via `utxow-pov-invalid`{.AgdaFunction}.
 
 <!--
 ```agda
@@ -112,31 +120,7 @@ open ≡-Reasoning
 
 instance
   _ = +-0-monoid
-```
--->
 
-## The `LEDGER-PoV` module
-
-The supporting facts about the auxiliary transition systems are module parameters,
-in five groups:
-
-+  the set/map identities consumed by `ApplyToRewards-PoV`{.AgdaModule}
-   (`∪ˡ-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique`);
-+  the UTxO facts: coin equations for the `UTXOW`/`SUBUTXOW` steps and batch-wide
-   freshness/disjointness invariants
-   (`balance-∪`, `split-balance`, `noMintTx`, `noMintSubTx`, `outs-disjoint`,
-   `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`,
-   `utxow-pov-invalid`, `UTXOW-V-mechanical`, `UTXOW-batch-balance-coin`);
-+  the Certs facts: value accounting for a single `CERTS`{.AgdaDatatype} run
-   (`CERTS-rewards-pov`, `CERTS-deposits-pov`, `CERTS-deposits-registered`,
-   `CERTS-new-thread`, `refundCertDeposits-++`);
-+  the governance-deposit facts (`rmOrphanDRepVotes-coinFromGovDeposit`,
-   `GOVS-coinFromGovDeposit`);
-+  the no-truncation withdrawal bounds (`ENTITIES-wdrls-bounded`,
-   `SUBENTITIES-wdrls-bounded`); see `Entities.Properties.PoV`{.AgdaModule} for why
-   these are not consequences of the rules' own premises.
-
-```agda
 noMintingSubTxs : TopLevelTx → Type
 noMintingSubTxs tx = ∀ stx → stx ∈ˡ SubTransactionsOf tx → coin (MintedValueOf stx) ≡ 0
 
@@ -147,7 +131,38 @@ proposalsOf []            = []
 proposalsOf (inj₁ _ ∷ xs) = proposalsOf xs
 proposalsOf (inj₂ p ∷ xs) = p ∷ proposalsOf xs
 
+```
+-->
 
+## The <span class="AgdaModule">LEDGER-PoV</span> module
+
+The supporting facts about the auxiliary transition systems are module parameters
+which are organized into the following groups:
+
++  the set/map identities consumed by `ApplyToRewards-PoV`{.AgdaModule}
+   (`∪ˡ-lookup-preserve`{.AgdaFunction}, `sum-map-proj₂≡getCoin`{.AgdaFunction},
+   `setToList-Unique`{.AgdaFunction});
++  UTxO facts: coin equations for the
+   `UTXOW`{.AgdaDatatype}/`SUBUTXOW`{.AgdaDatatype} steps and batch-wide
+   freshness/disjointness invariants
+   (`balance-∪`{.AgdaFunction}, `split-balance`{.AgdaFunction},
+   `noMintTx`{.AgdaFunction}, `noMintSubTx`{.AgdaFunction},
+   `outs-disjoint`{.AgdaFunction}, `subutxow-step-coin`{.AgdaFunction},
+   `utxo₁-tx-spend-eq`{.AgdaFunction}, `fresh-top-tx-id`{.AgdaFunction},
+   `utxow-pov-invalid`{.AgdaFunction}, `UTXOW-V-mechanical`{.AgdaFunction},
+   `UTXOW-batch-balance-coin`{.AgdaFunction});
++  Cert facts: value accounting for a single `CERTS`{.AgdaDatatype} run
+   (`CERTS-rewards-pov`{.AgdaFunction}, `CERTS-deposits-pov`{.AgdaFunction},
+   `CERTS-deposits-registered`{.AgdaFunction}, `CERTS-new-thread`{.AgdaFunction},
+   `refundCertDeposits-++`{.AgdaFunction});
++  Gov deposit facts (`rmOrphanDRepVotes-coinFromGovDeposit`{.AgdaFunction},
+   `GOVS-coinFromGovDeposit`{.AgdaFunction});
++  no-truncation withdrawal bounds (`ENTITIES-wdrls-bounded`{.AgdaFunction},
+   `SUBENTITIES-wdrls-bounded`{.AgdaFunction}); see
+   `Entities.Properties.PoV`{.AgdaModule} for why these are not consequences of
+   the rules' own premises.
+
+```agda
 module LEDGER-PoV
   (tx : TopLevelTx) (let open Tx tx; open TxBody txBody)
 
@@ -276,7 +291,7 @@ module LEDGER-PoV
         ≡ getCoin s₁ + cbalance (UTxOOf s₀ ∣ SpendInputsOf tx) )
 
   -- Closed-form coin projection of the batch balance `consumedBatch ≡ producedBatch`
-  -- (the minted terms drop by `noMintTx`/`noMintSubTx`).  The cert-deposit summands
+  -- (the minted terms drop by `noMintTx`/`noMintSubTx`).  The cert deposit summands
   -- are in the spec's *closed form* — `refundCertDeposits`/`newCertDeposits` over
   -- `allDCerts tx`, with the pool set drawn from the environment's pre-batch
   -- `pools₀` — keeping this a pure UTxO obligation.  The governance-deposit summands
@@ -324,11 +339,12 @@ variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binde
 
 ## Deposit-change interface
 
-The cert-deposit change is the integer delta of `coinFromDeposits`{.AgdaFunction} at
-the top and sub levels.  The `LEDGER-V` chain tracks the deposit pots in this
-two-level `posPart`/`negPart` form; `bat'` obtains it from the closed-form
-`UTXOW-batch-balance-coin`{.AgdaFunction} parameter via the batch-wide deposit
-accounting (`bridgeEq`, composed by `SUBLEDGERS-deposits`{.AgdaFunction}) and
+The cert deposits change is the integer delta of `coinFromDeposits`{.AgdaFunction}
+at the top and sub levels.  The `LEDGER-V`{.AgdaInductiveConstructor} chain tracks
+the deposit pots in this two-level `posPart`/`negPart` form; `bat'`{.AgdaFunction}
+obtains it from the closed-form `UTXOW-batch-balance-coin`{.AgdaFunction}
+parameter via the batch-wide deposit accounting (`bridgeEq`{.AgdaFunction},
+composed by `SUBLEDGERS-deposits`{.AgdaFunction}) and
 `posNeg-deposits`{.AgdaFunction}.
 
 ```agda
@@ -361,7 +377,7 @@ accounting (`bridgeEq`, composed by `SUBLEDGERS-deposits`{.AgdaFunction}) and
 
 ## `posNeg-deposits`
 
-The deposit accounting identity used in the `LEDGER-V` chain.  Both sides express the
+The deposit accounting identity used in the `LEDGER-V`{.AgdaInductiveConstructor} chain.  Both sides express the
 same quantity (the sum of deposits across the batch), just rephrased to expose
 `posPart` vs `negPart` of the top-level and sub-level deposit changes.
 
@@ -389,8 +405,8 @@ same quantity (the sum of deposits across the batch), just rephrased to expose
 
 ## `SUBLEDGERS-utxo-coin`
 
-Induct over the `SUBLEDGERS` reflexive-transitive closure, applying the
-per-`SUBUTXOW` coin equation at each step:
+Induct over the `SUBLEDGERS`{.AgdaDatatype} reflexive-transitive closure, applying
+the per-`SUBUTXOW`{.AgdaDatatype} coin equation at each step:
 
 ```agda
   SUBLEDGERS-utxo-coin :
@@ -445,7 +461,7 @@ per-`SUBUTXOW` coin equation at each step:
     ih = SUBLEDGERS-utxo-coin isV rest
 ```
 
-## `SUBLEDGERS-rewards-pov`
+## <span class="AgdaFunction">SUBLEDGERS-rewards-pov</span>
 
 Parallel induction over `SUBLEDGERS`, composing per-sub-transaction `SUBENTITIES-pov`
 invocations.  The `NetworkId` witnesses and domain conditions are premises of the
@@ -493,7 +509,7 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     ih = SUBLEDGERS-rewards-pov isV rest
 ```
 
-## `SUBLEDGERS-deposits`
+## <span class="AgdaFunction">`SUBLEDGERS-deposits`</span>
 
 Composing the per-step deposit accounting across the batch.
 `refund-concatMap`{.AgdaFunction} distributes `refundCertDeposits`{.AgdaFunction}
@@ -501,10 +517,11 @@ over the batch's certificate lists; `SUBLEDGERS-registered`{.AgdaFunction} threa
 the pool-deposit registration invariant; and `SUBLEDGERS-deposits`{.AgdaFunction}
 telescopes the per-step closed forms, using
 `SUBENTITIES-new-thread`{.AgdaFunction} to split `newCertDeposits`{.AgdaFunction} at
-each step boundary — necessary because the pool set a `regpool` is charged against
-evolves through the batch.  The trailing certificate list `ys`{.AgdaBound}
-generalises the statement so the induction goes through; the `LEDGER-V` proof
-instantiates it with the top-level transaction's certificates.
+each step boundary; this is necessary because the pool set a `regpool` is charged
+against evolves through the batch.  The trailing certificate list `ys`{.AgdaBound}
+generalises the statement so the induction goes through; the
+`LEDGER-V`{.AgdaInductiveConstructor} proof instantiates it with the top-level
+transaction's certificates.
 
 ```agda
   refund-concatMap : (pp' : PParams) (stxs : List SubLevelTx)
@@ -596,13 +613,13 @@ instantiates it with the top-level transaction's certificates.
     resh = solve-∀
 ```
 
-## `SUBLEDGERS-gov-coin`
+## <span class="AgdaFunction">SUBLEDGERS-gov-coin</span>
 
-Induct over `SUBLEDGERS`, threading the per-`GOVS` gov-deposit growth: each
-`SUBLEDGER-V` step grows `coinFromGovDeposit`{.AgdaFunction} by the
+Induct over `SUBLEDGERS`{.AgdaDatatype}, threading the per-`GOVS` gov-deposit growth: each
+`SUBLEDGER-V`{.AgdaInductiveConstructor} step grows `coinFromGovDeposit`{.AgdaFunction} by the
 `govProposalsDeposits`{.AgdaFunction} of the sub-transaction's proposals (via the
 `GOVS-coinFromGovDeposit`{.AgdaFunction} parameter applied to the step's `GOVS`
-premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
+premise).  `SUBLEDGER-I`{.AgdaInductiveConstructor} is ruled out by the top-level validity flag.
 
 ```agda
   -- `proposalsOf (GovProposals+Votes t)` recovers exactly the proposals of `t`.
@@ -662,7 +679,7 @@ premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
     ih = SUBLEDGERS-gov-coin isV rest
 ```
 
-## `LEDGER-pov`
+## <span class="AgdaFunction">LEDGER-pov</span>
 
 The pool-deposit registration hypothesis concerns the initial state only; it is
 threaded through the batch by `SUBLEDGERS-registered`{.AgdaFunction} where needed.
@@ -673,9 +690,9 @@ threaded through the batch by `SUBLEDGERS-registered`{.AgdaFunction} where neede
     → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
 ```
 
-### `LEDGER-I` case (invalid transaction)
+### The <span class="AgdaInductiveConstructor">LEDGER-I</span> case (invalid transaction)
 
-`SUBLEDGERS` is a no-op when `IsValidFlagOf tx ≡ false`, so `certState` and `govSt`
+`SUBLEDGERS`{.AgdaDatatype} is a no-op when `IsValidFlagOf tx ≡ false`, so `certState` and `govSt`
 are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
 `utxow-pov-invalid`.
 
@@ -686,9 +703,9 @@ are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
           ( utxow-pov-invalid utxoStep invalid )
 ```
 
-### `LEDGER-V` case (valid transaction)
+### The <span class="AgdaInductiveConstructor">LEDGER-V</span> case (valid transaction)
 
-The proof is a single equational chain over `LedgerState` coin totals.
+The proof is a single equational chain over `LedgerState`{.AgdaRecord} coin totals.
 
 Setting `U = getCoin (UTxOState)`, `R = coinFromRewards`, `D = coinFromDeposits`,
 `G = coinFromGovDeposit`, and `allDirectDeps` / `allWdrls` for the top-level and
@@ -697,16 +714,18 @@ sub-level totals of direct deposits and withdrawals respectively, the goal
 
     U₀ + R₀ + D₀ + G₀  ≡  U₂ + R₂ + D₂ + G'
 
-where `G₀ = coinFromGovDeposit govState₀` and, since the final `LEDGER-V` `GovState`
+where `G₀ = coinFromGovDeposit govState₀` and, since the final
+`LEDGER-V`{.AgdaInductiveConstructor} `GovState`{.AgdaRecord}
 is `rmOrphanDRepVotes certState₂ govState₂` and `rmOrphanDRepVotes` preserves
 `coinFromGovDeposit` (parameter `rmOrphanDRepVotes-coinFromGovDeposit`),
 `G' = coinFromGovDeposit govState₂`.
 
-The body assembles the four-summand goal from two `where`-lemmas.
+The body assembles the goal from two lemmas:
 
-+  **`three-summand`**: `U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the UTxO/rewards/cert-deposit totals
-   with the produced-side gov deposits surfacing as `totGov`;
-+  **`gov-acc`**: `totGov+G₀ ≡ G'`, the gov-deposit accounting.
++  `three-summand`{.AgdaFunction}: `U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the
+   UTxO/rewards/cert-deposits totals with the produced-side gov deposits surfacing
+   as `totGov`;
++  `gov-acc`{.AgdaFunction}: `totGov+G₀ ≡ G'`, the gov-deposit accounting.
 
 ```agda
   LEDGER-pov {Γ} {s} registered₀
@@ -721,9 +740,8 @@ The body assembles the four-summand goal from two `where`-lemmas.
     where
 ```
 
-The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
-`arithmetic-N` helpers, and `mid-extract`/`rearr3`/`outer-rearr` (for the gov summand)
-— all pure `+`-rearrangements, discharged by the ring solver.
+A handful of arithmetic shuffles are required; these are pure
+`+`-rearrangements discharged by the ring solver.
 
 ```agda
       abcd-to-acdb : ∀ a b c d → a +ᴺ b +ᴺ c +ᴺ d ≡ a +ᴺ c +ᴺ d +ᴺ b
@@ -786,17 +804,18 @@ The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
       outer-rearr = solve-∀
 ```
 
-**The combined `ENTITIES-pov` invocation**.
+**The combined `ENTITIES-pov`{.AgdaFunction} invocation**.
 
 +  Pre-batch `certState` plus
 +  all direct deposits (top + sub) ≡ post-`ENTITIES` `certState` plus
 +  all withdrawals (top + sub).
 
-This is the key step where direct deposits cancel between the UTxO and CertState
-sides of the ledger.
+This is the step in which direct deposits on the UTxO and `CertState`{.AgdaRecord}
+sides cancel.
 
-(The `NetworkId` and domain conditions are premises of the `ENTITIES` rule
-itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
+(The `NetworkId` and domain conditions are premises of the
+`ENTITIES`{.AgdaDatatype} rule itself; the no-truncation bound comes from
+`ENTITIES-wdrls-bounded`{.AgdaFunction}.)
 
 ```agda
       combined-certs : coinFromRewards (CertStateOf s) + allDirectDeps
@@ -820,7 +839,8 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
             ∎
 ```
 
-`step-i`: introduce `allDirectDeps`, then rewrite using `combined-certs`.
+`step-i`: introduce `allDirectDeps`{.AgdaFunction}, then rewrite using
+`combined-certs`{.AgdaFunction}.
 
 ```agda
       step-i : (U₀ + R₀ + D₀) + allDirectDeps ≡ U₀ + R₂ + allWdrls + D₀
@@ -843,7 +863,8 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
       posneg = posNeg-deposits (CertStateOf s) cs₁ cs₂
 ```
 
-`UTXOW-V-mechanical` composed with the batch-wide "spend inputs preserved" invariant:
+`UTXOW-V-mechanical`{.AgdaFunction} composed with the batch-wide "spend inputs
+preserved" invariant:
 
 ```agda
       mech : U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
@@ -867,7 +888,7 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
       E = Ctop + Psub + posPart dct + posPart dcs
 ```
 
-The batch balance, rephrased to expose direct deposits and bring withdrawals together:
+**The batch balance** rephrased to expose direct deposits and bring withdrawals together.
 
 ```agda
       bat' : Ctop + allWdrls + Csub + negPart dct + negPart dcs
@@ -947,7 +968,7 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
                    + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx) + totGov
         closedEq = UTXOW-batch-balance-coin utxoStep
 
-        -- Batch-wide cert-deposit accounting, in ℕ form: pre-batch deposits + new
+        -- Batch-wide cert deposit accounting, in ℕ form: pre-batch deposits + new
         -- deposits ≡ post-batch deposits + refunds.  Composed from the per-step
         -- SUBENTITIES/ENTITIES deposit equations: `SUBLEDGERS-deposits` telescopes
         -- the sub-transactions (leaving the top-level certificates as the trailing
@@ -1020,7 +1041,7 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
           go = solve-∀
 ```
 
-The main inner chain, showing LHS + E ≡ RHS + E:
+**The main inner chain**, showing `LHS + E ≡ RHS + E`.
 
 ```agda
       LHS+E≡RHS+E : U₀ + allWdrls + D₀ + E ≡ U₂ + allDirectDeps + D₂ + totGov + E
@@ -1091,8 +1112,8 @@ discharged by the in-context `solve`{.AgdaMacro} rather than `solve-∀`{.AgdaMa
         arithmetic-5 a b c {d}{e}{f}{g} = solve (a ∷ b ∷ c ∷ d ∷ e ∷ f ∷ g ∷ [])
 ```
 
-Finally, `step-ii`: extract the actual equation from `LHS+E≡RHS+E` by cancelling `E`
-on both sides:
+Finally, `step-ii` extracts the actual equation from `LHS+E≡RHS+E` by cancelling `E`
+on both sides.
 
 ```agda
       step-ii : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + totGov + R₂
@@ -1100,7 +1121,7 @@ on both sides:
                       ( +-cancelʳ-≡  E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂ + totGov)
                                      LHS+E≡RHS+E )
 
-      -- The three LedgerState totals (UTxO + rewards + cert-deposits): the batch's
+      -- The three LedgerState totals (UTxO + rewards + cert deposits): the batch's
       -- gov deposits surface as `+ totGov` on the produced side.
       three-summand : U₀ + R₀ + D₀ ≡ U₂ + R₂ + D₂ + totGov
       three-summand = +-cancelʳ-≡ allDirectDeps (U₀ + R₀ + D₀) (U₂ + R₂ + D₂ + totGov)

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -71,9 +71,9 @@ gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (
        against the *pre-batch* snapshot `rewards₀` (except top-level legacy mode,
        which forces exact-balance withdrawals), which does not by itself bound them
        against the input state of a later step in the batch. This is the
-       phantom-withdrawal gap flagged in the review of PR #1256.
-       As such, these module parameters should be discharged in the follow-up to that
-       discussion, either by spec rule premises or by a batch-threading invariant.
+       phantom-withdrawal gap.[^1] As such, these module parameters should be
+       discharged in the follow-up to that discussion, either by spec rule premises
+       or by a batch-threading invariant.
 
 ## Proof Strategy
 
@@ -176,11 +176,9 @@ the follow-ups.
 noMintingSubTxs : TopLevelTx → Type
 noMintingSubTxs tx = ∀ stx → stx ∈ˡ SubTransactionsOf tx → coin (MintedValueOf stx) ≡ 0
 
--- The right injections of a list of sums, used (at `GovVote ⊎ GovProposal`) to
--- extract the proposals from a mixed `GOVS` input list for the
--- `GOVS-coinFromGovDeposit` gov-deposit accounting parameter below, stated
--- generically to avoid the doubly-imported `GovVote`/`GovProposal` names.
-proposalsOf : ∀ {A B : Type} → List (A ⊎ B) → List B
+-- proposalsOf is useful for extracting proposals from a mixed `GOVS` (`GovVote ⊎
+-- GovProposal`) input list for the `GOVS-coinFromGovDeposit` gov-deposit accounting.
+proposalsOf : {A B : Type} → List (A ⊎ B) → List B
 proposalsOf []            = []
 proposalsOf (inj₁ _ ∷ xs) = proposalsOf xs
 proposalsOf (inj₂ p ∷ xs) = p ∷ proposalsOf xs
@@ -204,21 +202,20 @@ module LEDGER-PoV
       → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
 
   -- UTXOW-PoV parameters
-  ( balance-∪ : ∀ {u u' : UTxO} → disjoint (dom u) (dom u')
+  ( balance-∪ : {u u' : UTxO} → disjoint (dom u) (dom u')
               → cbalance (u ∪ˡ u') ≡ cbalance u + cbalance u' )
-  ( split-balance : ∀ (u : UTxO) (keys : ℙ TxIn)
+  ( split-balance : (u : UTxO) (keys : ℙ TxIn)
                   → cbalance u ≡ cbalance (u ∣ keys ᶜ) + cbalance (u ∣ keys) )
   ( noMintTx : coin (MintedValueOf tx) ≡ 0 )
   ( noMintSubTx : noMintingSubTxs tx )
-  ( outs-disjoint : ∀ {u : UTxO}
+  ( outs-disjoint : {u : UTxO}
                   → TxIdOf tx ∉ mapˢ proj₁ (dom u)
                   → disjoint (dom (u ∣ SpendInputsOf tx ᶜ)) (dom (outs tx)) )
 
   -- Per-step SUBUTXOW coin equation.  A local proof would require, in addition to
   -- `balance-∪` and `split-balance`, a batch-wide "spend inputs preserved" invariant
-  -- (the running UTxO agrees with the snapshot on every sub-tx's spend inputs) and
-  -- freshness of each sub-tx's TxId relative to the running UTxO.
-  ( subutxow-step-coin : ∀ {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
+  -- and freshness of each sub-tx's TxId relative to the running UTxO.
+  ( subutxow-step-coin : {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
       → IsTopLevelValidFlagOf Γ ≡ true
       → Γ ⊢ s₀ ⇀⦇ stx ,SUBUTXOW⦈ s₁
       → getCoin s₀ + cbalance (outs stx) + DonationsOf stx
@@ -226,7 +223,7 @@ module LEDGER-PoV
 
   -- Batch-wide invariants on the post-SUBLEDGERS UTxO state.  Both follow from
   -- batch-wide input disjointness and TxId freshness, which the outer UTXO rule
-  -- establishes at the batch level but doesn't expose per-step.
+  -- establishes at batch level, not per-step.
   ( utxo₁-tx-spend-eq : {subΓ : SubLedgerEnv} {s : LedgerState}
         {utxoSt₁ : UTxOState} {govSt₁ : GovState} {certState₁ : CertState}
       → SubLedgerEnv.isTopLevelValid subΓ ≡ true
@@ -240,25 +237,22 @@ module LEDGER-PoV
       → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
 
-  -- Certs-PoV stubs (discharged later by follow-up PR #1210).  These were the
-  -- `Certs.Properties.PoV` provider lemmas; under the top-down plan they are module
-  -- parameters here.
-  ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+  -- Certs-PoV stubs to be discharged in follow-up PR
+  ( CERTS-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
       → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
-  -- Batch-wide cert-deposit bridge (discharged later by #1210).  The closed-form
-  -- deposit accounting over *all* batch certs (`allDCerts tx`, with `newCertDeposits`
-  -- threading the pre-batch registered-pool set) balances against the actual
-  -- `coinFromDeposits` evolution from the pre-batch cert state `CertStateOf ls₀` to
-  -- the post-`ENTITIES` cert state `cs₂`, in ℕ form:
+
+  -- Batch-wide cert-deposit bridge (discharged later).  The closed-form
+  -- deposit accounting over *all* batch certs balances against actual
+  -- `coinFromDeposits` evolution from pre-batch cert state `CertStateOf ls₀` to
+  -- post-`ENTITIES` cert state `cs₂`:
   --
   --     D₀ + newCertDeposits ≡ D₂ + refundCertDeposits
   --
-  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over the
-  -- sub-txs, then the top-level `ENTITIES`); composing the per-step cert bridges
-  -- across the batch is #1210's responsibility, so the `LEDGER-pov` consumer takes
-  -- the combined equation as given.
+  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over sub-txs,
+  -- then top-level `ENTITIES`); composing per-step cert bridges across the batch is
+  -- follow-up (CERTS PoV) work.
   ( batch-cert-deposits-bridge :
-      ∀ {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
+      {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
       → SubLedgerEnv.isTopLevelValid Γsub ≡ true
       → Γsub ⊢ ls₀ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ls₁
       → Γe ⊢ CertStateOf ls₁ ⇀⦇ tx ,ENTITIES⦈ cs₂
@@ -267,63 +261,59 @@ module LEDGER-PoV
         ≡ coinFromDeposits cs₂
           + refundCertDeposits (PParamsOf Γe) (allDCerts tx) )
 
-  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see the #1256
-  -- review).  `applyWithdrawals` subtracts with `_∸_`, so the ENTITIES/SUBENTITIES
-  -- value-flow equations need each withdrawal amount bounded by the account's balance
-  -- in the *input* state of the step that consumes it.  The spec's premises bound
-  -- withdrawals only against the pre-batch `rewards₀` (except top-level legacy mode),
-  -- so these facts are assumed here, to be discharged by a spec-side premise or a
-  -- batch-threading invariant in the follow-up to that discussion.
-  ( ENTITIES-wdrls-bounded : ∀ {Γe : EntitiesEnv} {cs cs' : CertState}
+  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see review of #1256).
+  -- `applyWithdrawals` subtracts with `_∸_`, so ENTITIES/SUBENTITIES value-flow
+  -- equations need each withdrawal amount bounded by account's balance in the
+  -- *input* state of the step that consumes it.  Premises bound withdrawals only
+  -- against the pre-batch `rewards₀` (except top-level legacy mode), so these facts
+  -- are assumed here, to be discharged by a spec-side premise or a batch-threading
+  -- invariant in follow-up to that discussion.
+  ( ENTITIES-wdrls-bounded : {Γe : EntitiesEnv} {cs cs' : CertState}
       → Γe ⊢ cs ⇀⦇ tx ,ENTITIES⦈ cs'
       → ∀[ (addr , amt) ∈ (WithdrawalsOf tx) ˢ ]
           amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
-  ( SUBENTITIES-wdrls-bounded : ∀ {Γe : SubEntitiesEnv} {cs cs' : CertState} {stx : SubLevelTx}
+  ( SUBENTITIES-wdrls-bounded : {Γe : SubEntitiesEnv} {cs cs' : CertState} {stx : SubLevelTx}
       → Γe ⊢ cs ⇀⦇ stx ,SUBENTITIES⦈ cs'
       → ∀[ (addr , amt) ∈ (WithdrawalsOf stx) ˢ ]
           amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
 
-  -- Governance-deposit accounting (to be discharged by a future `Gov.Properties.PoV`).
+  -- Governance-deposit accounting (to be discharged by future `Gov.Properties.PoV`).
   -- `rmOrphanDRepVotes` only rewrites `votes.gvDRep`, never `GovActionState.deposit`,
   -- so it leaves `coinFromGovDeposit` unchanged.
   ( rmOrphanDRepVotes-coinFromGovDeposit :
-      ∀ (cs : CertState) (g : GovState)
+      (cs : CertState) (g : GovState)
       → coinFromGovDeposit (rmOrphanDRepVotes cs g) ≡ coinFromGovDeposit g )
-  -- Per-`GOVS`-step gov-deposit growth equals the `govProposalsDeposits` of the step's
-  -- proposals (`GOV-Propose` stores `deposit = pp .govActionDeposit`; no `GOV-Vote` or
-  -- in-`LEDGER` removal changes a deposit).  Used by `SUBLEDGERS-gov-coin` (the sub-tx
-  -- GOVS steps) and `gov-acc` (the top-level GOVS step).
+
+  -- Per-`GOVS`-step gov-deposit growth equals `govProposalsDeposits` of step's
+  -- proposals.  Used by `SUBLEDGERS-gov-coin` and `gov-acc`.
   ( GOVS-coinFromGovDeposit :
       ∀ {Γ : GovEnv} {govSt govSt′ : GovState} {props}
       → Γ ⊢ govSt ⇀⦇ props ,GOVS⦈ govSt′
       → coinFromGovDeposit govSt′
         ≡ coinFromGovDeposit govSt + govProposalsDeposits (PParamsOf Γ) (proposalsOf props) )
 
-  -- Utxo/Utxow-PoV facts (discharged later by #1186; module-parameter stubs).
+  -- Utxo/Utxow-PoV facts (discharged later) --
+
   -- Invalid top-level tx: the UTXOW step preserves UTxO coin.
-  ( utxow-pov-invalid : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
-      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
-      → IsValidFlagOf tx ≡ false
-      → getCoin s₀ ≡ getCoin s₁ )
+  ( utxow-pov-invalid : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁ → IsValidFlagOf tx ≡ false → getCoin s₀ ≡ getCoin s₁ )
+
   -- Valid top-level tx, mechanical single-tx coin equation (spend inputs resolved
-  -- against the running UTxO; TxId freshness lets `outs tx` split off cleanly).
-  ( UTXOW-V-mechanical : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+  -- against running UTxO; TxId freshness lets `outs tx` split off cleanly).
+  ( UTXOW-V-mechanical : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
       → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
       → IsValidFlagOf tx ≡ true
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf s₀))
       → getCoin s₀ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
         ≡ getCoin s₁ + cbalance (UTxOOf s₀ ∣ SpendInputsOf tx) )
+
   -- Closed-form coin projection of the batch balance `consumedBatch ≡ producedBatch`
-  -- (#1186 discharges this from the spec premise; the minted terms drop by
-  -- `noMintTx`/`noMintSubTx`).  The cert-deposit summands are in the spec's *closed
-  -- form* — `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with the
-  -- pool set drawn from the environment's pre-batch `pools₀` — keeping this a pure
-  -- UTxO obligation (no post-batch cert states).  `bat'` converts it to the chain's
-  -- top/sub two-level `posPart`/`negPart` form via `batch-cert-deposits-bridge`
-  -- (#1210) together with `posNeg-deposits`.  The governance-deposit summands
-  -- (`govProposalsDeposits`, top and per-sub) sit on the produced side, matching
-  -- `producedTx`.
-  ( UTXOW-batch-balance-coin : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+  -- (discharged by UTXO/UTXOW PoV; minted terms drop by `noMintTx`/`noMintSubTx`).
+  -- cert-deposit summands are in spec's *closed form*:
+  -- `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with pool set drawn
+  -- from environment's pre-batch `pools₀`, keeping this a pure UTxO obligation.
+  -- governance-deposit summands sit on produced side, matching `producedTx`.
+  ( UTXOW-batch-balance-coin : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
       → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
       → cbalance (UTxOOf Γ' ∣ SpendInputsOf tx) + getCoin (WithdrawalsOf tx)
           + sum (map (λ stx → cbalance (UTxOOf Γ' ∣ SpendInputsOf stx) + getCoin (WithdrawalsOf stx))
@@ -339,31 +329,19 @@ module LEDGER-PoV
   where
 
   open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique CERTS-pov
-  -- open UTXOW-PoV tx (λ {u} {u'} → balance-∪ {u} {u'}) split-balance noMintTx noMintSubTx
-  --   (λ {u} → outs-disjoint {u})
-```
 
-The `λ {u}{u'} → balance-∪ {u}{u'}` and `λ {u} → outs-disjoint {u}` η-wrappers are
-needed because passing the assumptions directly triggers Agda to eta-expand the `{u
-u' : UTxO}` implicits through `UTxO`'s `Σ _ left-unique` record structure, leaving
-the `left-unique` field as an unresolved meta.
+  -- When UTXOW PoV proof lands, we'll uncomment the following line, adding appropriate args.
+  -- open UTXOW-PoV ...
+```
 
 ## Small arithmetic helpers
 
 The pure `+`-rearrangement lemmas in this module are discharged by the reflective
-ring solver over the commutative semiring of naturals
-(`Data.Nat.Tactic.RingSolver`): `solve-∀`{.AgdaMacro} proves a closed, universally
-quantified equation outright, and the in-context `solve`{.AgdaMacro} (applied to the
-list of atoms) proves an equation whose variables are already in scope — needed
-where a lemma's trailing variables are implicit, since `solve-∀`{.AgdaMacro} only
-handles visible binders.  Only the statements remain, which keeps the equational
-chains readable.
-
-One wrinkle: the solver recognises the ring's operations *syntactically*, so the
-`Ledger.Prelude` overloaded `_+_` (a `HasAdd`{.AgdaRecord} method, which merely
-*reduces* to `Data.Nat._+_`) defeats it.  The solver-facing statements are therefore
-written with the raw natural-number addition, imported as `_+ᴺ_` — definitionally
-equal to `_+_` at `Coin`, so the lemmas discharge `_+_` goals unchanged.
+ring solver over the commutative semiring of naturals (`Data.Nat.Tactic.RingSolver`):
+`solve-∀`{.AgdaMacro} proves a closed, universally quantified equation outright, and
+the in-context `solve`{.AgdaMacro} (applied to the list of atoms) proves an equation
+whose variables are already in scope; this is needed where a lemma's trailing
+variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binders.[^2]
 
 ```agda
   swap-right : ∀ a b c → a +ᴺ b +ᴺ c ≡ a +ᴺ c +ᴺ b
@@ -402,7 +380,7 @@ two-level `posPart`/`negPart` form; `bat'` obtains it from the closed-form
 
   -- ℕ-level posPart/negPart cancellation: `b + posPart (a ⊖ b)` and
   -- `a + negPart (a ⊖ b)` both equal `a ⊔ b`.
-  posPart-negPart-sym : ∀ (a b : ℕ) → b + posPart (a ⊖ b) ≡ a + negPart (a ⊖ b)
+  posPart-negPart-sym : (a b : ℕ) → b + posPart (a ⊖ b) ≡ a + negPart (a ⊖ b)
   posPart-negPart-sym a       zero    = sym (+-identityʳ a)
   posPart-negPart-sym zero    (suc b) = +-identityʳ (suc b)
   posPart-negPart-sym (suc a) (suc b) = begin
@@ -431,6 +409,7 @@ same quantity (the sum of deposits across the batch), just rephrased to expose
       coin₁ + pt  + ns   ≡⟨ cong (_+ ns) (posPart-negPart-sym coin₂ coin₁) ⟩
       coin₂ + nt  + ns   ∎
     where
+    coin₀ coin₁ coin₂ psp ns pt nt : Coin
     coin₀ = coinFromDeposits cs₀
     coin₁ = coinFromDeposits cs₁
     coin₂ = coinFromDeposits cs₂
@@ -446,13 +425,16 @@ Induct over the `SUBLEDGERS` reflexive-transitive closure, threading the
 per-`SUBUTXOW` coin equation:
 
 ```agda
-  SUBLEDGERS-utxo-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+  SUBLEDGERS-utxo-coin :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
     → SubLedgerEnv.isTopLevelValid Γ ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
     → getCoin (UTxOStateOf s₀)
       + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) stxs)
       ≡  getCoin (UTxOStateOf s₁)
-         + sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) stxs)
+         + sum (map (λ stx → cbalance (UTxOOf Γ ∣ SpendInputsOf stx)) stxs)
 
   -- Base case: empty list.  `Id-nop` unifies s₀ ≡ s₁ and both sums are 0.
   SUBLEDGERS-utxo-coin _ (BS-base Id-nop) = refl
@@ -465,24 +447,24 @@ per-`SUBUTXOW` coin equation:
   SUBLEDGERS-utxo-coin {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
     (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , _ , _)) rest) =
     begin
-      U₀ + (p-stx + p-sum)    ≡⟨ sym (+-assoc U₀ p-stx p-sum) ⟩
+      U₀ + (p-stx + p-sum)    ≡˘⟨ +-assoc U₀ p-stx p-sum ⟩
       U₀ + p-stx + p-sum      ≡⟨ cong (_+ p-sum) step-P-C ⟩
       U₁ + c-stx + p-sum      ≡⟨ +-assoc U₁ c-stx p-sum ⟩
       U₁ + (c-stx + p-sum)    ≡⟨ cong (U₁ +_) (+-comm c-stx p-sum) ⟩
-      U₁ + (p-sum + c-stx)    ≡⟨ sym (+-assoc U₁ p-sum c-stx) ⟩
+      U₁ + (p-sum + c-stx)    ≡˘⟨ +-assoc U₁ p-sum c-stx ⟩
       U₁ + p-sum + c-stx      ≡⟨ cong (_+ c-stx) ih ⟩
       Uₙ + c-sum + c-stx      ≡⟨ +-assoc Uₙ c-sum c-stx ⟩
       Uₙ + (c-sum + c-stx)    ≡⟨ cong (Uₙ +_) (+-comm c-sum c-stx) ⟩
       Uₙ + (c-stx + c-sum)    ∎
     where
+    U₀ U₁ Uₙ p-stx c-stx p-sum c-sum : Coin
     U₀ = getCoin (UTxOStateOf s₀)
     U₁ = getCoin (UTxOStateOf s₁)
     Uₙ = getCoin (UTxOStateOf sₙ)
-
     p-stx = cbalance (outs stx) + DonationsOf stx
-    c-stx = cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)
+    c-stx = cbalance (UTxOOf Γ ∣ SpendInputsOf stx)
     p-sum = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) sigs)
-    c-sum = sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) sigs)
+    c-sum = sum (map (λ stx → cbalance (UTxOOf Γ ∣ SpendInputsOf stx)) sigs)
 
     -- Single-step coin equation from the SUBUTXOW step assumption.
     step-eq : U₀ + cbalance (outs stx) + DonationsOf stx ≡ U₁ + c-stx
@@ -503,11 +485,13 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
 `SUBENTITIES-wdrls-bounded` module parameter.
 
 ```agda
+  open SubLedgerEnv
+
   SUBLEDGERS-certs-pov :
     {Γ : SubLedgerEnv}
     {s₀ s₁ : LedgerState}
     {stxs : List SubLevelTx}
-    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ .isTopLevelValid ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
     →  coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
        ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
@@ -521,26 +505,18 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) =
     begin
       coinFromRewards (CertStateOf s₀) + (getCoin (DirectDepositsOf stx) + sum (map ddwl sigs))
-        ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s₀))
-                        (getCoin (DirectDepositsOf stx))
-                        (sum (map ddwl sigs))) ⟩
-      (coinFromRewards (CertStateOf s₀) + getCoin (DirectDepositsOf stx)) + sum (map ddwl sigs)
-        ≡⟨ cong (_+ sum (map ddwl sigs))
-                (SUBENTITIES-pov (SUBENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
-      (coinFromRewards (CertStateOf s₁) + getCoin (WithdrawalsOf stx)) + sum (map ddwl sigs)
-        ≡⟨ swap-right (coinFromRewards (CertStateOf s₁))
-                      (getCoin (WithdrawalsOf stx))
-                      (sum (map ddwl sigs)) ⟩
-      (coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)) + getCoin (WithdrawalsOf stx)
+        ≡˘⟨ +-assoc (coinFromRewards (CertStateOf s₀)) (getCoin (DirectDepositsOf stx)) _ ⟩
+      coinFromRewards (CertStateOf s₀) + getCoin (DirectDepositsOf stx) + sum (map ddwl sigs)
+        ≡⟨ cong  (_+ sum (map ddwl sigs))
+                 (SUBENTITIES-pov (SUBENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+      coinFromRewards (CertStateOf s₁) + getCoin (WithdrawalsOf stx) + sum (map ddwl sigs)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf s₁)) (getCoin (WithdrawalsOf stx)) _ ⟩
+      coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs) + getCoin (WithdrawalsOf stx)
         ≡⟨ cong (_+ getCoin (WithdrawalsOf stx)) ih ⟩
-      (coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)) + getCoin (WithdrawalsOf stx)
-        ≡⟨ swap-right (coinFromRewards (CertStateOf sₙ))
-                      (sum (map wdrwl sigs))
-                      (getCoin (WithdrawalsOf stx)) ⟩
+      coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs) + getCoin (WithdrawalsOf stx)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf sₙ)) (sum (map wdrwl sigs)) _ ⟩
       (coinFromRewards (CertStateOf sₙ) + getCoin (WithdrawalsOf stx)) + sum (map wdrwl sigs)
-        ≡⟨ +-assoc (coinFromRewards (CertStateOf sₙ))
-                   (getCoin (WithdrawalsOf stx))
-                   (sum (map wdrwl sigs)) ⟩
+        ≡⟨ +-assoc (coinFromRewards (CertStateOf sₙ)) (getCoin (WithdrawalsOf stx)) _ ⟩
       coinFromRewards (CertStateOf sₙ) + (getCoin (WithdrawalsOf stx) + sum (map wdrwl sigs))
         ∎
     where
@@ -563,21 +539,26 @@ premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
     → proposalsOf (GovProposals+Votes t) ≡ ListOfGovProposalsOf t
   proposalsOf-Proposals+Votes t = go (ListOfGovProposalsOf t) (ListOfGovVotesOf t)
     where
-    drop-votes : ∀ {A B : Type} (vs : List A)
-      → proposalsOf {A = A} {B = B} (map inj₁ vs) ≡ []
-    drop-votes []       = refl
+    drop-votes : {A B : Type} (vs : List A) → proposalsOf {B = B} (map inj₁ vs) ≡ []
+    drop-votes [] = refl
     drop-votes (_ ∷ vs) = drop-votes vs
-    go : ∀ {A B : Type} (ps : List B) (vs : List A)
-       → proposalsOf (map inj₂ ps ++ map inj₁ vs) ≡ ps
-    go []       vs = drop-votes vs
+
+    go : {A B : Type} (ps : List B) (vs : List A)
+      → proposalsOf (map inj₂ ps ++ map inj₁ vs) ≡ ps
+    go [] vs = drop-votes vs
     go (p ∷ ps) vs = cong (p ∷_) (go ps vs)
 
-  SUBLEDGERS-gov-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
-    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+  open SubLedgerEnv
+
+  SUBLEDGERS-gov-coin :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
+    → Γ .isTopLevelValid ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
     → coinFromGovDeposit (GovStateOf s₁)
       ≡ coinFromGovDeposit (GovStateOf s₀)
-        + sum (map (λ stx → govProposalsDeposits (SubLedgerEnv.pparams Γ) (ListOfGovProposalsOf stx)) stxs)
+        + sum (map (λ stx → govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf stx)) stxs)
 
   SUBLEDGERS-gov-coin _ (BS-base Id-nop) = sym (+-identityʳ _)
 
@@ -596,14 +577,15 @@ premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
       coinFromGovDeposit (GovStateOf s₀) + (g-stx + g-sum)
         ∎
     where
-    pp = SubLedgerEnv.pparams Γ
-    g-stx = govProposalsDeposits pp (ListOfGovProposalsOf stx)
-    g-sum = sum (map (λ stx → govProposalsDeposits pp (ListOfGovProposalsOf stx)) sigs)
+    g-stx = govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf stx)
+    g-sum = sum (map (λ stx → govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf stx)) sigs)
 
     step-gov : coinFromGovDeposit (GovStateOf s₁) ≡ coinFromGovDeposit (GovStateOf s₀) + g-stx
-    step-gov = trans (GOVS-coinFromGovDeposit govStep)
-                     (cong (λ ps → coinFromGovDeposit (GovStateOf s₀) + govProposalsDeposits pp ps)
-                           (proposalsOf-Proposals+Votes stx))
+    step-gov =
+      trans  ( GOVS-coinFromGovDeposit govStep )
+             ( cong  ( λ ps →  coinFromGovDeposit (GovStateOf s₀)
+                               + govProposalsDeposits (PParamsOf Γ) ps )
+                     ( proposalsOf-Proposals+Votes stx ) )
 
     ih : coinFromGovDeposit (GovStateOf sₙ) ≡ coinFromGovDeposit (GovStateOf s₁) + g-sum
     ih = SUBLEDGERS-gov-coin isV rest
@@ -624,30 +606,32 @@ are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
 
 ```agda
   LEDGER-pov {Γ} {s} (LEDGER-I (invalid , _ , utxoStep)) =
-    cong (λ u → u + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
-                  + coinFromGovDeposit (GovStateOf s))
-         (utxow-pov-invalid utxoStep invalid)
+    cong  ( λ u → u  + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
+                     + coinFromGovDeposit (GovStateOf s) )
+          ( utxow-pov-invalid utxoStep invalid )
 ```
 
 ### `LEDGER-V` case (valid transaction)
 
-The proof is a single equational chain over `LedgerState` coin totals.  Setting
-`U = getCoin (UTxOState)`, `R = coinFromRewards`, `D = coinFromDeposits`,
+The proof is a single equational chain over `LedgerState` coin totals.
+
+Setting `U = getCoin (UTxOState)`, `R = coinFromRewards`, `D = coinFromDeposits`,
 `G = coinFromGovDeposit`, and `allDirectDeps` / `allWdrls` for the top-level and
 sub-level totals of direct deposits and withdrawals respectively, the goal
 `getCoin s ≡ getCoin s'` is
 
     U₀ + R₀ + D₀ + G₀  ≡  U₂ + R₂ + D₂ + G'
 
-where `G₀ = coinFromGovDeposit govState₀` and — since the final `LEDGER-V` `GovState`
+where `G₀ = coinFromGovDeposit govState₀` and, since the final `LEDGER-V` `GovState`
 is `rmOrphanDRepVotes certState₂ govState₂` and `rmOrphanDRepVotes` preserves
-`coinFromGovDeposit` (parameter `rmOrphanDRepVotes-coinFromGovDeposit`) —
+`coinFromGovDeposit` (parameter `rmOrphanDRepVotes-coinFromGovDeposit`),
 `G' = coinFromGovDeposit govState₂`.
 
-The body assembles the four-summand goal from two `where`-lemmas: `three-summand`
-(`U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the UTxO/rewards/cert-deposit totals with the
-produced-side gov deposits surfacing as `totGov`) and `gov-acc` (`totGov+G₀ ≡ G'`,
-the gov-deposit accounting).
+The body assembles the four-summand goal from two `where`-lemmas.
+
++  **`three-summand`**: `U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the UTxO/rewards/cert-deposit totals
+   with the produced-side gov deposits surfacing as `totGov`;
++  **`gov-acc`**: `totGov+G₀ ≡ G'`, the gov-deposit accounting.
 
 ```agda
   LEDGER-pov {Γ} {s}
@@ -655,14 +639,10 @@ the gov-deposit accounting).
               {certState₂ = cs₂} {govState₂ = govSt₂} {utxoState₂ = us₂}
               (valid , subStep , entitiesStep , govStep , utxoStep)) =
     begin
-      U₀ + R₀ + D₀ + G₀
-        ≡⟨ cong (_+ G₀) three-summand ⟩
-      U₂ + R₂ + D₂ + totGov + G₀
-        ≡⟨ +-assoc (U₂ + R₂ + D₂) totGov G₀ ⟩
-      U₂ + R₂ + D₂ + (totGov + G₀)
-        ≡⟨ cong (U₂ + R₂ + D₂ +_) gov-acc ⟩
-      U₂ + R₂ + D₂ + G'
-        ∎
+      U₀ + R₀ + D₀ + G₀             ≡⟨ cong (_+ G₀) three-summand ⟩
+      U₂ + R₂ + D₂ + totGov + G₀    ≡⟨ +-assoc (U₂ + R₂ + D₂) totGov G₀ ⟩
+      U₂ + R₂ + D₂ + (totGov + G₀)  ≡⟨ cong (U₂ + R₂ + D₂ +_) gov-acc ⟩
+      U₂ + R₂ + D₂ + G'             ∎
     where
 ```
 
@@ -687,10 +667,9 @@ The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
       R₀ = coinFromRewards (CertStateOf s)
       R₂ = coinFromRewards cs₂
 
-      -- Governance-deposit summands of the LedgerState totals.  G₀ is the initial
-      -- GovState's deposit; G' is the final state's (`rmOrphanDRepVotes cs₂ govSt₂`),
-      -- which `rmOrphanDRepVotes-coinFromGovDeposit` collapses to `coinFromGovDeposit
-      -- govSt₂`.  (Used by the `gov-acc` lemma.)
+      -- Governance-deposit summands of LedgerState totals:
+      -- + G₀ is the initial GovState's deposit;
+      -- + G' is the final state's (`rmOrphanDRepVotes cs₂ govSt₂`).
       G₀ G' : Coin
       G₀ = coinFromGovDeposit (GovStateOf s)
       G' = coinFromGovDeposit (rmOrphanDRepVotes cs₂ govSt₂)
@@ -710,11 +689,16 @@ The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
       -- Total governance-action deposits introduced by the batch (top + per-sub),
       -- matching the `govProposalsDeposits` summands on the produced side of the
       -- batch balance and the gov-deposit growth `G' − G₀`.
-      topGov subGovSum totGov : Coin
-      topGov    = govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf tx)
-      subGovSum = sum (map (λ stx → govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf stx))
-                           (SubTransactionsOf tx))
-      totGov    = topGov + subGovSum
+      topGov : Coin
+      topGov = govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf tx)
+
+      subGovSum : Coin
+      subGovSum =
+        sum (map  ( λ stx → govProposalsDeposits (PParamsOf  Γ) (ListOfGovProposalsOf stx) )
+                  ( SubTransactionsOf tx ) )
+
+      totGov : Coin
+      totGov = topGov + subGovSum
 
       -- Pure +-rearrangements for threading the gov summand.
       mid-extract : ∀ a b c d → a +ᴺ (b +ᴺ d) +ᴺ c ≡ a +ᴺ b +ᴺ c +ᴺ d
@@ -727,10 +711,16 @@ The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
       outer-rearr = solve-∀
 ```
 
-The "combined" `ENTITIES-pov` invocation: pre-batch `certState` + all direct deposits
-(top + sub) ≡ post-`ENTITIES` `certState` + all withdrawals (top + sub).  This is the
-key step where direct deposits cancel between the UTxO and CertState sides of the
-ledger.  (The `NetworkId` and domain conditions are premises of the `ENTITIES` rule
+**The combined `ENTITIES-pov` invocation**.
+
++  Pre-batch `certState` plus
++  all direct deposits (top + sub) ≡ post-`ENTITIES` `certState` plus
++  all withdrawals (top + sub).
+
+This is the key step where direct deposits cancel between the UTxO and CertState
+sides of the ledger.
+
+(The `NetworkId` and domain conditions are premises of the `ENTITIES` rule
 itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
 
 ```agda
@@ -742,17 +732,13 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
             ≡⟨ cong (coinFromRewards (CertStateOf s) +_)
                     (+-comm (getCoin (DirectDepositsOf tx)) subDirectDepsCoin) ⟩
           coinFromRewards (CertStateOf s) + (subDirectDepsCoin + getCoin (DirectDepositsOf tx))
-            ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s))
-                            subDirectDepsCoin
-                            (getCoin (DirectDepositsOf tx))) ⟩
+            ≡˘⟨ +-assoc (coinFromRewards (CertStateOf s)) subDirectDepsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards (CertStateOf s) + subDirectDepsCoin + getCoin (DirectDepositsOf tx)
-            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx))
-                    (SUBLEDGERS-certs-pov valid subStep) ⟩
+            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx)) (SUBLEDGERS-certs-pov valid subStep) ⟩
           coinFromRewards cs₁ + subWdrlsCoin + getCoin (DirectDepositsOf tx)
             ≡⟨ swap-right (coinFromRewards cs₁) subWdrlsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards cs₁ + getCoin (DirectDepositsOf tx) + subWdrlsCoin
-            ≡⟨ cong (_+ subWdrlsCoin)
-                    (ENTITIES-pov (ENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+            ≡⟨ cong (_+ subWdrlsCoin) (ENTITIES-pov (ENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
           coinFromRewards cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin
             ≡⟨ +-assoc (coinFromRewards cs₂) (getCoin (WithdrawalsOf tx)) subWdrlsCoin ⟩
           coinFromRewards cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)
@@ -768,7 +754,7 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
           U₀ + R₀ + D₀ + allDirectDeps    ≡⟨ swap-right (U₀ + R₀) D₀ allDirectDeps ⟩
           U₀ + R₀ + allDirectDeps + D₀    ≡⟨ cong (_+ D₀) (+-assoc U₀ R₀ allDirectDeps) ⟩
           U₀ + (R₀ + allDirectDeps) + D₀  ≡⟨ cong (λ x → U₀ + x + D₀) combined-certs ⟩
-          U₀ + (R₂ + allWdrls) + D₀       ≡⟨ cong (_+ D₀) (sym (+-assoc U₀ R₂ allWdrls)) ⟩
+          U₀ + (R₂ + allWdrls) + D₀       ≡˘⟨ cong (_+ D₀) (+-assoc U₀ R₂ allWdrls) ⟩
           U₀ + R₂ + allWdrls + D₀         ∎
 
       dc : DepositsChange
@@ -817,14 +803,11 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
           Ctop + allWdrls + Csub + negPart dct + negPart dcs
             ≡⟨⟩
           Ctop + (Wtop + subWdrlsCoin) + Csub + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + Csub + negPart dct + negPart dcs)
-                    (sym (+-assoc Ctop Wtop subWdrlsCoin)) ⟩
+            ≡˘⟨ cong (λ x → x + Csub + negPart dct + negPart dcs) (+-assoc Ctop Wtop subWdrlsCoin) ⟩
           Ctop + Wtop + subWdrlsCoin + Csub + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
-                    (swap-right (Ctop + Wtop) subWdrlsCoin Csub) ⟩
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (swap-right (Ctop + Wtop) subWdrlsCoin Csub) ⟩
           Ctop + Wtop + Csub + subWdrlsCoin + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
-                    (+-assoc (Ctop + Wtop) Csub subWdrlsCoin) ⟩
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (+-assoc (Ctop + Wtop) Csub subWdrlsCoin) ⟩
           Ctop + Wtop + (Csub + subWdrlsCoin) + negPart dct + negPart dcs
             ≡˘⟨ cong (λ x → Ctop + Wtop + x + negPart dct + negPart dcs)
                      (sum-map-+ (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx))
@@ -841,6 +824,8 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
           O + F + DN + allDirectDeps + Psub + posPart dct + posPart dcs + totGov
             ∎
         where
+        O F DN DDtop Wtop CsubW : Coin
+
         O     = cbalance (outs tx)
         F     = TxFeesOf tx
         DN    = DonationsOf tx
@@ -850,7 +835,7 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
                                 + getCoin (WithdrawalsOf stx))
                          (SubTransactionsOf tx))
 
-        pp = LedgerEnv.pparams Γ
+        pp = PParamsOf Γ
 
         -- Abstract net-conversion: reconcile the closed-form balance (`bal`, with
         -- cert deposits as `PZ`/`NZ`) with the chain's two-level form, using the
@@ -1004,38 +989,42 @@ on both sides:
 
 ```agda
       step-ii : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + totGov + R₂
-      step-ii = cong (_+ R₂)
-                     (+-cancelʳ-≡ E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂ + totGov)
-                                  LHS+E≡RHS+E)
+      step-ii = cong  ( _+ R₂ )
+                      ( +-cancelʳ-≡  E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂ + totGov)
+                                     LHS+E≡RHS+E )
 
       -- The three LedgerState totals (UTxO + rewards + cert-deposits): the batch's
       -- gov deposits surface as `+ totGov` on the produced side.
       three-summand : U₀ + R₀ + D₀ ≡ U₂ + R₂ + D₂ + totGov
-      three-summand =
-        +-cancelʳ-≡ allDirectDeps (U₀ + R₀ + D₀) (U₂ + R₂ + D₂ + totGov)
-          (begin
-            U₀ + R₀ + D₀ + allDirectDeps           ≡⟨ step-i ⟩
-            U₀ + R₂ + allWdrls + D₀                ≡⟨ abcd-to-acdb U₀ R₂ allWdrls D₀ ⟩
-            U₀ + allWdrls + D₀ + R₂                ≡⟨ step-ii ⟩
-            U₂ + allDirectDeps + D₂ + totGov + R₂  ≡⟨ outer-rearr U₂ allDirectDeps D₂ totGov R₂ ⟩
-            U₂ + R₂ + D₂ + totGov + allDirectDeps  ∎)
+      three-summand = +-cancelʳ-≡ allDirectDeps (U₀ + R₀ + D₀) (U₂ + R₂ + D₂ + totGov)
+        $ begin
+          U₀ + R₀ + D₀ + allDirectDeps           ≡⟨ step-i ⟩
+          U₀ + R₂ + allWdrls + D₀                ≡⟨ abcd-to-acdb U₀ R₂ allWdrls D₀ ⟩
+          U₀ + allWdrls + D₀ + R₂                ≡⟨ step-ii ⟩
+          U₂ + allDirectDeps + D₂ + totGov + R₂  ≡⟨ outer-rearr U₂ allDirectDeps D₂ totGov R₂ ⟩
+          U₂ + R₂ + D₂ + totGov + allDirectDeps  ∎
 
       -- Gov-deposit accounting: the batch's total gov deposits exactly account for
       -- the growth from the initial gov state's deposit (G₀) to the final one (G').
       gov-acc : totGov + G₀ ≡ G'
-      gov-acc =
-        begin
-          totGov + G₀                          ≡⟨ rearr3 topGov subGovSum G₀ ⟩
-          G₀ + subGovSum + topGov              ≡˘⟨ cong (_+ topGov) (SUBLEDGERS-gov-coin valid subStep) ⟩
-          coinFromGovDeposit govSt₁ + topGov   ≡˘⟨ govStep-eq ⟩
-          coinFromGovDeposit govSt₂            ≡˘⟨ rmOrphanDRepVotes-coinFromGovDeposit cs₂ govSt₂ ⟩
-          G'                                   ∎
+      gov-acc = begin
+        totGov + G₀                          ≡⟨ rearr3 topGov subGovSum G₀ ⟩
+        G₀ + subGovSum + topGov              ≡˘⟨ cong (_+ topGov) (SUBLEDGERS-gov-coin valid subStep) ⟩
+        coinFromGovDeposit govSt₁ + topGov   ≡˘⟨ govStep-eq ⟩
+        coinFromGovDeposit govSt₂            ≡˘⟨ rmOrphanDRepVotes-coinFromGovDeposit cs₂ govSt₂ ⟩
+        G'                                   ∎
         where
         govStep-eq : coinFromGovDeposit govSt₂ ≡ coinFromGovDeposit govSt₁ + topGov
-        govStep-eq = trans (GOVS-coinFromGovDeposit govStep)
-                           (cong (λ ps → coinFromGovDeposit govSt₁
-                                       + govProposalsDeposits (LedgerEnv.pparams Γ) ps)
-                                 (proposalsOf-Proposals+Votes tx))
+        govStep-eq = trans  (GOVS-coinFromGovDeposit govStep)
+                            (cong (λ ps  → coinFromGovDeposit govSt₁
+                                         + govProposalsDeposits (PParamsOf Γ) ps)
+                                  (proposalsOf-Proposals+Votes tx))
 ```
 
 [^1]: See the review of PR #1256.
+
+[^2]: One wrinkle: the solver recognises the ring's operations *syntactically*, so
+      the `Ledger.Prelude` overloaded `_+_` (a `HasAdd`{.AgdaRecord} method, which merely
+      *reduces* to `Data.Nat._+_`) defeats it.  The solver-facing statements are therefore
+      written with the raw natural-number addition, imported as `_+ᴺ_` — definitionally
+      equal to `_+_` at `Coin`, so the lemmas discharge `_+_` goals unchanged.

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -35,10 +35,10 @@ the direct-deposit trick (see *Proof Strategy*), and the gov-deposit growth
 
 The `PoolDepositsRegistered`{.AgdaFunction} hypothesis is necessary, not an artifact
 of the proof: the batch balance charges `newCertDeposits`{.AgdaFunction} against the
-registered-pool set, while `POOL-reg`{.AgdaInductiveConstructor}'s left-biased pot
-update silently keeps a stale entry for an unregistered pool — at a state with such
-an entry, a pool registration destroys the charged deposit and the theorem is false.
-On-chain states satisfy the hypothesis by construction.
+registered-pool set, while `POOL-reg`{.AgdaInductiveConstructor}'s left-biased update
+silently keeps a stale entry for an unregistered pool; at a state with such an entry,
+a pool registration destroys the charged deposit and the theorem is false.  On-chain
+states satisfy the hypothesis by construction.
 
 ## Proof Strategy
 
@@ -49,25 +49,24 @@ The Dijkstra `LEDGER-pov`{.AgdaFunction} does not decompose into independent
 may individually transfer value between UTxO and CertState without local balancing.
 
 Instead, the `LEDGER-V` proof is a single equational chain at the
-`LedgerState`{.AgdaRecord} level, with the cancellation of total direct deposits as
-the central trick — direct-deposit value appears both on the UTxO side (via
+`LedgerState`{.AgdaRecord} level, and cancellation of the *total* direct deposits is
+the key to the proof.  Direct-deposit value appears both on the UTxO side (via
 `producedBatch`) and on the CertState side (via `applyDirectDeposits` inside
 `ENTITIES`) and cancels in the total.
 
 Concretely, the proof composes four inductions over the `SUBLEDGERS`{.AgdaDatatype}
 reflexive-transitive closure, plus one arithmetic identity.
 
-+  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** threads the per-`SUBUTXOW` coin equation
-   (`subutxow-step-coin`).
-+  **`SUBLEDGERS-certs-pov`{.AgdaFunction}** composes per-sub-transaction
++  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** inducts over the subtransaction list,
+   applying the per-`SUBUTXOW` coin equation (`subutxow-step-coin`) at each step.
++  **`SUBLEDGERS-rewards-pov`{.AgdaFunction}** composes per-sub-transaction
    `SUBENTITIES-pov`{.AgdaFunction} invocations (the rewards flow).
 +  **`SUBLEDGERS-deposits`{.AgdaFunction}** (with `SUBLEDGERS-registered`{.AgdaFunction})
    telescopes the per-step closed-form deposit accounting into the batch-wide
    equation consumed by `bat'`.
-+  **`SUBLEDGERS-gov-coin`{.AgdaFunction}** accumulates the per-`GOVS` gov-deposit
-   growth.
-+  **`posNeg-deposits`{.AgdaFunction}** equationally relates the pre-/post-batch deposit
-   totals to the `posPart`/`negPart` of `calculateDepositsChange`.
++  **`SUBLEDGERS-gov-coin`{.AgdaFunction}** accumulates the per-`GOVS` gov-deposit growth.
++  **`posNeg-deposits`{.AgdaFunction}** relates the pre-/post-batch deposit totals to
+   the `posPart`/`negPart` of `calculateDepositsChange`.
 
 The `LEDGER-I` case is straightforward; `certState` and `govSt` are unchanged,
 `SUBLEDGERS` is a no-op, and only the `UTXOW` step affects `getCoin`, which it
@@ -105,10 +104,6 @@ open import Ledger.Dijkstra.Specification.Utxo txs abs
 open import Ledger.Dijkstra.Specification.Utxow txs abs
 
 open import Ledger.Dijkstra.Specification.Entities.Properties.PoV txs
-
--- We will import the following once the UTXO/UTXOW PoV proofs land:
--- open import Ledger.Dijkstra.Specification.Utxo.Properties.PoV txs abs
--- open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
 
 open import Interface.STS
 
@@ -394,8 +389,8 @@ same quantity (the sum of deposits across the batch), just rephrased to expose
 
 ## `SUBLEDGERS-utxo-coin`
 
-Induct over the `SUBLEDGERS` reflexive-transitive closure, threading the
-per-`SUBUTXOW` coin equation:
+Induct over the `SUBLEDGERS` reflexive-transitive closure, applying the
+per-`SUBUTXOW` coin equation at each step:
 
 ```agda
   SUBLEDGERS-utxo-coin :
@@ -450,7 +445,7 @@ per-`SUBUTXOW` coin equation:
     ih = SUBLEDGERS-utxo-coin isV rest
 ```
 
-## `SUBLEDGERS-certs-pov`
+## `SUBLEDGERS-rewards-pov`
 
 Parallel induction over `SUBLEDGERS`, composing per-sub-transaction `SUBENTITIES-pov`
 invocations.  The `NetworkId` witnesses and domain conditions are premises of the
@@ -460,7 +455,7 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
 ```agda
   open SubLedgerEnv
 
-  SUBLEDGERS-certs-pov :
+  SUBLEDGERS-rewards-pov :
     {Γ : SubLedgerEnv}
     {s₀ s₁ : LedgerState}
     {stxs : List SubLevelTx}
@@ -469,12 +464,12 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     →  coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
        ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
 
-  SUBLEDGERS-certs-pov _ (BS-base Id-nop) = refl
+  SUBLEDGERS-rewards-pov _ (BS-base Id-nop) = refl
 
-  SUBLEDGERS-certs-pov isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+  SUBLEDGERS-rewards-pov isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
     ⊥-elim (case trans (sym isV) isI of λ ())
 
-  SUBLEDGERS-certs-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+  SUBLEDGERS-rewards-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
     (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) =
     begin
       coinFromRewards (CertStateOf s₀) + (getCoin (DirectDepositsOf stx) + sum (map ddwl sigs))
@@ -495,7 +490,7 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     where
     ih : coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)
          ≡ coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)
-    ih = SUBLEDGERS-certs-pov isV rest
+    ih = SUBLEDGERS-rewards-pov isV rest
 ```
 
 ## `SUBLEDGERS-deposits`
@@ -814,7 +809,7 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
           coinFromRewards (CertStateOf s) + (subDirectDepsCoin + getCoin (DirectDepositsOf tx))
             ≡˘⟨ +-assoc (coinFromRewards (CertStateOf s)) subDirectDepsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards (CertStateOf s) + subDirectDepsCoin + getCoin (DirectDepositsOf tx)
-            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx)) (SUBLEDGERS-certs-pov valid subStep) ⟩
+            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx)) (SUBLEDGERS-rewards-pov valid subStep) ⟩
           coinFromRewards cs₁ + subWdrlsCoin + getCoin (DirectDepositsOf tx)
             ≡⟨ swap-right (coinFromRewards cs₁) subWdrlsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards cs₁ + getCoin (DirectDepositsOf tx) + subWdrlsCoin
@@ -1038,10 +1033,7 @@ The main inner chain, showing LHS + E ≡ RHS + E:
           ≡⟨ arithmetic-2 U₀ allWdrls D₀ ⟩
         U₀ + Psub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
           ≡⟨ cong  (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
-                   (subst  (λ u → U₀ + Psub ≡ U₁ + sum (map  (λ stx → cbalance (u ∣ SpendInputsOf stx))
-                                                             (SubTransactionsOf tx)))
-                           (refl {x = UTxOOf (UTxOStateOf s)})
-                           (SUBLEDGERS-utxo-coin valid subStep)) ⟩
+                           (SUBLEDGERS-utxo-coin valid subStep) ⟩
         U₁ + Csub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
           ≡⟨ cong (λ x → (U₁ + Csub) + allWdrls + x + Ctop) posneg ⟩
         U₁ + Csub + allWdrls + (D₂ + negPart dct + negPart dcs) + Ctop

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -8,10 +8,9 @@ source_path: src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
 This module proves the top-level preservation-of-value (PoV) theorem for the Dijkstra
 `LEDGER`{.AgdaDatatype} rule.  If
 
-+  `Γ`{.AgdaBound} is a ledger environment,
-+  `tx`{.AgdaBound} is top-level transaction, and
-+  `s`{.AgdaBound} and `s'`{.AgdaBound} are ledger states related by
-   `LEDGER`{.AgdaDatatype},
++  `Γ` is a ledger environment,
++  `tx` is top-level transaction, and
++  `s` and `s'` are ledger states related by `LEDGER`{.AgdaDatatype},
 
 then `getCoin s ≡ getCoin s'`.
 
@@ -23,51 +22,63 @@ Recall (from `Ledger.lagda.md`) that `getCoin (LedgerState)` is
     + coinFromGovDeposit (GovStateOf s)
 
 This is the sum of UTxO coin, the cert-state rewards balance
-(`coinFromRewards`{.AgdaFunction}), the deposits from `DState`, `PState`, and `GState`
-(`coinFromDeposits`{.AgdaFunction}), and the governance-action deposits
-(`coinFromGovDeposit`{.AgdaFunction}).  Note `getCoin (CertState)` itself now sums the
-rewards balance *and* the deposit pots (`coinFromRewards + coinFromDeposits`), so the
-two middle summands are exactly `getCoin (CertStateOf s)`.
+(`coinFromRewards`{.AgdaFunction}), the deposits from `DState`{.AgdaRecord},
+`PState`{.AgdaRecord}, and `GState`{.AgdaRecord} (`coinFromDeposits`{.AgdaFunction}),
+and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}).
 
-> **Status — complete.** `LEDGER-pov` typechecks end-to-end under `--safe` (no
-> postulates or holes).  Following the top-down plan, this module proves only the
-> top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
-> as **module parameters**, discharged downstream:
->
-> - **Certs-PoV** (`CERTS-pov`, `batch-cert-deposits-bridge`) — by #1210.
-> - **Utxo/Utxow-PoV** (`utxow-pov-invalid`, `UTXOW-V-mechanical`,
->   `UTXOW-batch-balance-coin`, and the UTxO algebra `balance-∪`, `split-balance`,
->   `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`, …) — by the
->   utxo/utxow-pov work (#1186).  `UTXOW-batch-balance-coin` is the coin projection of
->   the spec's `consumedBatch ≡ producedBatch` premise, with the produced-side
->   `govProposalsDeposits` collected into a single trailing `totGov` term.  Its
->   cert-deposit summands are in the spec's *closed form* (`refundCertDeposits` /
->   `newCertDeposits` over `allDCerts tx`, against the pre-batch registered-pool set),
->   keeping it a pure UTxO obligation; `bat'` converts these to the chain's top/sub
->   two-level form using the `batch-cert-deposits-bridge` (#1210) and `posNeg-deposits`.
-> - **Gov-deposit accounting** (`rmOrphanDRepVotes-coinFromGovDeposit`,
->   `GOVS-coinFromGovDeposit`) — by a future `Gov.Properties.PoV`.
-> - **No-truncation bounds** (`ENTITIES-wdrls-bounded`, `SUBENTITIES-wdrls-bounded`) —
->   each withdrawal amount is bounded by the account's balance in the input state of
->   the `ENTITIES`/`SUBENTITIES` step that consumes it.  The spec's own premises bound
->   withdrawals only against the *pre-batch* snapshot `rewards₀` (except top-level
->   legacy mode, which forces exact-balance withdrawals), which does not by itself
->   bound them against the input state of a later step in the batch — the
->   phantom-withdrawal gap flagged in the #1256 review.  These parameters are to be
->   discharged either by a spec-side premise or by a batch-threading invariant, in the
->   follow-up to that discussion.
->
-> `getCoin` on a `LedgerState` has the four summands above — UTxO coin, rewards
-> balance, the cert-deposit pots (`coinFromDeposits`), and the gov-action deposits
-> (`coinFromGovDeposit`) — and the `LEDGER-V` chain accounts for all four: the cert
-> deposits cancel via the direct-deposit trick (see *Proof Strategy*), and the
-> gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (the
-> `gov-acc` lemma, from `SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
+Note `getCoin (CertState)` itself now sums the rewards balance *and* the deposit pots
+(`coinFromRewards + coinFromDeposits`), so the two middle summands are exactly
+`getCoin (CertStateOf s)`.
+
+`getCoin` on a `LedgerState` has the four summands above — UTxO coin, rewards
+balance, the cert-deposit pots (`coinFromDeposits`), and the gov-action deposits
+(`coinFromGovDeposit`) — and the `LEDGER-V` chain accounts for all four.  The cert
+deposits cancel via the direct-deposit trick (see *Proof Strategy*), and the
+gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (the
+`gov-acc` lemma, from `SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
+
+??? note "**Status: complete**"
+
+    `LEDGER-pov`{.AgdaFunction}n typechecks end-to-end under `--safe` (no
+    postulates or holes).  Following the top-down plan, this module proves only the
+    top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
+    as *module parameters*, discharged downstream:
+
+    +  **Certs-PoV** (`CERTS-pov`, `batch-cert-deposits-bridge`).
+
+    +  **Utxo/Utxow-PoV** (`utxow-pov-invalid`, `UTXOW-V-mechanical`,
+       `UTXOW-batch-balance-coin`, and the UTxO algebra `balance-∪`, `split-balance`,
+       `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`, etc.).
+
+       `UTXOW-batch-balance-coin` is the coin projection of the spec's
+       `consumedBatch ≡ producedBatch` premise, with the produced-side
+       `govProposalsDeposits` collected into a single trailing `totGov` term.
+       Its cert-deposit summands are obtained from `refundCertDeposits` and
+       `newCertDeposits` over `allDCerts tx`, against the pre-batch registered-pool
+       set, keeping it a pure UTxO obligation; `bat'` converts these to the chain's
+       top/sub two-level form using the `batch-cert-deposits-bridge` and
+       `posNeg-deposits`.
+
+    +  **Gov-deposit accounting** (`rmOrphanDRepVotes-coinFromGovDeposit`,
+       `GOVS-coinFromGovDeposit`), to be supplied by a future `Gov.Properties.PoV`.
+
+    +  **No-truncation bounds** (`ENTITIES-wdrls-bounded`, `SUBENTITIES-wdrls-bounded`).
+
+       Each withdrawal amount is bounded by the account's balance in the input state of
+       the `ENTITIES`/`SUBENTITIES` step that consumes it.
+
+       **N.B.**  The premises of the spec transition rules bound withdrawals only
+       against the *pre-batch* snapshot `rewards₀` (except top-level legacy mode,
+       which forces exact-balance withdrawals), which does not by itself bound them
+       against the input state of a later step in the batch. This is the
+       phantom-withdrawal gap flagged in the review of PR #1256.
+       As such, these module parameters should be discharged in the follow-up to that
+       discussion, either by spec rule premises or by a batch-threading invariant.
 
 ## Proof Strategy
 
 The Dijkstra `LEDGER-pov`{.AgdaFunction} does not decompose into independent
-`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces: individual
+`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces; individual
 `SUBUTXO`{.AgdaDatatype} rules have no balance equation (only the *batch-level*
 `consumedBatch ≡ producedBatch` equation constrains the total), and sub-transactions
 may individually transfer value between UTxO and CertState without local balancing.
@@ -78,18 +89,18 @@ the central trick — direct-deposit value appears both on the UTxO side (via
 `producedBatch`) and on the CertState side (via `applyDirectDeposits` inside
 `ENTITIES`) and cancels in the total.
 
-Concretely, the proof uses three helper lemmas:
+Concretely, the proof uses three helper lemmas.
 
-+  `SUBLEDGERS-utxo-coin`{.AgdaFunction}: induct over the `SUBLEDGERS`{.AgdaDatatype}
++  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** inducts over the `SUBLEDGERS`{.AgdaDatatype}
    reflexive-transitive closure, threading the per-`SUBUTXOW` coin equation
    (`subutxow-step-coin`).
-+  `SUBLEDGERS-certs-pov`{.AgdaFunction}: parallel induction over
++  **`SUBLEDGERS-certs-pov`{.AgdaFunction}** is parallel induction over
    `SUBLEDGERS`{.AgdaDatatype}, composing per-sub-transaction
    `SUBENTITIES-pov`{.AgdaFunction} invocations.
-+  `posNeg-deposits`{.AgdaFunction}: equationally relates the pre-/post-batch deposit
++  **`posNeg-deposits`{.AgdaFunction}** equationally relates the pre-/post-batch deposit
    totals to the `posPart`/`negPart` of `calculateDepositsChange`.
 
-The `LEDGER-I` case is straightforward: `certState` and `govSt` are unchanged,
+The `LEDGER-I` case is straightforward; `certState` and `govSt` are unchanged,
 `SUBLEDGERS` is a no-op, and only the `UTXOW` step affects `getCoin`, which it
 preserves via `utxow-pov-invalid`.
 
@@ -105,25 +116,29 @@ module Ledger.Dijkstra.Specification.Ledger.Properties.PoV
   (abs : AbstractFunctions txs) (open AbstractFunctions abs)
   where
 
-open import Ledger.Prelude
-open import Ledger.Dijkstra.Specification.Certs govStructure
-open import Ledger.Dijkstra.Specification.Entities txs
-open import Ledger.Dijkstra.Specification.Gov govStructure
-open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
-open import Ledger.Dijkstra.Specification.Utxo txs abs
-open import Ledger.Dijkstra.Specification.Utxow txs abs
-open import Ledger.Dijkstra.Specification.Ledger txs abs
-
-open import Ledger.Dijkstra.Specification.Entities.Properties.PoV txs
--- open import Ledger.Dijkstra.Specification.Utxo.Properties.PoV txs abs
--- open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
-
-open import Interface.STS
 open import Data.Nat.Properties
   using (+-comm; +-assoc; +-0-monoid; +-identityʳ; +-cancelʳ-≡)
 open import Data.Integer using (ℤ; 0ℤ; _-_; _⊖_)
 open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n) renaming (+-comm to +ℤ-comm)
 open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
+
+open import Ledger.Prelude
+
+open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Entities txs
+open import Ledger.Dijkstra.Specification.Gov govStructure
+open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
+open import Ledger.Dijkstra.Specification.Ledger txs abs
+open import Ledger.Dijkstra.Specification.Utxo txs abs
+open import Ledger.Dijkstra.Specification.Utxow txs abs
+
+open import Ledger.Dijkstra.Specification.Entities.Properties.PoV txs
+
+-- We will import the following once the UTXO/UTXOW PoV proofs land:
+-- open import Ledger.Dijkstra.Specification.Utxo.Properties.PoV txs abs
+-- open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
+
+open import Interface.STS
 
 open RewardAddress
 open ≡-Reasoning
@@ -135,35 +150,34 @@ instance
 
 ## The `LEDGER-PoV` module
 
-`LEDGER-pov`{.AgdaFunction} threads through five groups of module
-parameters:
+`LEDGER-pov`{.AgdaFunction} currently depends on module parameters from the following
+groups:
 
 +  the three set/map identities from `ApplyToRewards-PoV`{.AgdaModule}
    (`∪ˡ-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique`);
 +  the UTxO arithmetic / freshness assumptions and batch-wide invariants
    (`balance-∪`, `split-balance`, `noMintTx`, `noMintSubTx`, `outs-disjoint`,
    `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`,
-   `utxow-pov-invalid`, `UTXOW-V-mechanical`, `UTXOW-batch-balance-coin`) — the #1186
-   obligations;
-+  the Certs facts (`CERTS-pov`, `batch-cert-deposits-bridge`) — the #1210 obligations;
+   `utxow-pov-invalid`, `UTXOW-V-mechanical`, `UTXOW-batch-balance-coin`);
++  the Certs facts (`CERTS-pov`, `batch-cert-deposits-bridge`);
 +  the governance-deposit facts (`rmOrphanDRepVotes-coinFromGovDeposit`,
-   `GOVS-coinFromGovDeposit`) — for a future `Gov.Properties.PoV`;
+   `GOVS-coinFromGovDeposit`) from a future `Gov.Properties.PoV`;
 +  the no-truncation withdrawal bounds (`ENTITIES-wdrls-bounded`,
-   `SUBENTITIES-wdrls-bounded`) — the phantom-withdrawal gap (see the #1256 review),
+   `SUBENTITIES-wdrls-bounded`), the phantom-withdrawal gap,[^1]
    to be discharged by a spec-side premise or a batch-threading invariant.
 
 All are stated with detailed provenance notes in comments and are to be discharged in
 follow-up work.  This parameter list is the frozen interface between this proof and
-the follow-up PRs.
+the follow-ups.
 
 ```agda
 noMintingSubTxs : TopLevelTx → Type
 noMintingSubTxs tx = ∀ stx → stx ∈ˡ SubTransactionsOf tx → coin (MintedValueOf stx) ≡ 0
 
--- The right injections of a list of sums.  Used (at `GovVote ⊎ GovProposal`) to
+-- The right injections of a list of sums, used (at `GovVote ⊎ GovProposal`) to
 -- extract the proposals from a mixed `GOVS` input list for the
--- `GOVS-coinFromGovDeposit` gov-deposit accounting parameter below.  Stated generically
--- to avoid the doubly-imported `GovVote`/`GovProposal` names.
+-- `GOVS-coinFromGovDeposit` gov-deposit accounting parameter below, stated
+-- generically to avoid the doubly-imported `GovVote`/`GovProposal` names.
 proposalsOf : ∀ {A B : Type} → List (A ⊎ B) → List B
 proposalsOf []            = []
 proposalsOf (inj₁ _ ∷ xs) = proposalsOf xs
@@ -198,21 +212,19 @@ module LEDGER-PoV
                   → TxIdOf tx ∉ mapˢ proj₁ (dom u)
                   → disjoint (dom (u ∣ SpendInputsOf tx ᶜ)) (dom (outs tx)) )
 
-  -- Per-step SUBUTXOW coin equation.  A local proof would require, in
-  -- addition to `balance-∪` and `split-balance`, a batch-wide
-  -- "spend inputs preserved" invariant (the running UTxO agrees with
-  -- the snapshot on every sub-tx's spend inputs) and freshness of each
-  -- sub-tx's TxId relative to the running UTxO.
+  -- Per-step SUBUTXOW coin equation.  A local proof would require, in addition to
+  -- `balance-∪` and `split-balance`, a batch-wide "spend inputs preserved" invariant
+  -- (the running UTxO agrees with the snapshot on every sub-tx's spend inputs) and
+  -- freshness of each sub-tx's TxId relative to the running UTxO.
   ( subutxow-step-coin : ∀ {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
       → IsTopLevelValidFlagOf Γ ≡ true
       → Γ ⊢ s₀ ⇀⦇ stx ,SUBUTXOW⦈ s₁
       → getCoin s₀ + cbalance (outs stx) + DonationsOf stx
         ≡ getCoin s₁ + cbalance (UTxOOf Γ ∣ SpendInputsOf stx) )
 
-  -- Batch-wide invariants on the post-SUBLEDGERS UTxO state.  Both
-  -- follow from batch-wide input disjointness and TxId freshness,
-  -- which the outer UTXO rule establishes at the batch level but
-  -- doesn't expose per-step.
+  -- Batch-wide invariants on the post-SUBLEDGERS UTxO state.  Both follow from
+  -- batch-wide input disjointness and TxId freshness, which the outer UTXO rule
+  -- establishes at the batch level but doesn't expose per-step.
   ( utxo₁-tx-spend-eq : {subΓ : SubLedgerEnv} {s : LedgerState}
         {utxoSt₁ : UTxOState} {govSt₁ : GovState} {certState₁ : CertState}
       → SubLedgerEnv.isTopLevelValid subΓ ≡ true
@@ -226,8 +238,9 @@ module LEDGER-PoV
       → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
 
-  -- Certs-PoV stubs (discharged later by #1210).  These were the `Certs.Properties.PoV`
-  -- provider lemmas; under the top-down plan they are module parameters here.
+  -- Certs-PoV stubs (discharged later by follow-up PR #1210).  These were the
+  -- `Certs.Properties.PoV` provider lemmas; under the top-down plan they are module
+  -- parameters here.
   ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
       → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
   -- Batch-wide cert-deposit bridge (discharged later by #1210).  The closed-form
@@ -420,8 +433,10 @@ per-`SUBUTXOW` coin equation:
   SUBLEDGERS-utxo-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
     → SubLedgerEnv.isTopLevelValid Γ ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
-    → getCoin (UTxOStateOf s₀) + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) stxs)
-      ≡ getCoin (UTxOStateOf s₁) + sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) stxs)
+    → getCoin (UTxOStateOf s₀)
+      + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) stxs)
+      ≡  getCoin (UTxOStateOf s₁)
+         + sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) stxs)
 
   -- Base case: empty list.  `Id-nop` unifies s₀ ≡ s₁ and both sums are 0.
   SUBLEDGERS-utxo-coin _ (BS-base Id-nop) = refl
@@ -472,11 +487,14 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
 `SUBENTITIES-wdrls-bounded` module parameter.
 
 ```agda
-  SUBLEDGERS-certs-pov : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+  SUBLEDGERS-certs-pov :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
     → SubLedgerEnv.isTopLevelValid Γ ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
-    → coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
-      ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
+    →  coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
+       ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
 
   SUBLEDGERS-certs-pov _ (BS-base Id-nop) = refl
 
@@ -947,24 +965,29 @@ The main inner chain, showing LHS + E ≡ RHS + E:
         U₀ + allWdrls + D₀ + Ctop + Psub + posPart dct + posPart dcs
           ≡⟨ arithmetic-2 U₀ allWdrls D₀ ⟩
         U₀ + Psub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
-          ≡⟨ cong (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
-                  (subst (λ u →   U₀ + Psub
-                              ≡ U₁ + sum (map (λ stx → cbalance (u ∣ SpendInputsOf stx))
-                                              (SubTransactionsOf tx)))
-                         (refl {x = UTxOOf (UTxOStateOf s)})
-                         (SUBLEDGERS-utxo-coin valid subStep)) ⟩
+          ≡⟨ cong  (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
+                   (subst  (λ u → U₀ + Psub ≡ U₁ + sum (map  (λ stx → cbalance (u ∣ SpendInputsOf stx))
+                                                             (SubTransactionsOf tx)))
+                           (refl {x = UTxOOf (UTxOStateOf s)})
+                           (SUBLEDGERS-utxo-coin valid subStep)) ⟩
         U₁ + Csub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
           ≡⟨ cong (λ x → (U₁ + Csub) + allWdrls + x + Ctop) posneg ⟩
         U₁ + Csub + allWdrls + (D₂ + negPart dct + negPart dcs) + Ctop
           ≡⟨ arithmetic-3 U₁ Csub allWdrls ⟩
         U₁ + (Ctop + allWdrls + Csub + negPart dct + negPart dcs) + D₂
           ≡⟨ cong (λ x → U₁ + x + D₂) bat' ⟩
-        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs + totGov) + D₂
-          ≡⟨ mid-extract U₁ (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs) D₂ totGov ⟩
-        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs) + D₂ + totGov
+        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps
+           + Psub + posPart dct + posPart dcs + totGov) + D₂
+          ≡⟨ mid-extract U₁ (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+             + allDirectDeps + Psub + posPart dct + posPart dcs) D₂ totGov ⟩
+        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps
+           + Psub + posPart dct + posPart dcs) + D₂ + totGov
           ≡⟨ cong (_+ totGov) (arithmetic-4 U₁ (cbalance (outs tx)) (TxFeesOf tx)) ⟩
-        U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs + D₂ + totGov
-          ≡⟨ cong (_+ totGov) (cong (λ x → x + allDirectDeps + Psub + posPart dct + posPart dcs + D₂) mech) ⟩
+        U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub
+           + posPart dct + posPart dcs + D₂ + totGov
+          ≡⟨ cong  ( _+ totGov )
+                   ( cong  (λ x → x + allDirectDeps + Psub + posPart dct + posPart dcs + D₂)
+                           mech ) ⟩
         U₂ + Ctop + allDirectDeps + Psub + posPart dct + posPart dcs + D₂ + totGov
           ≡⟨ cong (_+ totGov) (arithmetic-5 U₂ Ctop allDirectDeps) ⟩
         U₂ + allDirectDeps + D₂ + Ctop + Psub + posPart dct + posPart dcs + totGov
@@ -1084,3 +1107,5 @@ on both sides:
                                        + govProposalsDeposits (LedgerEnv.pparams Γ) ps)
                                  (proposalsOf-Proposals+Votes tx))
 ```
+
+[^1]: See the review of PR #1256.

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -1,0 +1,1111 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+---
+
+# Properties of `LEDGER`: Preservation of Value {#thm:LEDGER-PoV}
+
+This module proves the top-level preservation-of-value (PoV) theorem for the Dijkstra
+`LEDGER`{.AgdaDatatype} rule.  If
+
++  `Γ` is a ledger environment,
++  `tx` is top-level transaction, and
++  `s` and `s'` are ledger states related by `LEDGER`{.AgdaDatatype},
+
+then `getCoin s ≡ getCoin s'`.
+
+Recall (from `Ledger.lagda.md`) that `getCoin (LedgerState)` is
+
+    getCoin (UTxOStateOf s)
+    + coinFromRewards (CertStateOf s)
+    + coinFromDeposits (CertStateOf s)
+    + coinFromGovDeposit (GovStateOf s)
+
+This is the sum of UTxO coin, the cert-state rewards balance
+(`coinFromRewards`{.AgdaFunction}), the deposits from `DState`{.AgdaRecord},
+`PState`{.AgdaRecord}, and `GState`{.AgdaRecord} (`coinFromDeposits`{.AgdaFunction}),
+and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}).
+
+Note `getCoin (CertState)` itself now sums the rewards balance *and* the deposit pots
+(`coinFromRewards + coinFromDeposits`), so the two middle summands are exactly
+`getCoin (CertStateOf s)`.
+
+`getCoin` on a `LedgerState` has the four summands above — UTxO coin, rewards
+balance, the cert-deposit pots (`coinFromDeposits`), and the gov-action deposits
+(`coinFromGovDeposit`) — and the `LEDGER-V` chain accounts for all four.  The cert
+deposits cancel via the direct-deposit trick (see *Proof Strategy*), and the
+gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (the
+`gov-acc` lemma, from `SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
+
+??? note "**Status: complete**"
+
+    `LEDGER-pov`{.AgdaFunction}n typechecks end-to-end under `--safe` (no
+    postulates or holes).  Following the top-down plan, this module proves only the
+    top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
+    as *module parameters*, discharged downstream:
+
+    +  **Certs-PoV** (`CERTS-pov`, `batch-cert-deposits-bridge`).
+
+    +  **Utxo/Utxow-PoV** (`utxow-pov-invalid`, `UTXOW-V-mechanical`,
+       `UTXOW-batch-balance-coin`, and the UTxO algebra `balance-∪`, `split-balance`,
+       `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`, etc.).
+
+       `UTXOW-batch-balance-coin` is the coin projection of the spec's
+       `consumedBatch ≡ producedBatch` premise, with the produced-side
+       `govProposalsDeposits` collected into a single trailing `totGov` term.
+       Its cert-deposit summands are obtained from `refundCertDeposits` and
+       `newCertDeposits` over `allDCerts tx`, against the pre-batch registered-pool
+       set, keeping it a pure UTxO obligation; `bat'` converts these to the chain's
+       top/sub two-level form using the `batch-cert-deposits-bridge` and
+       `posNeg-deposits`.
+
+    +  **Gov-deposit accounting** (`rmOrphanDRepVotes-coinFromGovDeposit`,
+       `GOVS-coinFromGovDeposit`), to be supplied by a future `Gov.Properties.PoV`.
+
+    +  **No-truncation bounds** (`ENTITIES-wdrls-bounded`, `SUBENTITIES-wdrls-bounded`).
+
+       Each withdrawal amount is bounded by the account's balance in the input state of
+       the `ENTITIES`/`SUBENTITIES` step that consumes it.
+
+       **N.B.**  The premises of the spec transition rules bound withdrawals only
+       against the *pre-batch* snapshot `rewards₀` (except top-level legacy mode,
+       which forces exact-balance withdrawals), which does not by itself bound them
+       against the input state of a later step in the batch. This is the
+       phantom-withdrawal gap flagged in the review of PR #1256.
+       As such, these module parameters should be discharged in the follow-up to that
+       discussion, either by spec rule premises or by a batch-threading invariant.
+
+## Proof Strategy
+
+The Dijkstra `LEDGER-pov`{.AgdaFunction} does not decompose into independent
+`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces; individual
+`SUBUTXO`{.AgdaDatatype} rules have no balance equation (only the *batch-level*
+`consumedBatch ≡ producedBatch` equation constrains the total), and sub-transactions
+may individually transfer value between UTxO and CertState without local balancing.
+
+Instead, the `LEDGER-V` proof is a single equational chain at the
+`LedgerState`{.AgdaRecord} level, with the cancellation of total direct deposits as
+the central trick — direct-deposit value appears both on the UTxO side (via
+`producedBatch`) and on the CertState side (via `applyDirectDeposits` inside
+`ENTITIES`) and cancels in the total.
+
+Concretely, the proof uses three helper lemmas.
+
++  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** inducts over the `SUBLEDGERS`{.AgdaDatatype}
+   reflexive-transitive closure, threading the per-`SUBUTXOW` coin equation
+   (`subutxow-step-coin`).
++  **`SUBLEDGERS-certs-pov`{.AgdaFunction}** is parallel induction over
+   `SUBLEDGERS`{.AgdaDatatype}, composing per-sub-transaction
+   `SUBENTITIES-pov`{.AgdaFunction} invocations.
++  **`posNeg-deposits`{.AgdaFunction}** equationally relates the pre-/post-batch deposit
+   totals to the `posPart`/`negPart` of `calculateDepositsChange`.
+
+The `LEDGER-I` case is straightforward; `certState` and `govSt` are unchanged,
+`SUBLEDGERS` is a no-op, and only the `UTXOW` step affects `getCoin`, which it
+preserves via `utxow-pov-invalid`.
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Transaction
+open import Ledger.Dijkstra.Specification.Abstract
+
+module Ledger.Dijkstra.Specification.Ledger.Properties.PoV
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs) (open AbstractFunctions abs)
+  where
+
+open import Data.Nat.Properties
+  using (+-comm; +-assoc; +-0-monoid; +-identityʳ; +-cancelʳ-≡)
+open import Data.Integer using (ℤ; 0ℤ; _-_; _⊖_)
+open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n) renaming (+-comm to +ℤ-comm)
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
+
+open import Ledger.Prelude
+
+open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Entities txs
+open import Ledger.Dijkstra.Specification.Gov govStructure
+open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
+open import Ledger.Dijkstra.Specification.Ledger txs abs
+open import Ledger.Dijkstra.Specification.Utxo txs abs
+open import Ledger.Dijkstra.Specification.Utxow txs abs
+
+open import Ledger.Dijkstra.Specification.Entities.Properties.PoV txs
+
+-- We will import the following once the UTXO/UTXOW PoV proofs land:
+-- open import Ledger.Dijkstra.Specification.Utxo.Properties.PoV txs abs
+-- open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
+
+open import Interface.STS
+
+open RewardAddress
+open ≡-Reasoning
+
+instance
+  _ = +-0-monoid
+```
+-->
+
+## The `LEDGER-PoV` module
+
+`LEDGER-pov`{.AgdaFunction} currently depends on module parameters from the following
+groups:
+
++  the three set/map identities from `ApplyToRewards-PoV`{.AgdaModule}
+   (`∪ˡ-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique`);
++  the UTxO arithmetic / freshness assumptions and batch-wide invariants
+   (`balance-∪`, `split-balance`, `noMintTx`, `noMintSubTx`, `outs-disjoint`,
+   `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`,
+   `utxow-pov-invalid`, `UTXOW-V-mechanical`, `UTXOW-batch-balance-coin`);
++  the Certs facts (`CERTS-pov`, `batch-cert-deposits-bridge`);
++  the governance-deposit facts (`rmOrphanDRepVotes-coinFromGovDeposit`,
+   `GOVS-coinFromGovDeposit`) from a future `Gov.Properties.PoV`;
++  the no-truncation withdrawal bounds (`ENTITIES-wdrls-bounded`,
+   `SUBENTITIES-wdrls-bounded`), the phantom-withdrawal gap,[^1]
+   to be discharged by a spec-side premise or a batch-threading invariant.
+
+All are stated with detailed provenance notes in comments and are to be discharged in
+follow-up work.  This parameter list is the frozen interface between this proof and
+the follow-ups.
+
+```agda
+noMintingSubTxs : TopLevelTx → Type
+noMintingSubTxs tx = ∀ stx → stx ∈ˡ SubTransactionsOf tx → coin (MintedValueOf stx) ≡ 0
+
+-- The right injections of a list of sums, used (at `GovVote ⊎ GovProposal`) to
+-- extract the proposals from a mixed `GOVS` input list for the
+-- `GOVS-coinFromGovDeposit` gov-deposit accounting parameter below, stated
+-- generically to avoid the doubly-imported `GovVote`/`GovProposal` names.
+proposalsOf : ∀ {A B : Type} → List (A ⊎ B) → List B
+proposalsOf []            = []
+proposalsOf (inj₁ _ ∷ xs) = proposalsOf xs
+proposalsOf (inj₂ p ∷ xs) = p ∷ proposalsOf xs
+
+
+module LEDGER-PoV
+  (tx : TopLevelTx) (let open Tx tx; open TxBody txBody)
+
+  -- ApplyToRewards-PoV parameters
+  ( ∪ˡ-lookup-preserve :
+      (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
+
+  ( sum-map-proj₂≡getCoin :
+      (m : RewardAddress ⇀ Coin)
+      → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  ( setToList-Unique :
+      (m : RewardAddress ⇀ Coin)
+      → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
+  -- UTXOW-PoV parameters
+  ( balance-∪ : ∀ {u u' : UTxO} → disjoint (dom u) (dom u')
+              → cbalance (u ∪ˡ u') ≡ cbalance u + cbalance u' )
+  ( split-balance : ∀ (u : UTxO) (keys : ℙ TxIn)
+                  → cbalance u ≡ cbalance (u ∣ keys ᶜ) + cbalance (u ∣ keys) )
+  ( noMintTx : coin (MintedValueOf tx) ≡ 0 )
+  ( noMintSubTx : noMintingSubTxs tx )
+  ( outs-disjoint : ∀ {u : UTxO}
+                  → TxIdOf tx ∉ mapˢ proj₁ (dom u)
+                  → disjoint (dom (u ∣ SpendInputsOf tx ᶜ)) (dom (outs tx)) )
+
+  -- Per-step SUBUTXOW coin equation.  A local proof would require, in addition to
+  -- `balance-∪` and `split-balance`, a batch-wide "spend inputs preserved" invariant
+  -- (the running UTxO agrees with the snapshot on every sub-tx's spend inputs) and
+  -- freshness of each sub-tx's TxId relative to the running UTxO.
+  ( subutxow-step-coin : ∀ {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
+      → IsTopLevelValidFlagOf Γ ≡ true
+      → Γ ⊢ s₀ ⇀⦇ stx ,SUBUTXOW⦈ s₁
+      → getCoin s₀ + cbalance (outs stx) + DonationsOf stx
+        ≡ getCoin s₁ + cbalance (UTxOOf Γ ∣ SpendInputsOf stx) )
+
+  -- Batch-wide invariants on the post-SUBLEDGERS UTxO state.  Both follow from
+  -- batch-wide input disjointness and TxId freshness, which the outer UTXO rule
+  -- establishes at the batch level but doesn't expose per-step.
+  ( utxo₁-tx-spend-eq : {subΓ : SubLedgerEnv} {s : LedgerState}
+        {utxoSt₁ : UTxOState} {govSt₁ : GovState} {certState₁ : CertState}
+      → SubLedgerEnv.isTopLevelValid subΓ ≡ true
+      → SubLedgerEnv.utxo₀ subΓ ≡ UTxOOf (UTxOStateOf s)
+      → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
+      → cbalance (UTxOOf utxoSt₁ ∣ SpendInputsOf tx)
+        ≡ cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx) )
+  ( fresh-top-tx-id : {subΓ : SubLedgerEnv} {s : LedgerState}
+        {utxoSt₁ : UTxOState} {govSt₁ : GovState} {certState₁ : CertState}
+      → SubLedgerEnv.isTopLevelValid subΓ ≡ true
+      → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
+      → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
+
+  -- Certs-PoV stubs (discharged later by follow-up PR #1210).  These were the
+  -- `Certs.Properties.PoV` provider lemmas; under the top-down plan they are module
+  -- parameters here.
+  ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
+  -- Batch-wide cert-deposit bridge (discharged later by #1210).  The closed-form
+  -- deposit accounting over *all* batch certs (`allDCerts tx`, with `newCertDeposits`
+  -- threading the pre-batch registered-pool set) balances against the actual
+  -- `coinFromDeposits` evolution from the pre-batch cert state `CertStateOf ls₀` to
+  -- the post-`ENTITIES` cert state `cs₂`, in ℕ form:
+  --
+  --     D₀ + newCertDeposits ≡ D₂ + refundCertDeposits
+  --
+  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over the
+  -- sub-txs, then the top-level `ENTITIES`); composing the per-step cert bridges
+  -- across the batch is #1210's responsibility, so the `LEDGER-pov` consumer takes
+  -- the combined equation as given.
+  ( batch-cert-deposits-bridge :
+      ∀ {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
+      → SubLedgerEnv.isTopLevelValid Γsub ≡ true
+      → Γsub ⊢ ls₀ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ls₁
+      → Γe ⊢ CertStateOf ls₁ ⇀⦇ tx ,ENTITIES⦈ cs₂
+      → coinFromDeposits (CertStateOf ls₀)
+          + newCertDeposits (PParamsOf Γe) (dom (PoolsOf (CertStateOf ls₀))) (allDCerts tx)
+        ≡ coinFromDeposits cs₂
+          + refundCertDeposits (PParamsOf Γe) (allDCerts tx) )
+
+  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see the #1256
+  -- review).  `applyWithdrawals` subtracts with `_∸_`, so the ENTITIES/SUBENTITIES
+  -- value-flow equations need each withdrawal amount bounded by the account's balance
+  -- in the *input* state of the step that consumes it.  The spec's premises bound
+  -- withdrawals only against the pre-batch `rewards₀` (except top-level legacy mode),
+  -- so these facts are assumed here, to be discharged by a spec-side premise or a
+  -- batch-threading invariant in the follow-up to that discussion.
+  ( ENTITIES-wdrls-bounded : ∀ {Γe : EntitiesEnv} {cs cs' : CertState}
+      → Γe ⊢ cs ⇀⦇ tx ,ENTITIES⦈ cs'
+      → ∀[ (addr , amt) ∈ (WithdrawalsOf tx) ˢ ]
+          amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
+  ( SUBENTITIES-wdrls-bounded : ∀ {Γe : SubEntitiesEnv} {cs cs' : CertState} {stx : SubLevelTx}
+      → Γe ⊢ cs ⇀⦇ stx ,SUBENTITIES⦈ cs'
+      → ∀[ (addr , amt) ∈ (WithdrawalsOf stx) ˢ ]
+          amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
+
+  -- Governance-deposit accounting (to be discharged by a future `Gov.Properties.PoV`).
+  -- `rmOrphanDRepVotes` only rewrites `votes.gvDRep`, never `GovActionState.deposit`,
+  -- so it leaves `coinFromGovDeposit` unchanged.
+  ( rmOrphanDRepVotes-coinFromGovDeposit :
+      ∀ (cs : CertState) (g : GovState)
+      → coinFromGovDeposit (rmOrphanDRepVotes cs g) ≡ coinFromGovDeposit g )
+  -- Per-`GOVS`-step gov-deposit growth equals the `govProposalsDeposits` of the step's
+  -- proposals (`GOV-Propose` stores `deposit = pp .govActionDeposit`; no `GOV-Vote` or
+  -- in-`LEDGER` removal changes a deposit).  Used by `SUBLEDGERS-gov-coin` (the sub-tx
+  -- GOVS steps) and `gov-acc` (the top-level GOVS step).
+  ( GOVS-coinFromGovDeposit :
+      ∀ {Γ : GovEnv} {govSt govSt′ : GovState} {props}
+      → Γ ⊢ govSt ⇀⦇ props ,GOVS⦈ govSt′
+      → coinFromGovDeposit govSt′
+        ≡ coinFromGovDeposit govSt + govProposalsDeposits (PParamsOf Γ) (proposalsOf props) )
+
+  -- Utxo/Utxow-PoV facts (discharged later by #1186; module-parameter stubs).
+  -- Invalid top-level tx: the UTXOW step preserves UTxO coin.
+  ( utxow-pov-invalid : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
+      → IsValidFlagOf tx ≡ false
+      → getCoin s₀ ≡ getCoin s₁ )
+  -- Valid top-level tx, mechanical single-tx coin equation (spend inputs resolved
+  -- against the running UTxO; TxId freshness lets `outs tx` split off cleanly).
+  ( UTXOW-V-mechanical : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
+      → IsValidFlagOf tx ≡ true
+      → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf s₀))
+      → getCoin s₀ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+        ≡ getCoin s₁ + cbalance (UTxOOf s₀ ∣ SpendInputsOf tx) )
+  -- Closed-form coin projection of the batch balance `consumedBatch ≡ producedBatch`
+  -- (#1186 discharges this from the spec premise; the minted terms drop by
+  -- `noMintTx`/`noMintSubTx`).  The cert-deposit summands are in the spec's *closed
+  -- form* — `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with the
+  -- pool set drawn from the environment's pre-batch `pools₀` — keeping this a pure
+  -- UTxO obligation (no post-batch cert states).  `bat'` converts it to the chain's
+  -- top/sub two-level `posPart`/`negPart` form via `batch-cert-deposits-bridge`
+  -- (#1210) together with `posNeg-deposits`.  The governance-deposit summands
+  -- (`govProposalsDeposits`, top and per-sub) sit on the produced side, matching
+  -- `producedTx`.
+  ( UTXOW-batch-balance-coin : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
+      → cbalance (UTxOOf Γ' ∣ SpendInputsOf tx) + getCoin (WithdrawalsOf tx)
+          + sum (map (λ stx → cbalance (UTxOOf Γ' ∣ SpendInputsOf stx) + getCoin (WithdrawalsOf stx))
+                     (SubTransactionsOf tx))
+          + refundCertDeposits (PParamsOf Γ') (allDCerts tx)
+        ≡ cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + getCoin (DirectDepositsOf tx)
+          + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx + getCoin (DirectDepositsOf stx))
+                     (SubTransactionsOf tx))
+          + newCertDeposits (PParamsOf Γ') (dom (PoolsOf Γ')) (allDCerts tx)
+          + ( govProposalsDeposits (PParamsOf Γ') (ListOfGovProposalsOf tx)
+            + sum (map (λ stx → govProposalsDeposits (PParamsOf Γ') (ListOfGovProposalsOf stx))
+                       (SubTransactionsOf tx)) ) )
+  where
+
+  open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique CERTS-pov
+  -- open UTXOW-PoV tx (λ {u} {u'} → balance-∪ {u} {u'}) split-balance noMintTx noMintSubTx
+  --   (λ {u} → outs-disjoint {u})
+```
+
+The `λ {u}{u'} → balance-∪ {u}{u'}` and `λ {u} → outs-disjoint {u}` η-wrappers are
+needed because passing the assumptions directly triggers Agda to eta-expand the `{u
+u' : UTxO}` implicits through `UTxO`'s `Σ _ left-unique` record structure, leaving
+the `left-unique` field as an unresolved meta.
+
+## Small arithmetic helpers
+
+```agda
+  swap-right : ∀ a b c → a + b + c ≡ a + c + b
+  swap-right a b c = trans (+-assoc a b c)
+                           (trans (cong (a +_) (+-comm b c)) (sym (+-assoc a c b)))
+
+  -- Per-sub-tx withdrawal and direct-deposit totals.
+  wdrwl : SubLevelTx → Coin
+  wdrwl = getCoin ∘ WithdrawalsOf
+
+  ddwl : SubLevelTx → Coin
+  ddwl = getCoin ∘ DirectDepositsOf
+```
+
+## Deposit-change interface
+
+The cert-deposit change is the integer delta of `coinFromDeposits`{.AgdaFunction} at
+the top and sub levels.  The `LEDGER-V` chain tracks the deposit pots in this
+two-level `posPart`/`negPart` form; `bat'` obtains it from the closed-form
+`UTXOW-batch-balance-coin`{.AgdaFunction} parameter via the
+`batch-cert-deposits-bridge`{.AgdaFunction} and `posNeg-deposits`{.AgdaFunction}.
+
+```agda
+  DepositsChange : Type
+  DepositsChange = ℤ × ℤ            -- (top-level Δ , sub-level Δ)
+
+  DepositsChangeTopOf : DepositsChange → ℤ
+  DepositsChangeTopOf = proj₁
+
+  DepositsChangeSubOf : DepositsChange → ℤ
+  DepositsChangeSubOf = proj₂
+
+  calculateDepositsChange : CertState → CertState → CertState → DepositsChange
+  calculateDepositsChange cs₀ cs₁ cs₂ =
+      (coinFromDeposits cs₂ ⊖ coinFromDeposits cs₁)
+    , (coinFromDeposits cs₁ ⊖ coinFromDeposits cs₀)
+
+  -- ℕ-level posPart/negPart cancellation: `b + posPart (a ⊖ b)` and
+  -- `a + negPart (a ⊖ b)` both equal `a ⊔ b`.
+  posPart-negPart-sym : ∀ (a b : ℕ) → b + posPart (a ⊖ b) ≡ a + negPart (a ⊖ b)
+  posPart-negPart-sym a       zero    = sym (+-identityʳ a)
+  posPart-negPart-sym zero    (suc b) = +-identityʳ (suc b)
+  posPart-negPart-sym (suc a) (suc b) = begin
+      suc b + posPart (suc a ⊖ suc b)  ≡⟨ cong (λ z → suc b + posPart z) ([1+m]⊖[1+n]≡m⊖n a b) ⟩
+      suc b + posPart (a ⊖ b)          ≡⟨ cong suc (posPart-negPart-sym a b) ⟩
+      suc a + negPart (a ⊖ b)          ≡˘⟨ cong (λ z → suc a + negPart z) ([1+m]⊖[1+n]≡m⊖n a b) ⟩
+      suc a + negPart (suc a ⊖ suc b)  ∎
+    where open ≡-Reasoning
+```
+
+## `posNeg-deposits`
+
+The deposit accounting identity used in the `LEDGER-V` chain.  Both sides express the
+same quantity (the sum of deposits across the batch), just rephrased to expose
+`posPart` vs `negPart` of the top-level and sub-level deposit changes.
+
+```agda
+  posNeg-deposits : (cs₀ cs₁ cs₂ : CertState)
+    → let dc = calculateDepositsChange cs₀ cs₁ cs₂ in
+      coinFromDeposits cs₀ + posPart (DepositsChangeTopOf dc) + posPart (DepositsChangeSubOf dc)
+      ≡ coinFromDeposits cs₂ + negPart (DepositsChangeTopOf dc) + negPart (DepositsChangeSubOf dc)
+  posNeg-deposits cs₀ cs₁ cs₂ = begin
+      coin₀ + pt + psp   ≡⟨ swap-right coin₀ pt psp ⟩
+      coin₀ + psp + pt   ≡⟨ cong (_+ pt) (posPart-negPart-sym coin₁ coin₀) ⟩
+      coin₁ + ns  + pt   ≡⟨ swap-right coin₁ ns pt ⟩
+      coin₁ + pt  + ns   ≡⟨ cong (_+ ns) (posPart-negPart-sym coin₂ coin₁) ⟩
+      coin₂ + nt  + ns   ∎
+    where
+    coin₀ = coinFromDeposits cs₀
+    coin₁ = coinFromDeposits cs₁
+    coin₂ = coinFromDeposits cs₂
+    psp = posPart (coin₁ ⊖ coin₀)   -- DepositsChangeSubOf dc
+    ns  = negPart (coin₁ ⊖ coin₀)
+    pt  = posPart (coin₂ ⊖ coin₁)   -- DepositsChangeTopOf dc
+    nt  = negPart (coin₂ ⊖ coin₁)
+```
+
+## `SUBLEDGERS-utxo-coin`
+
+Induct over the `SUBLEDGERS` reflexive-transitive closure, threading the
+per-`SUBUTXOW` coin equation:
+
+```agda
+  SUBLEDGERS-utxo-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → getCoin (UTxOStateOf s₀)
+      + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) stxs)
+      ≡  getCoin (UTxOStateOf s₁)
+         + sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) stxs)
+
+  -- Base case: empty list.  `Id-nop` unifies s₀ ≡ s₁ and both sums are 0.
+  SUBLEDGERS-utxo-coin _ (BS-base Id-nop) = refl
+
+  -- SUBLEDGER-I ruled out by isV : isTopLevelValid ≡ true.
+  SUBLEDGERS-utxo-coin isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  -- Inductive step: combine the per-step SUBUTXOW balance with the IH.
+  SUBLEDGERS-utxo-coin {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , _ , _)) rest) =
+    begin
+      U₀ + (p-stx + p-sum)    ≡⟨ sym (+-assoc U₀ p-stx p-sum) ⟩
+      U₀ + p-stx + p-sum      ≡⟨ cong (_+ p-sum) step-P-C ⟩
+      U₁ + c-stx + p-sum      ≡⟨ +-assoc U₁ c-stx p-sum ⟩
+      U₁ + (c-stx + p-sum)    ≡⟨ cong (U₁ +_) (+-comm c-stx p-sum) ⟩
+      U₁ + (p-sum + c-stx)    ≡⟨ sym (+-assoc U₁ p-sum c-stx) ⟩
+      U₁ + p-sum + c-stx      ≡⟨ cong (_+ c-stx) ih ⟩
+      Uₙ + c-sum + c-stx      ≡⟨ +-assoc Uₙ c-sum c-stx ⟩
+      Uₙ + (c-sum + c-stx)    ≡⟨ cong (Uₙ +_) (+-comm c-sum c-stx) ⟩
+      Uₙ + (c-stx + c-sum)    ∎
+    where
+    U₀ = getCoin (UTxOStateOf s₀)
+    U₁ = getCoin (UTxOStateOf s₁)
+    Uₙ = getCoin (UTxOStateOf sₙ)
+
+    p-stx = cbalance (outs stx) + DonationsOf stx
+    c-stx = cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)
+    p-sum = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) sigs)
+    c-sum = sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) sigs)
+
+    -- Single-step coin equation from the SUBUTXOW step assumption.
+    step-eq : U₀ + cbalance (outs stx) + DonationsOf stx ≡ U₁ + c-stx
+    step-eq = subutxow-step-coin isV' subutxowStep
+
+    step-P-C : U₀ + p-stx ≡ U₁ + c-stx
+    step-P-C = trans (sym (+-assoc U₀ (cbalance (outs stx)) (DonationsOf stx))) step-eq
+
+    ih : U₁ + p-sum ≡ Uₙ + c-sum
+    ih = SUBLEDGERS-utxo-coin isV rest
+```
+
+## `SUBLEDGERS-certs-pov`
+
+Parallel induction over `SUBLEDGERS`, composing per-sub-transaction `SUBENTITIES-pov`
+invocations.  The `NetworkId` witnesses and domain conditions are premises of the
+`SUBENTITIES` rule itself; only the no-truncation bound is external, supplied by the
+`SUBENTITIES-wdrls-bounded` module parameter.
+
+```agda
+  SUBLEDGERS-certs-pov :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    →  coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
+       ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
+
+  SUBLEDGERS-certs-pov _ (BS-base Id-nop) = refl
+
+  SUBLEDGERS-certs-pov isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-certs-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) =
+    begin
+      coinFromRewards (CertStateOf s₀) + (getCoin (DirectDepositsOf stx) + sum (map ddwl sigs))
+        ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s₀))
+                        (getCoin (DirectDepositsOf stx))
+                        (sum (map ddwl sigs))) ⟩
+      (coinFromRewards (CertStateOf s₀) + getCoin (DirectDepositsOf stx)) + sum (map ddwl sigs)
+        ≡⟨ cong (_+ sum (map ddwl sigs))
+                (SUBENTITIES-pov (SUBENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+      (coinFromRewards (CertStateOf s₁) + getCoin (WithdrawalsOf stx)) + sum (map ddwl sigs)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf s₁))
+                      (getCoin (WithdrawalsOf stx))
+                      (sum (map ddwl sigs)) ⟩
+      (coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)) + getCoin (WithdrawalsOf stx)
+        ≡⟨ cong (_+ getCoin (WithdrawalsOf stx)) ih ⟩
+      (coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)) + getCoin (WithdrawalsOf stx)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf sₙ))
+                      (sum (map wdrwl sigs))
+                      (getCoin (WithdrawalsOf stx)) ⟩
+      (coinFromRewards (CertStateOf sₙ) + getCoin (WithdrawalsOf stx)) + sum (map wdrwl sigs)
+        ≡⟨ +-assoc (coinFromRewards (CertStateOf sₙ))
+                   (getCoin (WithdrawalsOf stx))
+                   (sum (map wdrwl sigs)) ⟩
+      coinFromRewards (CertStateOf sₙ) + (getCoin (WithdrawalsOf stx) + sum (map wdrwl sigs))
+        ∎
+    where
+    ih : coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)
+         ≡ coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)
+    ih = SUBLEDGERS-certs-pov isV rest
+```
+
+## `SUBLEDGERS-gov-coin`
+
+Induct over `SUBLEDGERS`, threading the per-`GOVS` gov-deposit growth: each
+`SUBLEDGER-V` step grows `coinFromGovDeposit`{.AgdaFunction} by the
+`govProposalsDeposits`{.AgdaFunction} of the sub-transaction's proposals (via the
+`GOVS-coinFromGovDeposit`{.AgdaFunction} parameter applied to the step's `GOVS`
+premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
+
+```agda
+  -- `proposalsOf (GovProposals+Votes t)` recovers exactly the proposals of `t`.
+  proposalsOf-Proposals+Votes : ∀ {ℓ} (t : Tx ℓ)
+    → proposalsOf (GovProposals+Votes t) ≡ ListOfGovProposalsOf t
+  proposalsOf-Proposals+Votes t = go (ListOfGovProposalsOf t) (ListOfGovVotesOf t)
+    where
+    drop-votes : ∀ {A B : Type} (vs : List A)
+      → proposalsOf {A = A} {B = B} (map inj₁ vs) ≡ []
+    drop-votes []       = refl
+    drop-votes (_ ∷ vs) = drop-votes vs
+    go : ∀ {A B : Type} (ps : List B) (vs : List A)
+       → proposalsOf (map inj₂ ps ++ map inj₁ vs) ≡ ps
+    go []       vs = drop-votes vs
+    go (p ∷ ps) vs = cong (p ∷_) (go ps vs)
+
+  SUBLEDGERS-gov-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → coinFromGovDeposit (GovStateOf s₁)
+      ≡ coinFromGovDeposit (GovStateOf s₀)
+        + sum (map (λ stx → govProposalsDeposits (SubLedgerEnv.pparams Γ) (ListOfGovProposalsOf stx)) stxs)
+
+  SUBLEDGERS-gov-coin _ (BS-base Id-nop) = sym (+-identityʳ _)
+
+  SUBLEDGERS-gov-coin isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-gov-coin {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (_ , _ , _ , govStep)) rest) =
+    begin
+      coinFromGovDeposit (GovStateOf sₙ)
+        ≡⟨ ih ⟩
+      coinFromGovDeposit (GovStateOf s₁) + g-sum
+        ≡⟨ cong (_+ g-sum) step-gov ⟩
+      coinFromGovDeposit (GovStateOf s₀) + g-stx + g-sum
+        ≡⟨ +-assoc (coinFromGovDeposit (GovStateOf s₀)) g-stx g-sum ⟩
+      coinFromGovDeposit (GovStateOf s₀) + (g-stx + g-sum)
+        ∎
+    where
+    pp = SubLedgerEnv.pparams Γ
+    g-stx = govProposalsDeposits pp (ListOfGovProposalsOf stx)
+    g-sum = sum (map (λ stx → govProposalsDeposits pp (ListOfGovProposalsOf stx)) sigs)
+
+    step-gov : coinFromGovDeposit (GovStateOf s₁) ≡ coinFromGovDeposit (GovStateOf s₀) + g-stx
+    step-gov = trans (GOVS-coinFromGovDeposit govStep)
+                     (cong (λ ps → coinFromGovDeposit (GovStateOf s₀) + govProposalsDeposits pp ps)
+                           (proposalsOf-Proposals+Votes stx))
+
+    ih : coinFromGovDeposit (GovStateOf sₙ) ≡ coinFromGovDeposit (GovStateOf s₁) + g-sum
+    ih = SUBLEDGERS-gov-coin isV rest
+```
+
+## `LEDGER-pov`
+
+```agda
+  LEDGER-pov : {Γ : LedgerEnv} {s s' : LedgerState}
+    → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
+```
+
+### `LEDGER-I` case (invalid transaction)
+
+`SUBLEDGERS` is a no-op when `IsValidFlagOf tx ≡ false`, so `certState` and `govSt`
+are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
+`utxow-pov-invalid`.
+
+```agda
+  LEDGER-pov {Γ} {s} (LEDGER-I (invalid , _ , utxoStep)) =
+    cong (λ u → u + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
+                  + coinFromGovDeposit (GovStateOf s))
+         (utxow-pov-invalid utxoStep invalid)
+```
+
+### `LEDGER-V` case (valid transaction)
+
+The proof is a single equational chain over `LedgerState` coin totals.  Setting
+`U = getCoin (UTxOState)`, `R = coinFromRewards`, `D = coinFromDeposits`,
+`G = coinFromGovDeposit`, and `allDirectDeps` / `allWdrls` for the top-level and
+sub-level totals of direct deposits and withdrawals respectively, the goal
+`getCoin s ≡ getCoin s'` is
+
+    U₀ + R₀ + D₀ + G₀  ≡  U₂ + R₂ + D₂ + G'
+
+where `G₀ = coinFromGovDeposit govState₀` and — since the final `LEDGER-V` `GovState`
+is `rmOrphanDRepVotes certState₂ govState₂` and `rmOrphanDRepVotes` preserves
+`coinFromGovDeposit` (parameter `rmOrphanDRepVotes-coinFromGovDeposit`) —
+`G' = coinFromGovDeposit govState₂`.
+
+The body assembles the four-summand goal from two `where`-lemmas: `three-summand`
+(`U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the UTxO/rewards/cert-deposit totals with the
+produced-side gov deposits surfacing as `totGov`) and `gov-acc` (`totGov+G₀ ≡ G'`,
+the gov-deposit accounting).
+
+```agda
+  LEDGER-pov {Γ} {s}
+    (LEDGER-V {utxoState₁ = us₁} {govState₁ = govSt₁} {certState₁ = cs₁}
+              {certState₂ = cs₂} {govState₂ = govSt₂} {utxoState₂ = us₂}
+              (valid , subStep , entitiesStep , govStep , utxoStep)) =
+    begin
+      U₀ + R₀ + D₀ + G₀
+        ≡⟨ cong (_+ G₀) three-summand ⟩
+      U₂ + R₂ + D₂ + totGov + G₀
+        ≡⟨ +-assoc (U₂ + R₂ + D₂) totGov G₀ ⟩
+      U₂ + R₂ + D₂ + (totGov + G₀)
+        ≡⟨ cong (U₂ + R₂ + D₂ +_) gov-acc ⟩
+      U₂ + R₂ + D₂ + G'
+        ∎
+    where
+```
+
+The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
+`arithmetic-N` helpers, and `mid-extract`/`rearr3`/`outer-rearr` (for the gov summand)
+— all pure `+`-monoid rearrangements.  Commutative steps go through `swap-right`, so
+`solve-macro` (a *non-normalising* monoid solver) cannot discharge them directly; they
+are stated explicitly to keep the chain readable.
+
+```agda
+      abcd-to-acdb : ∀ a b c d → a + b + c + d ≡ a + c + d + b
+      abcd-to-acdb a b c d = begin
+        a + b + c + d     ≡⟨ cong (_+ d) (+-assoc a b c) ⟩
+        a + (b + c) + d   ≡⟨ cong (λ x → a + x + d) (+-comm b c) ⟩
+        a + (c + b) + d   ≡⟨ cong (_+ d) (sym (+-assoc a c b)) ⟩
+        a + c + b + d     ≡⟨ +-assoc (a + c) b d ⟩
+        a + c + (b + d)   ≡⟨ cong ((a + c) +_) (+-comm b d) ⟩
+        a + c + (d + b)   ≡⟨ sym (+-assoc (a + c) d b) ⟩
+        a + c + d + b     ∎
+
+      U₀ U₁ U₂ : Coin
+      U₀ = getCoin (UTxOStateOf s)
+      U₁ = getCoin us₁
+      U₂ = getCoin us₂
+
+      D₀ D₂ : Coin
+      D₀ = coinFromDeposits (CertStateOf s)
+      D₂ = coinFromDeposits cs₂
+
+      R₀ R₂ : Coin
+      R₀ = coinFromRewards (CertStateOf s)
+      R₂ = coinFromRewards cs₂
+
+      -- Governance-deposit summands of the LedgerState totals.  G₀ is the initial
+      -- GovState's deposit; G' is the final state's (`rmOrphanDRepVotes cs₂ govSt₂`),
+      -- which `rmOrphanDRepVotes-coinFromGovDeposit` collapses to `coinFromGovDeposit
+      -- govSt₂`.  (Used by the `gov-acc` lemma.)
+      G₀ G' : Coin
+      G₀ = coinFromGovDeposit (GovStateOf s)
+      G' = coinFromGovDeposit (rmOrphanDRepVotes cs₂ govSt₂)
+
+      subDirectDepsCoin : Coin
+      subDirectDepsCoin = sum (map ddwl (SubTransactionsOf tx))
+
+      allDirectDeps : Coin
+      allDirectDeps = getCoin (DirectDepositsOf tx) + subDirectDepsCoin
+
+      subWdrlsCoin : Coin
+      subWdrlsCoin = sum (map wdrwl (SubTransactionsOf tx))
+
+      allWdrls : Coin
+      allWdrls = getCoin (WithdrawalsOf tx) + subWdrlsCoin
+
+      -- Total governance-action deposits introduced by the batch (top + per-sub),
+      -- matching the `govProposalsDeposits` summands on the produced side of the
+      -- batch balance and the gov-deposit growth `G' − G₀`.
+      topGov subGovSum totGov : Coin
+      topGov    = govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf tx)
+      subGovSum = sum (map (λ stx → govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf stx))
+                           (SubTransactionsOf tx))
+      totGov    = topGov + subGovSum
+
+      -- Pure +-monoid rearrangements for threading the gov summand.
+      mid-extract : ∀ a b c d → a + (b + d) + c ≡ a + b + c + d
+      mid-extract a b c d = trans (cong (_+ c) (sym (+-assoc a b d)))
+                                  (swap-right (a + b) d c)
+
+      rearr3 : ∀ a b c → a + b + c ≡ c + b + a
+      rearr3 a b c = begin
+        a + b + c   ≡⟨ swap-right a b c ⟩
+        a + c + b   ≡⟨ cong (_+ b) (+-comm a c) ⟩
+        c + a + b   ≡⟨ swap-right c a b ⟩
+        c + b + a   ∎
+
+      outer-rearr : ∀ u a d g r → u + a + d + g + r ≡ u + r + d + g + a
+      outer-rearr u a d g r = begin
+        u + a + d + g + r   ≡⟨ swap-right (u + a + d) g r ⟩
+        u + a + d + r + g   ≡⟨ cong (_+ g) (swap-right (u + a) d r) ⟩
+        u + a + r + d + g   ≡⟨ cong (λ x → x + d + g) (swap-right u a r) ⟩
+        u + r + a + d + g   ≡⟨ cong (_+ g) (swap-right (u + r) a d) ⟩
+        u + r + d + a + g   ≡⟨ swap-right (u + r + d) a g ⟩
+        u + r + d + g + a   ∎
+```
+
+The "combined" `ENTITIES-pov` invocation: pre-batch `certState` + all direct deposits
+(top + sub) ≡ post-`ENTITIES` `certState` + all withdrawals (top + sub).  This is the
+key step where direct deposits cancel between the UTxO and CertState sides of the
+ledger.  (The `NetworkId` and domain conditions are premises of the `ENTITIES` rule
+itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
+
+```agda
+      combined-certs : coinFromRewards (CertStateOf s) + allDirectDeps
+                     ≡ coinFromRewards cs₂ + allWdrls
+      combined-certs =
+        begin
+          coinFromRewards (CertStateOf s) + allDirectDeps
+            ≡⟨ cong (coinFromRewards (CertStateOf s) +_)
+                    (+-comm (getCoin (DirectDepositsOf tx)) subDirectDepsCoin) ⟩
+          coinFromRewards (CertStateOf s) + (subDirectDepsCoin + getCoin (DirectDepositsOf tx))
+            ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s))
+                            subDirectDepsCoin
+                            (getCoin (DirectDepositsOf tx))) ⟩
+          coinFromRewards (CertStateOf s) + subDirectDepsCoin + getCoin (DirectDepositsOf tx)
+            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx))
+                    (SUBLEDGERS-certs-pov valid subStep) ⟩
+          coinFromRewards cs₁ + subWdrlsCoin + getCoin (DirectDepositsOf tx)
+            ≡⟨ swap-right (coinFromRewards cs₁) subWdrlsCoin (getCoin (DirectDepositsOf tx)) ⟩
+          coinFromRewards cs₁ + getCoin (DirectDepositsOf tx) + subWdrlsCoin
+            ≡⟨ cong (_+ subWdrlsCoin)
+                    (ENTITIES-pov (ENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+          coinFromRewards cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin
+            ≡⟨ +-assoc (coinFromRewards cs₂) (getCoin (WithdrawalsOf tx)) subWdrlsCoin ⟩
+          coinFromRewards cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)
+            ∎
+```
+
+`step-i`: introduce `allDirectDeps`, then rewrite using `combined-certs`.
+
+```agda
+      step-i : (U₀ + R₀ + D₀) + allDirectDeps ≡ U₀ + R₂ + allWdrls + D₀
+      step-i =
+        begin
+          U₀ + R₀ + D₀ + allDirectDeps    ≡⟨ swap-right (U₀ + R₀) D₀ allDirectDeps ⟩
+          U₀ + R₀ + allDirectDeps + D₀    ≡⟨ cong (_+ D₀) (+-assoc U₀ R₀ allDirectDeps) ⟩
+          U₀ + (R₀ + allDirectDeps) + D₀  ≡⟨ cong (λ x → U₀ + x + D₀) combined-certs ⟩
+          U₀ + (R₂ + allWdrls) + D₀       ≡⟨ cong (_+ D₀) (sym (+-assoc U₀ R₂ allWdrls)) ⟩
+          U₀ + R₂ + allWdrls + D₀         ∎
+
+      dc : DepositsChange
+      dc = calculateDepositsChange (CertStateOf s) cs₁ cs₂
+
+      dct dcs : ℤ
+      dct = DepositsChangeTopOf dc
+      dcs = DepositsChangeSubOf dc
+
+      posneg : D₀ + posPart dct + posPart dcs ≡ D₂ + negPart dct + negPart dcs
+      posneg = posNeg-deposits (CertStateOf s) cs₁ cs₂
+```
+
+`UTXOW-V-mechanical` composed with the batch-wide "spend inputs preserved" invariant:
+
+```agda
+      mech : U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+           ≡ U₂ + cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx)
+      mech = trans (UTXOW-V-mechanical utxoStep valid (fresh-top-tx-id valid subStep))
+                   (cong (U₂ +_) (utxo₁-tx-spend-eq valid refl subStep))
+
+      Ctop Csub : Coin
+      Ctop = cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx)
+      Csub = sum (map (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx))
+                      (SubTransactionsOf tx))
+
+      Psub PsubDD : Coin
+      Psub = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx)
+                      (SubTransactionsOf tx))
+      PsubDD = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx + getCoin (DirectDepositsOf stx))
+                        (SubTransactionsOf tx))
+
+      -- The additive constant on both sides of the inner chain.
+      E : Coin
+      E = Ctop + Psub + posPart dct + posPart dcs
+```
+
+The batch balance, rephrased to expose direct deposits and bring withdrawals together:
+
+```agda
+      bat' : Ctop + allWdrls + Csub + negPart dct + negPart dcs
+           ≡ cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+             + allDirectDeps + Psub + posPart dct + posPart dcs + totGov
+      bat' =
+        begin
+          Ctop + allWdrls + Csub + negPart dct + negPart dcs
+            ≡⟨⟩
+          Ctop + (Wtop + subWdrlsCoin) + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + Csub + negPart dct + negPart dcs)
+                    (sym (+-assoc Ctop Wtop subWdrlsCoin)) ⟩
+          Ctop + Wtop + subWdrlsCoin + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
+                    (swap-right (Ctop + Wtop) subWdrlsCoin Csub) ⟩
+          Ctop + Wtop + Csub + subWdrlsCoin + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
+                    (+-assoc (Ctop + Wtop) Csub subWdrlsCoin) ⟩
+          Ctop + Wtop + (Csub + subWdrlsCoin) + negPart dct + negPart dcs
+            ≡˘⟨ cong (λ x → Ctop + Wtop + x + negPart dct + negPart dcs)
+                     (sum-map-+ (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx))
+                                wdrwl (SubTransactionsOf tx)) ⟩
+          Ctop + Wtop + CsubW + negPart dct + negPart dcs
+            ≡⟨ convert ⟩
+          O + F + DN + DDtop + posPart dct + PsubDD + posPart dcs + totGov
+            ≡⟨ cong (λ x → O + F + DN + DDtop + posPart dct + x + posPart dcs + totGov)
+                    (sum-map-+ (λ stx → cbalance (outs stx) + DonationsOf stx)
+                               (λ stx → getCoin (DirectDepositsOf stx))
+                               (SubTransactionsOf tx)) ⟩
+          O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs + totGov
+            ≡⟨ cong (_+ totGov) reshuffle-to-DD ⟩
+          O + F + DN + allDirectDeps + Psub + posPart dct + posPart dcs + totGov
+            ∎
+        where
+        O     = cbalance (outs tx)
+        F     = TxFeesOf tx
+        DN    = DonationsOf tx
+        DDtop = getCoin (DirectDepositsOf tx)
+        Wtop  = getCoin (WithdrawalsOf tx)
+        CsubW = sum (map (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx)
+                                + getCoin (WithdrawalsOf stx))
+                         (SubTransactionsOf tx))
+
+        pp = LedgerEnv.pparams Γ
+
+        -- Abstract net-conversion: reconcile the closed-form balance (`bal`, with
+        -- cert deposits as `PZ`/`NZ`) with the chain's two-level form, using the
+        -- batch bridge (`sf`) and the two-level deposit identity (`pn`).  Cancels
+        -- the constant `D0 + PZ` on the right.
+        net-arith : ∀ (A B G PZ NZ Pt Ps Nt Ns D0 D2 : ℕ)
+          → A + NZ ≡ B + PZ + G
+          → D0 + PZ ≡ D2 + NZ
+          → D0 + Pt + Ps ≡ D2 + Nt + Ns
+          → A + Nt + Ns ≡ B + Pt + Ps + G
+        net-arith A B G PZ NZ Pt Ps Nt Ns D0 D2 bal sf pn =
+          +-cancelʳ-≡ (D0 + PZ) (A + Nt + Ns) (B + Pt + Ps + G) big
+          where
+          rearr-X : (A + Nt + Ns) + (D2 + NZ) ≡ (A + NZ) + (Nt + Ns + D2)
+          rearr-X = begin
+            (A + Nt + Ns) + (D2 + NZ)   ≡˘⟨ +-assoc (A + Nt + Ns) D2 NZ ⟩
+            A + Nt + Ns + D2 + NZ        ≡⟨ swap-right (A + Nt + Ns) D2 NZ ⟩
+            A + Nt + Ns + NZ + D2        ≡⟨ cong (_+ D2) (swap-right (A + Nt) Ns NZ) ⟩
+            A + Nt + NZ + Ns + D2        ≡⟨ cong (λ w → w + Ns + D2) (swap-right A Nt NZ) ⟩
+            A + NZ + Nt + Ns + D2        ≡⟨ +-assoc (A + NZ + Nt) Ns D2 ⟩
+            A + NZ + Nt + (Ns + D2)      ≡⟨ +-assoc (A + NZ) Nt (Ns + D2) ⟩
+            A + NZ + (Nt + (Ns + D2))    ≡⟨ cong (A + NZ +_) (sym (+-assoc Nt Ns D2)) ⟩
+            (A + NZ) + (Nt + Ns + D2)    ∎
+          rearr-Y : Nt + Ns + D2 ≡ D2 + Nt + Ns
+          rearr-Y = trans (+-comm (Nt + Ns) D2) (sym (+-assoc D2 Nt Ns))
+          rearr-Z : (B + PZ + G) + (D0 + Pt + Ps) ≡ (B + Pt + Ps + G) + (D0 + PZ)
+          rearr-Z = begin
+            (B + PZ + G) + (D0 + Pt + Ps)   ≡˘⟨ +-assoc (B + PZ + G) (D0 + Pt) Ps ⟩
+            (B + PZ + G) + (D0 + Pt) + Ps    ≡˘⟨ cong (_+ Ps) (+-assoc (B + PZ + G) D0 Pt) ⟩
+            (B + PZ + G) + D0 + Pt + Ps      ≡⟨ cong (λ w → w + D0 + Pt + Ps) (swap-right B PZ G) ⟩
+            B + G + PZ + D0 + Pt + Ps        ≡⟨ cong (λ w → w + Pt + Ps) (swap-right (B + G) PZ D0) ⟩
+            B + G + D0 + PZ + Pt + Ps        ≡⟨ cong (_+ Ps) (swap-right (B + G + D0) PZ Pt) ⟩
+            B + G + D0 + Pt + PZ + Ps        ≡⟨ swap-right (B + G + D0 + Pt) PZ Ps ⟩
+            B + G + D0 + Pt + Ps + PZ        ≡⟨ cong (λ w → w + Ps + PZ) (swap-right (B + G) D0 Pt) ⟩
+            B + G + Pt + D0 + Ps + PZ        ≡⟨ cong (λ w → w + PZ) (swap-right (B + G + Pt) D0 Ps) ⟩
+            B + G + Pt + Ps + D0 + PZ        ≡⟨ cong (λ w → w + Ps + D0 + PZ) (swap-right B G Pt) ⟩
+            B + Pt + G + Ps + D0 + PZ        ≡⟨ cong (λ w → w + D0 + PZ) (swap-right (B + Pt) G Ps) ⟩
+            B + Pt + Ps + G + D0 + PZ        ≡⟨ +-assoc (B + Pt + Ps + G) D0 PZ ⟩
+            (B + Pt + Ps + G) + (D0 + PZ)    ∎
+          big : (A + Nt + Ns) + (D0 + PZ) ≡ (B + Pt + Ps + G) + (D0 + PZ)
+          big = begin
+            (A + Nt + Ns) + (D0 + PZ)     ≡⟨ cong (A + Nt + Ns +_) sf ⟩
+            (A + Nt + Ns) + (D2 + NZ)     ≡⟨ rearr-X ⟩
+            (A + NZ) + (Nt + Ns + D2)     ≡⟨ cong (_+ (Nt + Ns + D2)) bal ⟩
+            (B + PZ + G) + (Nt + Ns + D2) ≡⟨ cong ((B + PZ + G) +_) rearr-Y ⟩
+            (B + PZ + G) + (D2 + Nt + Ns) ≡˘⟨ cong ((B + PZ + G) +_) pn ⟩
+            (B + PZ + G) + (D0 + Pt + Ps) ≡⟨ rearr-Z ⟩
+            (B + Pt + Ps + G) + (D0 + PZ) ∎
+
+        -- The #1186 closed-form batch balance (cert deposits in the spec's closed
+        -- form, over `allDCerts tx` against the pre-batch registered-pool set).
+        closedEq : Ctop + Wtop + CsubW + refundCertDeposits pp (allDCerts tx)
+                 ≡ O + F + DN + DDtop + PsubDD
+                   + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx) + totGov
+        closedEq = UTXOW-batch-balance-coin utxoStep
+
+        -- The #1210 batch cert-deposit bridge, in ℕ form:
+        -- pre-batch deposits + new deposits ≡ post-batch deposits + refunds.
+        bridgeEq : D₀ + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx)
+                 ≡ D₂ + refundCertDeposits pp (allDCerts tx)
+        bridgeEq = batch-cert-deposits-bridge valid subStep entitiesStep
+
+        -- Convert the closed-form balance to the chain's two-level posPart/negPart
+        -- form, via `net-arith` fed the bridge (`bridgeEq`) and the two-level
+        -- deposit identity (`posneg`).
+        convert : Ctop + Wtop + CsubW + negPart dct + negPart dcs
+                ≡ O + F + DN + DDtop + posPart dct + PsubDD + posPart dcs + totGov
+        convert = begin
+          Ctop + Wtop + CsubW + negPart dct + negPart dcs
+            ≡⟨ net-arith (Ctop + Wtop + CsubW) (O + F + DN + DDtop + PsubDD) totGov
+                         (newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx))
+                         (refundCertDeposits pp (allDCerts tx))
+                         (posPart dct) (posPart dcs) (negPart dct) (negPart dcs) D₀ D₂
+                         closedEq bridgeEq posneg ⟩
+          O + F + DN + DDtop + PsubDD + posPart dct + posPart dcs + totGov
+            ≡⟨ cong (λ w → w + posPart dcs + totGov)
+                    (swap-right (O + F + DN + DDtop) PsubDD (posPart dct)) ⟩
+          O + F + DN + DDtop + posPart dct + PsubDD + posPart dcs + totGov
+            ∎
+
+        reshuffle-to-DD :
+            O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
+          ≡ O + F + DN + (DDtop + subDirectDepsCoin) + Psub + posPart dct + posPart dcs
+        reshuffle-to-DD = begin
+          O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
+            ≡⟨ cong (_+ posPart dcs) (sym (+-assoc (O + F + DN + DDtop + posPart dct) Psub subDirectDepsCoin)) ⟩
+          O + F + DN + DDtop + posPart dct + Psub + subDirectDepsCoin + posPart dcs
+            ≡⟨ cong (_+ posPart dcs) (swap-right (O + F + DN + DDtop + posPart dct) Psub subDirectDepsCoin) ⟩
+          O + F + DN + DDtop + posPart dct + subDirectDepsCoin + Psub + posPart dcs
+            ≡⟨ cong (λ x → x + Psub + posPart dcs) (swap-right (O + F + DN + DDtop) (posPart dct) subDirectDepsCoin) ⟩
+          O + F + DN + DDtop + subDirectDepsCoin + posPart dct + Psub + posPart dcs
+            ≡⟨ cong (_+ posPart dcs) (swap-right (O + F + DN + DDtop + subDirectDepsCoin) (posPart dct) Psub) ⟩
+          O + F + DN + DDtop + subDirectDepsCoin + Psub + posPart dct + posPart dcs
+            ≡⟨ cong (λ x → x + Psub + posPart dct + posPart dcs) (+-assoc (O + F + DN) DDtop subDirectDepsCoin) ⟩
+          O + F + DN + (DDtop + subDirectDepsCoin) + Psub + posPart dct + posPart dcs
+            ∎
+```
+
+The main inner chain, showing LHS + E ≡ RHS + E:
+
+```agda
+      LHS+E≡RHS+E : U₀ + allWdrls + D₀ + E ≡ U₂ + allDirectDeps + D₂ + totGov + E
+      LHS+E≡RHS+E = begin
+        U₀ + allWdrls + D₀ + E
+          ≡⟨⟩
+        U₀ + allWdrls + D₀ + (Ctop + Psub + posPart dct + posPart dcs)
+          ≡⟨ arithmetic-1 U₀ allWdrls D₀ ⟩
+        U₀ + allWdrls + D₀ + Ctop + Psub + posPart dct + posPart dcs
+          ≡⟨ arithmetic-2 U₀ allWdrls D₀ ⟩
+        U₀ + Psub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
+          ≡⟨ cong  (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
+                   (subst  (λ u → U₀ + Psub ≡ U₁ + sum (map  (λ stx → cbalance (u ∣ SpendInputsOf stx))
+                                                             (SubTransactionsOf tx)))
+                           (refl {x = UTxOOf (UTxOStateOf s)})
+                           (SUBLEDGERS-utxo-coin valid subStep)) ⟩
+        U₁ + Csub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
+          ≡⟨ cong (λ x → (U₁ + Csub) + allWdrls + x + Ctop) posneg ⟩
+        U₁ + Csub + allWdrls + (D₂ + negPart dct + negPart dcs) + Ctop
+          ≡⟨ arithmetic-3 U₁ Csub allWdrls ⟩
+        U₁ + (Ctop + allWdrls + Csub + negPart dct + negPart dcs) + D₂
+          ≡⟨ cong (λ x → U₁ + x + D₂) bat' ⟩
+        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps
+           + Psub + posPart dct + posPart dcs + totGov) + D₂
+          ≡⟨ mid-extract U₁ (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+             + allDirectDeps + Psub + posPart dct + posPart dcs) D₂ totGov ⟩
+        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps
+           + Psub + posPart dct + posPart dcs) + D₂ + totGov
+          ≡⟨ cong (_+ totGov) (arithmetic-4 U₁ (cbalance (outs tx)) (TxFeesOf tx)) ⟩
+        U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub
+           + posPart dct + posPart dcs + D₂ + totGov
+          ≡⟨ cong  ( _+ totGov )
+                   ( cong  (λ x → x + allDirectDeps + Psub + posPart dct + posPart dcs + D₂)
+                           mech ) ⟩
+        U₂ + Ctop + allDirectDeps + Psub + posPart dct + posPart dcs + D₂ + totGov
+          ≡⟨ cong (_+ totGov) (arithmetic-5 U₂ Ctop allDirectDeps) ⟩
+        U₂ + allDirectDeps + D₂ + Ctop + Psub + posPart dct + posPart dcs + totGov
+          ≡˘⟨ cong (_+ totGov) (arithmetic-1 U₂ allDirectDeps D₂) ⟩
+        U₂ + allDirectDeps + D₂ + E + totGov
+          ≡⟨ swap-right (U₂ + allDirectDeps + D₂) E totGov ⟩
+        U₂ + allDirectDeps + D₂ + totGov + E
+          ∎
+        where
+```
+
+The five `arithmetic-N` helpers are pure `+`-monoid rearrangements, each unfolded
+explicitly:
+
+```agda
+        arithmetic-1 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + (d + e + f + g) ≡ a + b + c + d + e + f + g
+        arithmetic-1 a b c {d}{e}{f}{g} = begin
+          a + b + c + (d + e + f + g)  ≡˘⟨ +-assoc (a + b + c) (d + e + f) g ⟩
+          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+          a + b + c + d + e + f + g    ∎
+
+        arithmetic-2 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + d + e + f + g ≡ a + e + b + (c + f + g) + d
+        arithmetic-2 a b c {d}{e}{f}{g} = begin
+          a + b + c + d + e + f + g    ≡⟨ cong (λ x → x + f + g) (swap-right (a + b + c) d e) ⟩
+          a + b + c + e + d + f + g    ≡⟨ cong (_+ g) (swap-right (a + b + c + e) d f) ⟩
+          a + b + c + e + f + d + g    ≡⟨ swap-right (a + b + c + e + f) d g ⟩
+          a + b + c + e + f + g + d    ≡⟨ cong (λ x → x + f + g + d) (swap-right (a + b) c e) ⟩
+          a + b + e + c + f + g + d    ≡⟨ cong (λ x → x + c + f + g + d) (swap-right a b e) ⟩
+          a + e + b + c + f + g + d    ≡⟨ cong (_+ d) reassoc-middle ⟩
+          a + e + b + (c + f + g) + d  ∎
+          where
+          reassoc-middle : a + e + b + c + f + g ≡ a + e + b + (c + f + g)
+          reassoc-middle = trans (+-assoc (a + e + b + c) f g)
+                                 (trans (+-assoc (a + e + b) c (f + g))
+                                        (cong (a + e + b +_) (sym (+-assoc c f g))))
+
+        arithmetic-3 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + (d + e + f) + g ≡ a + (g + c + b + e + f) + d
+        arithmetic-3 a b c {d}{e}{f}{g} = begin
+          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+          a + b + c + d + e + f + g    ≡⟨ swap-right (a + b + c + d + e) f g ⟩
+          a + b + c + d + e + g + f    ≡⟨ cong (_+ f) (swap-right (a + b + c + d) e g) ⟩
+          a + b + c + d + g + e + f    ≡⟨ cong (λ x → x + e + f) (swap-right (a + b + c) d g) ⟩
+          a + b + c + g + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + b) c g) ⟩
+          a + b + g + c + d + e + f    ≡⟨ cong (λ x → x + c + d + e + f) (swap-right a b g) ⟩
+          a + g + b + c + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + g) b c) ⟩
+          a + g + c + b + d + e + f    ≡⟨ cong (_+ f) (swap-right (a + g + c + b) d e) ⟩
+          a + g + c + b + e + d + f    ≡⟨ swap-right (a + g + c + b + e) d f ⟩
+          a + g + c + b + e + f + d    ≡⟨ cong (λ x → x + b + e + f + d) (+-assoc a g c) ⟩
+          a + (g + c) + b + e + f + d  ≡⟨ cong (λ x → x + e + f + d) (+-assoc a (g + c) b) ⟩
+          a + (g + c + b) + e + f + d  ≡⟨ cong (λ x → x + f + d) (+-assoc a (g + c + b) e) ⟩
+          a + (g + c + b + e) + f + d  ≡⟨ cong (_+ d) (+-assoc a (g + c + b + e) f) ⟩
+          a + (g + c + b + e + f) + d  ∎
+
+        arithmetic-4 : ∀ a b c {d}{e}{f}{g}{h}{i}
+          → a + (b + c + d + e + f + g + h) + i ≡ a + b + c + d + e + f + g + h + i
+        arithmetic-4 a b c {d}{e}{f}{g}{h}{i} = cong (_+ i) $
+          begin
+          a + (b + c + d + e + f + g + h)  ≡˘⟨ +-assoc a _ h ⟩
+          a + (b + c + d + e + f + g) + h  ≡˘⟨ cong (_+ h) (+-assoc a _ g) ⟩
+          a + (b + c + d + e + f) + g + h  ≡˘⟨ cong (λ x → x + g + h) (+-assoc a _ f) ⟩
+          a + (b + c + d + e) + f + g + h  ≡˘⟨ cong (λ x → x + f + g + h) (+-assoc a _ e) ⟩
+          a + (b + c + d) + e + f + g + h  ≡˘⟨ cong (λ x → x + e + f + g + h) (+-assoc a _ d) ⟩
+          a + (b + c) + d + e + f + g + h  ≡˘⟨ cong (λ x → x + d + e + f + g + h) (+-assoc a b c) ⟩
+          a + b + c + d + e + f + g + h    ∎
+
+        arithmetic-5 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + d + e + f + g ≡ a + c + g + b + d + e + f
+        arithmetic-5 a b c {d}{e}{f}{g} = begin
+          a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + d + e + f + g) (swap-right a b c) ⟩
+          a + c + b + d + e + f + g  ≡⟨ swap-right (a + c + b + d + e) f g ⟩
+          a + c + b + d + e + g + f  ≡⟨ cong (_+ f) (swap-right (a + c + b + d) e g) ⟩
+          a + c + b + d + g + e + f  ≡⟨ cong (λ x → x + e + f) (swap-right (a + c + b) d g) ⟩
+          a + c + b + g + d + e + f  ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + c) b g) ⟩
+          a + c + g + b + d + e + f  ∎
+```
+
+Finally, `step-ii`: extract the actual equation from `LHS+E≡RHS+E` by cancelling `E`
+on both sides:
+
+```agda
+      step-ii : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + totGov + R₂
+      step-ii = cong (_+ R₂)
+                     (+-cancelʳ-≡ E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂ + totGov)
+                                  LHS+E≡RHS+E)
+
+      -- The three LedgerState totals (UTxO + rewards + cert-deposits): the batch's
+      -- gov deposits surface as `+ totGov` on the produced side.
+      three-summand : U₀ + R₀ + D₀ ≡ U₂ + R₂ + D₂ + totGov
+      three-summand =
+        +-cancelʳ-≡ allDirectDeps (U₀ + R₀ + D₀) (U₂ + R₂ + D₂ + totGov)
+          (begin
+            U₀ + R₀ + D₀ + allDirectDeps           ≡⟨ step-i ⟩
+            U₀ + R₂ + allWdrls + D₀                ≡⟨ abcd-to-acdb U₀ R₂ allWdrls D₀ ⟩
+            U₀ + allWdrls + D₀ + R₂                ≡⟨ step-ii ⟩
+            U₂ + allDirectDeps + D₂ + totGov + R₂  ≡⟨ outer-rearr U₂ allDirectDeps D₂ totGov R₂ ⟩
+            U₂ + R₂ + D₂ + totGov + allDirectDeps  ∎)
+
+      -- Gov-deposit accounting: the batch's total gov deposits exactly account for
+      -- the growth from the initial gov state's deposit (G₀) to the final one (G').
+      gov-acc : totGov + G₀ ≡ G'
+      gov-acc =
+        begin
+          totGov + G₀                          ≡⟨ rearr3 topGov subGovSum G₀ ⟩
+          G₀ + subGovSum + topGov              ≡˘⟨ cong (_+ topGov) (SUBLEDGERS-gov-coin valid subStep) ⟩
+          coinFromGovDeposit govSt₁ + topGov   ≡˘⟨ govStep-eq ⟩
+          coinFromGovDeposit govSt₂            ≡˘⟨ rmOrphanDRepVotes-coinFromGovDeposit cs₂ govSt₂ ⟩
+          G'                                   ∎
+        where
+        govStep-eq : coinFromGovDeposit govSt₂ ≡ coinFromGovDeposit govSt₁ + topGov
+        govStep-eq = trans (GOVS-coinFromGovDeposit govStep)
+                           (cong (λ ps → coinFromGovDeposit govSt₁
+                                       + govProposalsDeposits (LedgerEnv.pparams Γ) ps)
+                                 (proposalsOf-Proposals+Votes tx))
+```
+
+[^1]: See the review of PR #1256.

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -39,7 +39,7 @@ gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (
 
 ??? note "**Status: complete**"
 
-    `LEDGER-pov`{.AgdaFunction}n typechecks end-to-end under `--safe` (no
+    `LEDGER-pov`{.AgdaFunction} typechecks end-to-end under `--safe` (no
     postulates or holes).  Following the top-down plan, this module proves only the
     top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
     as *module parameters*, discharged downstream:
@@ -71,9 +71,9 @@ gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (
        against the *pre-batch* snapshot `rewards₀` (except top-level legacy mode,
        which forces exact-balance withdrawals), which does not by itself bound them
        against the input state of a later step in the batch. This is the
-       phantom-withdrawal gap flagged in the review of PR #1256.
-       As such, these module parameters should be discharged in the follow-up to that
-       discussion, either by spec rule premises or by a batch-threading invariant.
+       phantom-withdrawal gap.[^1] As such, these module parameters should be
+       discharged in the follow-up to that discussion, either by spec rule premises
+       or by a batch-threading invariant.
 
 ## Proof Strategy
 
@@ -176,11 +176,9 @@ the follow-ups.
 noMintingSubTxs : TopLevelTx → Type
 noMintingSubTxs tx = ∀ stx → stx ∈ˡ SubTransactionsOf tx → coin (MintedValueOf stx) ≡ 0
 
--- The right injections of a list of sums, used (at `GovVote ⊎ GovProposal`) to
--- extract the proposals from a mixed `GOVS` input list for the
--- `GOVS-coinFromGovDeposit` gov-deposit accounting parameter below, stated
--- generically to avoid the doubly-imported `GovVote`/`GovProposal` names.
-proposalsOf : ∀ {A B : Type} → List (A ⊎ B) → List B
+-- proposalsOf is useful for extracting proposals from a mixed `GOVS` (`GovVote ⊎
+-- GovProposal`) input list for the `GOVS-coinFromGovDeposit` gov-deposit accounting.
+proposalsOf : {A B : Type} → List (A ⊎ B) → List B
 proposalsOf []            = []
 proposalsOf (inj₁ _ ∷ xs) = proposalsOf xs
 proposalsOf (inj₂ p ∷ xs) = p ∷ proposalsOf xs
@@ -204,21 +202,20 @@ module LEDGER-PoV
       → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
 
   -- UTXOW-PoV parameters
-  ( balance-∪ : ∀ {u u' : UTxO} → disjoint (dom u) (dom u')
+  ( balance-∪ : {u u' : UTxO} → disjoint (dom u) (dom u')
               → cbalance (u ∪ˡ u') ≡ cbalance u + cbalance u' )
-  ( split-balance : ∀ (u : UTxO) (keys : ℙ TxIn)
+  ( split-balance : (u : UTxO) (keys : ℙ TxIn)
                   → cbalance u ≡ cbalance (u ∣ keys ᶜ) + cbalance (u ∣ keys) )
   ( noMintTx : coin (MintedValueOf tx) ≡ 0 )
   ( noMintSubTx : noMintingSubTxs tx )
-  ( outs-disjoint : ∀ {u : UTxO}
+  ( outs-disjoint : {u : UTxO}
                   → TxIdOf tx ∉ mapˢ proj₁ (dom u)
                   → disjoint (dom (u ∣ SpendInputsOf tx ᶜ)) (dom (outs tx)) )
 
   -- Per-step SUBUTXOW coin equation.  A local proof would require, in addition to
   -- `balance-∪` and `split-balance`, a batch-wide "spend inputs preserved" invariant
-  -- (the running UTxO agrees with the snapshot on every sub-tx's spend inputs) and
-  -- freshness of each sub-tx's TxId relative to the running UTxO.
-  ( subutxow-step-coin : ∀ {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
+  -- and freshness of each sub-tx's TxId relative to the running UTxO.
+  ( subutxow-step-coin : {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
       → IsTopLevelValidFlagOf Γ ≡ true
       → Γ ⊢ s₀ ⇀⦇ stx ,SUBUTXOW⦈ s₁
       → getCoin s₀ + cbalance (outs stx) + DonationsOf stx
@@ -226,7 +223,7 @@ module LEDGER-PoV
 
   -- Batch-wide invariants on the post-SUBLEDGERS UTxO state.  Both follow from
   -- batch-wide input disjointness and TxId freshness, which the outer UTXO rule
-  -- establishes at the batch level but doesn't expose per-step.
+  -- establishes at batch level, not per-step.
   ( utxo₁-tx-spend-eq : {subΓ : SubLedgerEnv} {s : LedgerState}
         {utxoSt₁ : UTxOState} {govSt₁ : GovState} {certState₁ : CertState}
       → SubLedgerEnv.isTopLevelValid subΓ ≡ true
@@ -240,25 +237,22 @@ module LEDGER-PoV
       → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
 
-  -- Certs-PoV stubs (discharged later by follow-up PR #1210).  These were the
-  -- `Certs.Properties.PoV` provider lemmas; under the top-down plan they are module
-  -- parameters here.
-  ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+  -- Certs-PoV stubs to be discharged in follow-up PR
+  ( CERTS-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
       → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
-  -- Batch-wide cert-deposit bridge (discharged later by #1210).  The closed-form
-  -- deposit accounting over *all* batch certs (`allDCerts tx`, with `newCertDeposits`
-  -- threading the pre-batch registered-pool set) balances against the actual
-  -- `coinFromDeposits` evolution from the pre-batch cert state `CertStateOf ls₀` to
-  -- the post-`ENTITIES` cert state `cs₂`, in ℕ form:
+
+  -- Batch-wide cert-deposit bridge (discharged later).  The closed-form
+  -- deposit accounting over *all* batch certs balances against actual
+  -- `coinFromDeposits` evolution from pre-batch cert state `CertStateOf ls₀` to
+  -- post-`ENTITIES` cert state `cs₂`:
   --
   --     D₀ + newCertDeposits ≡ D₂ + refundCertDeposits
   --
-  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over the
-  -- sub-txs, then the top-level `ENTITIES`); composing the per-step cert bridges
-  -- across the batch is #1210's responsibility, so the `LEDGER-pov` consumer takes
-  -- the combined equation as given.
+  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over sub-txs,
+  -- then top-level `ENTITIES`); composing per-step cert bridges across the batch is
+  -- follow-up (CERTS PoV) work.
   ( batch-cert-deposits-bridge :
-      ∀ {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
+      {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
       → SubLedgerEnv.isTopLevelValid Γsub ≡ true
       → Γsub ⊢ ls₀ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ls₁
       → Γe ⊢ CertStateOf ls₁ ⇀⦇ tx ,ENTITIES⦈ cs₂
@@ -267,63 +261,59 @@ module LEDGER-PoV
         ≡ coinFromDeposits cs₂
           + refundCertDeposits (PParamsOf Γe) (allDCerts tx) )
 
-  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see the #1256
-  -- review).  `applyWithdrawals` subtracts with `_∸_`, so the ENTITIES/SUBENTITIES
-  -- value-flow equations need each withdrawal amount bounded by the account's balance
-  -- in the *input* state of the step that consumes it.  The spec's premises bound
-  -- withdrawals only against the pre-batch `rewards₀` (except top-level legacy mode),
-  -- so these facts are assumed here, to be discharged by a spec-side premise or a
-  -- batch-threading invariant in the follow-up to that discussion.
-  ( ENTITIES-wdrls-bounded : ∀ {Γe : EntitiesEnv} {cs cs' : CertState}
+  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see review of #1256).
+  -- `applyWithdrawals` subtracts with `_∸_`, so ENTITIES/SUBENTITIES value-flow
+  -- equations need each withdrawal amount bounded by account's balance in the
+  -- *input* state of the step that consumes it.  Premises bound withdrawals only
+  -- against the pre-batch `rewards₀` (except top-level legacy mode), so these facts
+  -- are assumed here, to be discharged by a spec-side premise or a batch-threading
+  -- invariant in follow-up to that discussion.
+  ( ENTITIES-wdrls-bounded : {Γe : EntitiesEnv} {cs cs' : CertState}
       → Γe ⊢ cs ⇀⦇ tx ,ENTITIES⦈ cs'
       → ∀[ (addr , amt) ∈ (WithdrawalsOf tx) ˢ ]
           amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
-  ( SUBENTITIES-wdrls-bounded : ∀ {Γe : SubEntitiesEnv} {cs cs' : CertState} {stx : SubLevelTx}
+  ( SUBENTITIES-wdrls-bounded : {Γe : SubEntitiesEnv} {cs cs' : CertState} {stx : SubLevelTx}
       → Γe ⊢ cs ⇀⦇ stx ,SUBENTITIES⦈ cs'
       → ∀[ (addr , amt) ∈ (WithdrawalsOf stx) ˢ ]
           amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
 
-  -- Governance-deposit accounting (to be discharged by a future `Gov.Properties.PoV`).
+  -- Governance-deposit accounting (to be discharged by future `Gov.Properties.PoV`).
   -- `rmOrphanDRepVotes` only rewrites `votes.gvDRep`, never `GovActionState.deposit`,
   -- so it leaves `coinFromGovDeposit` unchanged.
   ( rmOrphanDRepVotes-coinFromGovDeposit :
-      ∀ (cs : CertState) (g : GovState)
+      (cs : CertState) (g : GovState)
       → coinFromGovDeposit (rmOrphanDRepVotes cs g) ≡ coinFromGovDeposit g )
-  -- Per-`GOVS`-step gov-deposit growth equals the `govProposalsDeposits` of the step's
-  -- proposals (`GOV-Propose` stores `deposit = pp .govActionDeposit`; no `GOV-Vote` or
-  -- in-`LEDGER` removal changes a deposit).  Used by `SUBLEDGERS-gov-coin` (the sub-tx
-  -- GOVS steps) and `gov-acc` (the top-level GOVS step).
+
+  -- Per-`GOVS`-step gov-deposit growth equals `govProposalsDeposits` of step's
+  -- proposals.  Used by `SUBLEDGERS-gov-coin` and `gov-acc`.
   ( GOVS-coinFromGovDeposit :
       ∀ {Γ : GovEnv} {govSt govSt′ : GovState} {props}
       → Γ ⊢ govSt ⇀⦇ props ,GOVS⦈ govSt′
       → coinFromGovDeposit govSt′
         ≡ coinFromGovDeposit govSt + govProposalsDeposits (PParamsOf Γ) (proposalsOf props) )
 
-  -- Utxo/Utxow-PoV facts (discharged later by #1186; module-parameter stubs).
+  -- Utxo/Utxow-PoV facts (discharged later) --
+
   -- Invalid top-level tx: the UTXOW step preserves UTxO coin.
-  ( utxow-pov-invalid : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
-      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
-      → IsValidFlagOf tx ≡ false
-      → getCoin s₀ ≡ getCoin s₁ )
+  ( utxow-pov-invalid : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁ → IsValidFlagOf tx ≡ false → getCoin s₀ ≡ getCoin s₁ )
+
   -- Valid top-level tx, mechanical single-tx coin equation (spend inputs resolved
-  -- against the running UTxO; TxId freshness lets `outs tx` split off cleanly).
-  ( UTXOW-V-mechanical : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+  -- against running UTxO; TxId freshness lets `outs tx` split off cleanly).
+  ( UTXOW-V-mechanical : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
       → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
       → IsValidFlagOf tx ≡ true
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf s₀))
       → getCoin s₀ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
         ≡ getCoin s₁ + cbalance (UTxOOf s₀ ∣ SpendInputsOf tx) )
+
   -- Closed-form coin projection of the batch balance `consumedBatch ≡ producedBatch`
-  -- (#1186 discharges this from the spec premise; the minted terms drop by
-  -- `noMintTx`/`noMintSubTx`).  The cert-deposit summands are in the spec's *closed
-  -- form* — `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with the
-  -- pool set drawn from the environment's pre-batch `pools₀` — keeping this a pure
-  -- UTxO obligation (no post-batch cert states).  `bat'` converts it to the chain's
-  -- top/sub two-level `posPart`/`negPart` form via `batch-cert-deposits-bridge`
-  -- (#1210) together with `posNeg-deposits`.  The governance-deposit summands
-  -- (`govProposalsDeposits`, top and per-sub) sit on the produced side, matching
-  -- `producedTx`.
-  ( UTXOW-batch-balance-coin : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+  -- (discharged by UTXO/UTXOW PoV; minted terms drop by `noMintTx`/`noMintSubTx`).
+  -- cert-deposit summands are in spec's *closed form*:
+  -- `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with pool set drawn
+  -- from environment's pre-batch `pools₀`, keeping this a pure UTxO obligation.
+  -- governance-deposit summands sit on produced side, matching `producedTx`.
+  ( UTXOW-batch-balance-coin : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
       → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
       → cbalance (UTxOOf Γ' ∣ SpendInputsOf tx) + getCoin (WithdrawalsOf tx)
           + sum (map (λ stx → cbalance (UTxOOf Γ' ∣ SpendInputsOf stx) + getCoin (WithdrawalsOf stx))
@@ -339,31 +329,19 @@ module LEDGER-PoV
   where
 
   open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique CERTS-pov
-  -- open UTXOW-PoV tx (λ {u} {u'} → balance-∪ {u} {u'}) split-balance noMintTx noMintSubTx
-  --   (λ {u} → outs-disjoint {u})
-```
 
-The `λ {u}{u'} → balance-∪ {u}{u'}` and `λ {u} → outs-disjoint {u}` η-wrappers are
-needed because passing the assumptions directly triggers Agda to eta-expand the `{u
-u' : UTxO}` implicits through `UTxO`'s `Σ _ left-unique` record structure, leaving
-the `left-unique` field as an unresolved meta.
+  -- When UTXOW PoV proof lands, we'll uncomment the following line, adding appropriate args.
+  -- open UTXOW-PoV ...
+```
 
 ## Small arithmetic helpers
 
 The pure `+`-rearrangement lemmas in this module are discharged by the reflective
-ring solver over the commutative semiring of naturals
-(`Data.Nat.Tactic.RingSolver`): `solve-∀`{.AgdaMacro} proves a closed, universally
-quantified equation outright, and the in-context `solve`{.AgdaMacro} (applied to the
-list of atoms) proves an equation whose variables are already in scope — needed
-where a lemma's trailing variables are implicit, since `solve-∀`{.AgdaMacro} only
-handles visible binders.  Only the statements remain, which keeps the equational
-chains readable.
-
-One wrinkle: the solver recognises the ring's operations *syntactically*, so the
-`Ledger.Prelude` overloaded `_+_` (a `HasAdd`{.AgdaRecord} method, which merely
-*reduces* to `Data.Nat._+_`) defeats it.  The solver-facing statements are therefore
-written with the raw natural-number addition, imported as `_+ᴺ_` — definitionally
-equal to `_+_` at `Coin`, so the lemmas discharge `_+_` goals unchanged.
+ring solver over the commutative semiring of naturals (`Data.Nat.Tactic.RingSolver`):
+`solve-∀`{.AgdaMacro} proves a closed, universally quantified equation outright, and
+the in-context `solve`{.AgdaMacro} (applied to the list of atoms) proves an equation
+whose variables are already in scope; this is needed where a lemma's trailing
+variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binders.[^2]
 
 ```agda
   swap-right : ∀ a b c → a +ᴺ b +ᴺ c ≡ a +ᴺ c +ᴺ b
@@ -402,7 +380,7 @@ two-level `posPart`/`negPart` form; `bat'` obtains it from the closed-form
 
   -- ℕ-level posPart/negPart cancellation: `b + posPart (a ⊖ b)` and
   -- `a + negPart (a ⊖ b)` both equal `a ⊔ b`.
-  posPart-negPart-sym : ∀ (a b : ℕ) → b + posPart (a ⊖ b) ≡ a + negPart (a ⊖ b)
+  posPart-negPart-sym : (a b : ℕ) → b + posPart (a ⊖ b) ≡ a + negPart (a ⊖ b)
   posPart-negPart-sym a       zero    = sym (+-identityʳ a)
   posPart-negPart-sym zero    (suc b) = +-identityʳ (suc b)
   posPart-negPart-sym (suc a) (suc b) = begin
@@ -431,6 +409,7 @@ same quantity (the sum of deposits across the batch), just rephrased to expose
       coin₁ + pt  + ns   ≡⟨ cong (_+ ns) (posPart-negPart-sym coin₂ coin₁) ⟩
       coin₂ + nt  + ns   ∎
     where
+    coin₀ coin₁ coin₂ psp ns pt nt : Coin
     coin₀ = coinFromDeposits cs₀
     coin₁ = coinFromDeposits cs₁
     coin₂ = coinFromDeposits cs₂
@@ -446,13 +425,16 @@ Induct over the `SUBLEDGERS` reflexive-transitive closure, threading the
 per-`SUBUTXOW` coin equation:
 
 ```agda
-  SUBLEDGERS-utxo-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+  SUBLEDGERS-utxo-coin :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
     → SubLedgerEnv.isTopLevelValid Γ ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
     → getCoin (UTxOStateOf s₀)
       + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) stxs)
       ≡  getCoin (UTxOStateOf s₁)
-         + sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) stxs)
+         + sum (map (λ stx → cbalance (UTxOOf Γ ∣ SpendInputsOf stx)) stxs)
 
   -- Base case: empty list.  `Id-nop` unifies s₀ ≡ s₁ and both sums are 0.
   SUBLEDGERS-utxo-coin _ (BS-base Id-nop) = refl
@@ -465,24 +447,24 @@ per-`SUBUTXOW` coin equation:
   SUBLEDGERS-utxo-coin {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
     (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , _ , _)) rest) =
     begin
-      U₀ + (p-stx + p-sum)    ≡⟨ sym (+-assoc U₀ p-stx p-sum) ⟩
+      U₀ + (p-stx + p-sum)    ≡˘⟨ +-assoc U₀ p-stx p-sum ⟩
       U₀ + p-stx + p-sum      ≡⟨ cong (_+ p-sum) step-P-C ⟩
       U₁ + c-stx + p-sum      ≡⟨ +-assoc U₁ c-stx p-sum ⟩
       U₁ + (c-stx + p-sum)    ≡⟨ cong (U₁ +_) (+-comm c-stx p-sum) ⟩
-      U₁ + (p-sum + c-stx)    ≡⟨ sym (+-assoc U₁ p-sum c-stx) ⟩
+      U₁ + (p-sum + c-stx)    ≡˘⟨ +-assoc U₁ p-sum c-stx ⟩
       U₁ + p-sum + c-stx      ≡⟨ cong (_+ c-stx) ih ⟩
       Uₙ + c-sum + c-stx      ≡⟨ +-assoc Uₙ c-sum c-stx ⟩
       Uₙ + (c-sum + c-stx)    ≡⟨ cong (Uₙ +_) (+-comm c-sum c-stx) ⟩
       Uₙ + (c-stx + c-sum)    ∎
     where
+    U₀ U₁ Uₙ p-stx c-stx p-sum c-sum : Coin
     U₀ = getCoin (UTxOStateOf s₀)
     U₁ = getCoin (UTxOStateOf s₁)
     Uₙ = getCoin (UTxOStateOf sₙ)
-
     p-stx = cbalance (outs stx) + DonationsOf stx
-    c-stx = cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)
+    c-stx = cbalance (UTxOOf Γ ∣ SpendInputsOf stx)
     p-sum = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) sigs)
-    c-sum = sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) sigs)
+    c-sum = sum (map (λ stx → cbalance (UTxOOf Γ ∣ SpendInputsOf stx)) sigs)
 
     -- Single-step coin equation from the SUBUTXOW step assumption.
     step-eq : U₀ + cbalance (outs stx) + DonationsOf stx ≡ U₁ + c-stx
@@ -503,11 +485,13 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
 `SUBENTITIES-wdrls-bounded` module parameter.
 
 ```agda
+  open SubLedgerEnv
+
   SUBLEDGERS-certs-pov :
     {Γ : SubLedgerEnv}
     {s₀ s₁ : LedgerState}
     {stxs : List SubLevelTx}
-    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ .isTopLevelValid ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
     →  coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
        ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
@@ -521,26 +505,18 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) =
     begin
       coinFromRewards (CertStateOf s₀) + (getCoin (DirectDepositsOf stx) + sum (map ddwl sigs))
-        ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s₀))
-                        (getCoin (DirectDepositsOf stx))
-                        (sum (map ddwl sigs))) ⟩
-      (coinFromRewards (CertStateOf s₀) + getCoin (DirectDepositsOf stx)) + sum (map ddwl sigs)
-        ≡⟨ cong (_+ sum (map ddwl sigs))
-                (SUBENTITIES-pov (SUBENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
-      (coinFromRewards (CertStateOf s₁) + getCoin (WithdrawalsOf stx)) + sum (map ddwl sigs)
-        ≡⟨ swap-right (coinFromRewards (CertStateOf s₁))
-                      (getCoin (WithdrawalsOf stx))
-                      (sum (map ddwl sigs)) ⟩
-      (coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)) + getCoin (WithdrawalsOf stx)
+        ≡˘⟨ +-assoc (coinFromRewards (CertStateOf s₀)) (getCoin (DirectDepositsOf stx)) _ ⟩
+      coinFromRewards (CertStateOf s₀) + getCoin (DirectDepositsOf stx) + sum (map ddwl sigs)
+        ≡⟨ cong  (_+ sum (map ddwl sigs))
+                 (SUBENTITIES-pov (SUBENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+      coinFromRewards (CertStateOf s₁) + getCoin (WithdrawalsOf stx) + sum (map ddwl sigs)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf s₁)) (getCoin (WithdrawalsOf stx)) _ ⟩
+      coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs) + getCoin (WithdrawalsOf stx)
         ≡⟨ cong (_+ getCoin (WithdrawalsOf stx)) ih ⟩
-      (coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)) + getCoin (WithdrawalsOf stx)
-        ≡⟨ swap-right (coinFromRewards (CertStateOf sₙ))
-                      (sum (map wdrwl sigs))
-                      (getCoin (WithdrawalsOf stx)) ⟩
+      coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs) + getCoin (WithdrawalsOf stx)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf sₙ)) (sum (map wdrwl sigs)) _ ⟩
       (coinFromRewards (CertStateOf sₙ) + getCoin (WithdrawalsOf stx)) + sum (map wdrwl sigs)
-        ≡⟨ +-assoc (coinFromRewards (CertStateOf sₙ))
-                   (getCoin (WithdrawalsOf stx))
-                   (sum (map wdrwl sigs)) ⟩
+        ≡⟨ +-assoc (coinFromRewards (CertStateOf sₙ)) (getCoin (WithdrawalsOf stx)) _ ⟩
       coinFromRewards (CertStateOf sₙ) + (getCoin (WithdrawalsOf stx) + sum (map wdrwl sigs))
         ∎
     where
@@ -563,21 +539,26 @@ premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
     → proposalsOf (GovProposals+Votes t) ≡ ListOfGovProposalsOf t
   proposalsOf-Proposals+Votes t = go (ListOfGovProposalsOf t) (ListOfGovVotesOf t)
     where
-    drop-votes : ∀ {A B : Type} (vs : List A)
-      → proposalsOf {A = A} {B = B} (map inj₁ vs) ≡ []
-    drop-votes []       = refl
+    drop-votes : {A B : Type} (vs : List A) → proposalsOf {B = B} (map inj₁ vs) ≡ []
+    drop-votes [] = refl
     drop-votes (_ ∷ vs) = drop-votes vs
-    go : ∀ {A B : Type} (ps : List B) (vs : List A)
-       → proposalsOf (map inj₂ ps ++ map inj₁ vs) ≡ ps
-    go []       vs = drop-votes vs
+
+    go : {A B : Type} (ps : List B) (vs : List A)
+      → proposalsOf (map inj₂ ps ++ map inj₁ vs) ≡ ps
+    go [] vs = drop-votes vs
     go (p ∷ ps) vs = cong (p ∷_) (go ps vs)
 
-  SUBLEDGERS-gov-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
-    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+  open SubLedgerEnv
+
+  SUBLEDGERS-gov-coin :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
+    → Γ .isTopLevelValid ≡ true
     → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
     → coinFromGovDeposit (GovStateOf s₁)
       ≡ coinFromGovDeposit (GovStateOf s₀)
-        + sum (map (λ stx → govProposalsDeposits (SubLedgerEnv.pparams Γ) (ListOfGovProposalsOf stx)) stxs)
+        + sum (map (λ stx → govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf stx)) stxs)
 
   SUBLEDGERS-gov-coin _ (BS-base Id-nop) = sym (+-identityʳ _)
 
@@ -596,14 +577,15 @@ premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
       coinFromGovDeposit (GovStateOf s₀) + (g-stx + g-sum)
         ∎
     where
-    pp = SubLedgerEnv.pparams Γ
-    g-stx = govProposalsDeposits pp (ListOfGovProposalsOf stx)
-    g-sum = sum (map (λ stx → govProposalsDeposits pp (ListOfGovProposalsOf stx)) sigs)
+    g-stx = govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf stx)
+    g-sum = sum (map (λ stx → govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf stx)) sigs)
 
     step-gov : coinFromGovDeposit (GovStateOf s₁) ≡ coinFromGovDeposit (GovStateOf s₀) + g-stx
-    step-gov = trans (GOVS-coinFromGovDeposit govStep)
-                     (cong (λ ps → coinFromGovDeposit (GovStateOf s₀) + govProposalsDeposits pp ps)
-                           (proposalsOf-Proposals+Votes stx))
+    step-gov =
+      trans  ( GOVS-coinFromGovDeposit govStep )
+             ( cong  ( λ ps →  coinFromGovDeposit (GovStateOf s₀)
+                               + govProposalsDeposits (PParamsOf Γ) ps )
+                     ( proposalsOf-Proposals+Votes stx ) )
 
     ih : coinFromGovDeposit (GovStateOf sₙ) ≡ coinFromGovDeposit (GovStateOf s₁) + g-sum
     ih = SUBLEDGERS-gov-coin isV rest
@@ -624,30 +606,32 @@ are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
 
 ```agda
   LEDGER-pov {Γ} {s} (LEDGER-I (invalid , _ , utxoStep)) =
-    cong (λ u → u + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
-                  + coinFromGovDeposit (GovStateOf s))
-         (utxow-pov-invalid utxoStep invalid)
+    cong  ( λ u → u  + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
+                     + coinFromGovDeposit (GovStateOf s) )
+          ( utxow-pov-invalid utxoStep invalid )
 ```
 
 ### `LEDGER-V` case (valid transaction)
 
-The proof is a single equational chain over `LedgerState` coin totals.  Setting
-`U = getCoin (UTxOState)`, `R = coinFromRewards`, `D = coinFromDeposits`,
+The proof is a single equational chain over `LedgerState` coin totals.
+
+Setting `U = getCoin (UTxOState)`, `R = coinFromRewards`, `D = coinFromDeposits`,
 `G = coinFromGovDeposit`, and `allDirectDeps` / `allWdrls` for the top-level and
 sub-level totals of direct deposits and withdrawals respectively, the goal
 `getCoin s ≡ getCoin s'` is
 
     U₀ + R₀ + D₀ + G₀  ≡  U₂ + R₂ + D₂ + G'
 
-where `G₀ = coinFromGovDeposit govState₀` and — since the final `LEDGER-V` `GovState`
+where `G₀ = coinFromGovDeposit govState₀` and, since the final `LEDGER-V` `GovState`
 is `rmOrphanDRepVotes certState₂ govState₂` and `rmOrphanDRepVotes` preserves
-`coinFromGovDeposit` (parameter `rmOrphanDRepVotes-coinFromGovDeposit`) —
+`coinFromGovDeposit` (parameter `rmOrphanDRepVotes-coinFromGovDeposit`),
 `G' = coinFromGovDeposit govState₂`.
 
-The body assembles the four-summand goal from two `where`-lemmas: `three-summand`
-(`U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the UTxO/rewards/cert-deposit totals with the
-produced-side gov deposits surfacing as `totGov`) and `gov-acc` (`totGov+G₀ ≡ G'`,
-the gov-deposit accounting).
+The body assembles the four-summand goal from two `where`-lemmas.
+
++  **`three-summand`**: `U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the UTxO/rewards/cert-deposit totals
+   with the produced-side gov deposits surfacing as `totGov`;
++  **`gov-acc`**: `totGov+G₀ ≡ G'`, the gov-deposit accounting.
 
 ```agda
   LEDGER-pov {Γ} {s}
@@ -655,14 +639,10 @@ the gov-deposit accounting).
               {certState₂ = cs₂} {govState₂ = govSt₂} {utxoState₂ = us₂}
               (valid , subStep , entitiesStep , govStep , utxoStep)) =
     begin
-      U₀ + R₀ + D₀ + G₀
-        ≡⟨ cong (_+ G₀) three-summand ⟩
-      U₂ + R₂ + D₂ + totGov + G₀
-        ≡⟨ +-assoc (U₂ + R₂ + D₂) totGov G₀ ⟩
-      U₂ + R₂ + D₂ + (totGov + G₀)
-        ≡⟨ cong (U₂ + R₂ + D₂ +_) gov-acc ⟩
-      U₂ + R₂ + D₂ + G'
-        ∎
+      U₀ + R₀ + D₀ + G₀             ≡⟨ cong (_+ G₀) three-summand ⟩
+      U₂ + R₂ + D₂ + totGov + G₀    ≡⟨ +-assoc (U₂ + R₂ + D₂) totGov G₀ ⟩
+      U₂ + R₂ + D₂ + (totGov + G₀)  ≡⟨ cong (U₂ + R₂ + D₂ +_) gov-acc ⟩
+      U₂ + R₂ + D₂ + G'             ∎
     where
 ```
 
@@ -687,10 +667,9 @@ The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
       R₀ = coinFromRewards (CertStateOf s)
       R₂ = coinFromRewards cs₂
 
-      -- Governance-deposit summands of the LedgerState totals.  G₀ is the initial
-      -- GovState's deposit; G' is the final state's (`rmOrphanDRepVotes cs₂ govSt₂`),
-      -- which `rmOrphanDRepVotes-coinFromGovDeposit` collapses to `coinFromGovDeposit
-      -- govSt₂`.  (Used by the `gov-acc` lemma.)
+      -- Governance-deposit summands of LedgerState totals:
+      -- + G₀ is the initial GovState's deposit;
+      -- + G' is the final state's (`rmOrphanDRepVotes cs₂ govSt₂`).
       G₀ G' : Coin
       G₀ = coinFromGovDeposit (GovStateOf s)
       G' = coinFromGovDeposit (rmOrphanDRepVotes cs₂ govSt₂)
@@ -710,11 +689,16 @@ The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
       -- Total governance-action deposits introduced by the batch (top + per-sub),
       -- matching the `govProposalsDeposits` summands on the produced side of the
       -- batch balance and the gov-deposit growth `G' − G₀`.
-      topGov subGovSum totGov : Coin
-      topGov    = govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf tx)
-      subGovSum = sum (map (λ stx → govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf stx))
-                           (SubTransactionsOf tx))
-      totGov    = topGov + subGovSum
+      topGov : Coin
+      topGov = govProposalsDeposits (PParamsOf Γ) (ListOfGovProposalsOf tx)
+
+      subGovSum : Coin
+      subGovSum =
+        sum (map  ( λ stx → govProposalsDeposits (PParamsOf  Γ) (ListOfGovProposalsOf stx) )
+                  ( SubTransactionsOf tx ) )
+
+      totGov : Coin
+      totGov = topGov + subGovSum
 
       -- Pure +-rearrangements for threading the gov summand.
       mid-extract : ∀ a b c d → a +ᴺ (b +ᴺ d) +ᴺ c ≡ a +ᴺ b +ᴺ c +ᴺ d
@@ -727,10 +711,16 @@ The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
       outer-rearr = solve-∀
 ```
 
-The "combined" `ENTITIES-pov` invocation: pre-batch `certState` + all direct deposits
-(top + sub) ≡ post-`ENTITIES` `certState` + all withdrawals (top + sub).  This is the
-key step where direct deposits cancel between the UTxO and CertState sides of the
-ledger.  (The `NetworkId` and domain conditions are premises of the `ENTITIES` rule
+**The combined `ENTITIES-pov` invocation**.
+
++  Pre-batch `certState` plus
++  all direct deposits (top + sub) ≡ post-`ENTITIES` `certState` plus
++  all withdrawals (top + sub).
+
+This is the key step where direct deposits cancel between the UTxO and CertState
+sides of the ledger.
+
+(The `NetworkId` and domain conditions are premises of the `ENTITIES` rule
 itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
 
 ```agda
@@ -742,17 +732,13 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
             ≡⟨ cong (coinFromRewards (CertStateOf s) +_)
                     (+-comm (getCoin (DirectDepositsOf tx)) subDirectDepsCoin) ⟩
           coinFromRewards (CertStateOf s) + (subDirectDepsCoin + getCoin (DirectDepositsOf tx))
-            ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s))
-                            subDirectDepsCoin
-                            (getCoin (DirectDepositsOf tx))) ⟩
+            ≡˘⟨ +-assoc (coinFromRewards (CertStateOf s)) subDirectDepsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards (CertStateOf s) + subDirectDepsCoin + getCoin (DirectDepositsOf tx)
-            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx))
-                    (SUBLEDGERS-certs-pov valid subStep) ⟩
+            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx)) (SUBLEDGERS-certs-pov valid subStep) ⟩
           coinFromRewards cs₁ + subWdrlsCoin + getCoin (DirectDepositsOf tx)
             ≡⟨ swap-right (coinFromRewards cs₁) subWdrlsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards cs₁ + getCoin (DirectDepositsOf tx) + subWdrlsCoin
-            ≡⟨ cong (_+ subWdrlsCoin)
-                    (ENTITIES-pov (ENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+            ≡⟨ cong (_+ subWdrlsCoin) (ENTITIES-pov (ENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
           coinFromRewards cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin
             ≡⟨ +-assoc (coinFromRewards cs₂) (getCoin (WithdrawalsOf tx)) subWdrlsCoin ⟩
           coinFromRewards cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)
@@ -768,7 +754,7 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
           U₀ + R₀ + D₀ + allDirectDeps    ≡⟨ swap-right (U₀ + R₀) D₀ allDirectDeps ⟩
           U₀ + R₀ + allDirectDeps + D₀    ≡⟨ cong (_+ D₀) (+-assoc U₀ R₀ allDirectDeps) ⟩
           U₀ + (R₀ + allDirectDeps) + D₀  ≡⟨ cong (λ x → U₀ + x + D₀) combined-certs ⟩
-          U₀ + (R₂ + allWdrls) + D₀       ≡⟨ cong (_+ D₀) (sym (+-assoc U₀ R₂ allWdrls)) ⟩
+          U₀ + (R₂ + allWdrls) + D₀       ≡˘⟨ cong (_+ D₀) (+-assoc U₀ R₂ allWdrls) ⟩
           U₀ + R₂ + allWdrls + D₀         ∎
 
       dc : DepositsChange
@@ -817,14 +803,11 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
           Ctop + allWdrls + Csub + negPart dct + negPart dcs
             ≡⟨⟩
           Ctop + (Wtop + subWdrlsCoin) + Csub + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + Csub + negPart dct + negPart dcs)
-                    (sym (+-assoc Ctop Wtop subWdrlsCoin)) ⟩
+            ≡˘⟨ cong (λ x → x + Csub + negPart dct + negPart dcs) (+-assoc Ctop Wtop subWdrlsCoin) ⟩
           Ctop + Wtop + subWdrlsCoin + Csub + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
-                    (swap-right (Ctop + Wtop) subWdrlsCoin Csub) ⟩
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (swap-right (Ctop + Wtop) subWdrlsCoin Csub) ⟩
           Ctop + Wtop + Csub + subWdrlsCoin + negPart dct + negPart dcs
-            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
-                    (+-assoc (Ctop + Wtop) Csub subWdrlsCoin) ⟩
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs) (+-assoc (Ctop + Wtop) Csub subWdrlsCoin) ⟩
           Ctop + Wtop + (Csub + subWdrlsCoin) + negPart dct + negPart dcs
             ≡˘⟨ cong (λ x → Ctop + Wtop + x + negPart dct + negPart dcs)
                      (sum-map-+ (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx))
@@ -841,6 +824,8 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
           O + F + DN + allDirectDeps + Psub + posPart dct + posPart dcs + totGov
             ∎
         where
+        O F DN DDtop Wtop CsubW : Coin
+
         O     = cbalance (outs tx)
         F     = TxFeesOf tx
         DN    = DonationsOf tx
@@ -850,7 +835,7 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
                                 + getCoin (WithdrawalsOf stx))
                          (SubTransactionsOf tx))
 
-        pp = LedgerEnv.pparams Γ
+        pp = PParamsOf Γ
 
         -- Abstract net-conversion: reconcile the closed-form balance (`bal`, with
         -- cert deposits as `PZ`/`NZ`) with the chain's two-level form, using the
@@ -1004,38 +989,42 @@ on both sides:
 
 ```agda
       step-ii : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + totGov + R₂
-      step-ii = cong (_+ R₂)
-                     (+-cancelʳ-≡ E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂ + totGov)
-                                  LHS+E≡RHS+E)
+      step-ii = cong  ( _+ R₂ )
+                      ( +-cancelʳ-≡  E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂ + totGov)
+                                     LHS+E≡RHS+E )
 
       -- The three LedgerState totals (UTxO + rewards + cert-deposits): the batch's
       -- gov deposits surface as `+ totGov` on the produced side.
       three-summand : U₀ + R₀ + D₀ ≡ U₂ + R₂ + D₂ + totGov
-      three-summand =
-        +-cancelʳ-≡ allDirectDeps (U₀ + R₀ + D₀) (U₂ + R₂ + D₂ + totGov)
-          (begin
-            U₀ + R₀ + D₀ + allDirectDeps           ≡⟨ step-i ⟩
-            U₀ + R₂ + allWdrls + D₀                ≡⟨ abcd-to-acdb U₀ R₂ allWdrls D₀ ⟩
-            U₀ + allWdrls + D₀ + R₂                ≡⟨ step-ii ⟩
-            U₂ + allDirectDeps + D₂ + totGov + R₂  ≡⟨ outer-rearr U₂ allDirectDeps D₂ totGov R₂ ⟩
-            U₂ + R₂ + D₂ + totGov + allDirectDeps  ∎)
+      three-summand = +-cancelʳ-≡ allDirectDeps (U₀ + R₀ + D₀) (U₂ + R₂ + D₂ + totGov)
+        $ begin
+          U₀ + R₀ + D₀ + allDirectDeps           ≡⟨ step-i ⟩
+          U₀ + R₂ + allWdrls + D₀                ≡⟨ abcd-to-acdb U₀ R₂ allWdrls D₀ ⟩
+          U₀ + allWdrls + D₀ + R₂                ≡⟨ step-ii ⟩
+          U₂ + allDirectDeps + D₂ + totGov + R₂  ≡⟨ outer-rearr U₂ allDirectDeps D₂ totGov R₂ ⟩
+          U₂ + R₂ + D₂ + totGov + allDirectDeps  ∎
 
       -- Gov-deposit accounting: the batch's total gov deposits exactly account for
       -- the growth from the initial gov state's deposit (G₀) to the final one (G').
       gov-acc : totGov + G₀ ≡ G'
-      gov-acc =
-        begin
-          totGov + G₀                          ≡⟨ rearr3 topGov subGovSum G₀ ⟩
-          G₀ + subGovSum + topGov              ≡˘⟨ cong (_+ topGov) (SUBLEDGERS-gov-coin valid subStep) ⟩
-          coinFromGovDeposit govSt₁ + topGov   ≡˘⟨ govStep-eq ⟩
-          coinFromGovDeposit govSt₂            ≡˘⟨ rmOrphanDRepVotes-coinFromGovDeposit cs₂ govSt₂ ⟩
-          G'                                   ∎
+      gov-acc = begin
+        totGov + G₀                          ≡⟨ rearr3 topGov subGovSum G₀ ⟩
+        G₀ + subGovSum + topGov              ≡˘⟨ cong (_+ topGov) (SUBLEDGERS-gov-coin valid subStep) ⟩
+        coinFromGovDeposit govSt₁ + topGov   ≡˘⟨ govStep-eq ⟩
+        coinFromGovDeposit govSt₂            ≡˘⟨ rmOrphanDRepVotes-coinFromGovDeposit cs₂ govSt₂ ⟩
+        G'                                   ∎
         where
         govStep-eq : coinFromGovDeposit govSt₂ ≡ coinFromGovDeposit govSt₁ + topGov
-        govStep-eq = trans (GOVS-coinFromGovDeposit govStep)
-                           (cong (λ ps → coinFromGovDeposit govSt₁
-                                       + govProposalsDeposits (LedgerEnv.pparams Γ) ps)
-                                 (proposalsOf-Proposals+Votes tx))
+        govStep-eq = trans  (GOVS-coinFromGovDeposit govStep)
+                            (cong (λ ps  → coinFromGovDeposit govSt₁
+                                         + govProposalsDeposits (PParamsOf Γ) ps)
+                                  (proposalsOf-Proposals+Votes tx))
 ```
 
 [^1]: See the review of PR #1256.
+
+[^2]: One wrinkle: the solver recognises the ring's operations *syntactically*, so
+      the `Ledger.Prelude` overloaded `_+_` (a `HasAdd`{.AgdaRecord} method, which merely
+      *reduces* to `Data.Nat._+_`) defeats it.  The solver-facing statements are therefore
+      written with the raw natural-number addition, imported as `_+ᴺ_` — definitionally
+      equal to `_+_` at `Coin`, so the lemmas discharge `_+_` goals unchanged.

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -1,0 +1,1086 @@
+---
+source_branch: master
+source_path: src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+---
+
+# Properties of `LEDGER`: Preservation of Value {#thm:LEDGER-PoV}
+
+This module proves the top-level preservation-of-value (PoV) theorem for the Dijkstra
+`LEDGER`{.AgdaDatatype} rule.  If
+
++  `Γ`{.AgdaBound} is a ledger environment,
++  `tx`{.AgdaBound} is top-level transaction, and
++  `s`{.AgdaBound} and `s'`{.AgdaBound} are ledger states related by
+   `LEDGER`{.AgdaDatatype},
+
+then `getCoin s ≡ getCoin s'`.
+
+Recall (from `Ledger.lagda.md`) that `getCoin (LedgerState)` is
+
+    getCoin (UTxOStateOf s)
+    + coinFromRewards (CertStateOf s)
+    + coinFromDeposits (CertStateOf s)
+    + coinFromGovDeposit (GovStateOf s)
+
+This is the sum of UTxO coin, the cert-state rewards balance
+(`coinFromRewards`{.AgdaFunction}), the deposits from `DState`, `PState`, and `GState`
+(`coinFromDeposits`{.AgdaFunction}), and the governance-action deposits
+(`coinFromGovDeposit`{.AgdaFunction}).  Note `getCoin (CertState)` itself now sums the
+rewards balance *and* the deposit pots (`coinFromRewards + coinFromDeposits`), so the
+two middle summands are exactly `getCoin (CertStateOf s)`.
+
+> **Status — complete.** `LEDGER-pov` typechecks end-to-end under `--safe` (no
+> postulates or holes).  Following the top-down plan, this module proves only the
+> top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
+> as **module parameters**, discharged downstream:
+>
+> - **Certs-PoV** (`CERTS-pov`, `batch-cert-deposits-bridge`) — by #1210.
+> - **Utxo/Utxow-PoV** (`utxow-pov-invalid`, `UTXOW-V-mechanical`,
+>   `UTXOW-batch-balance-coin`, and the UTxO algebra `balance-∪`, `split-balance`,
+>   `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`, …) — by the
+>   utxo/utxow-pov work (#1186).  `UTXOW-batch-balance-coin` is the coin projection of
+>   the spec's `consumedBatch ≡ producedBatch` premise, with the produced-side
+>   `govProposalsDeposits` collected into a single trailing `totGov` term.  Its
+>   cert-deposit summands are in the spec's *closed form* (`refundCertDeposits` /
+>   `newCertDeposits` over `allDCerts tx`, against the pre-batch registered-pool set),
+>   keeping it a pure UTxO obligation; `bat'` converts these to the chain's top/sub
+>   two-level form using the `batch-cert-deposits-bridge` (#1210) and `posNeg-deposits`.
+> - **Gov-deposit accounting** (`rmOrphanDRepVotes-coinFromGovDeposit`,
+>   `GOVS-coinFromGovDeposit`) — by a future `Gov.Properties.PoV`.
+> - **No-truncation bounds** (`ENTITIES-wdrls-bounded`, `SUBENTITIES-wdrls-bounded`) —
+>   each withdrawal amount is bounded by the account's balance in the input state of
+>   the `ENTITIES`/`SUBENTITIES` step that consumes it.  The spec's own premises bound
+>   withdrawals only against the *pre-batch* snapshot `rewards₀` (except top-level
+>   legacy mode, which forces exact-balance withdrawals), which does not by itself
+>   bound them against the input state of a later step in the batch — the
+>   phantom-withdrawal gap flagged in the #1256 review.  These parameters are to be
+>   discharged either by a spec-side premise or by a batch-threading invariant, in the
+>   follow-up to that discussion.
+>
+> `getCoin` on a `LedgerState` has the four summands above — UTxO coin, rewards
+> balance, the cert-deposit pots (`coinFromDeposits`), and the gov-action deposits
+> (`coinFromGovDeposit`) — and the `LEDGER-V` chain accounts for all four: the cert
+> deposits cancel via the direct-deposit trick (see *Proof Strategy*), and the
+> gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (the
+> `gov-acc` lemma, from `SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
+
+## Proof Strategy
+
+The Dijkstra `LEDGER-pov`{.AgdaFunction} does not decompose into independent
+`SUBLEDGERS-pov`{.AgdaFunction} and `UTXOW-pov`{.AgdaFunction} pieces: individual
+`SUBUTXO`{.AgdaDatatype} rules have no balance equation (only the *batch-level*
+`consumedBatch ≡ producedBatch` equation constrains the total), and sub-transactions
+may individually transfer value between UTxO and CertState without local balancing.
+
+Instead, the `LEDGER-V` proof is a single equational chain at the
+`LedgerState`{.AgdaRecord} level, with the cancellation of total direct deposits as
+the central trick — direct-deposit value appears both on the UTxO side (via
+`producedBatch`) and on the CertState side (via `applyDirectDeposits` inside
+`ENTITIES`) and cancels in the total.
+
+Concretely, the proof uses three helper lemmas:
+
++  `SUBLEDGERS-utxo-coin`{.AgdaFunction}: induct over the `SUBLEDGERS`{.AgdaDatatype}
+   reflexive-transitive closure, threading the per-`SUBUTXOW` coin equation
+   (`subutxow-step-coin`).
++  `SUBLEDGERS-certs-pov`{.AgdaFunction}: parallel induction over
+   `SUBLEDGERS`{.AgdaDatatype}, composing per-sub-transaction
+   `SUBENTITIES-pov`{.AgdaFunction} invocations.
++  `posNeg-deposits`{.AgdaFunction}: equationally relates the pre-/post-batch deposit
+   totals to the `posPart`/`negPart` of `calculateDepositsChange`.
+
+The `LEDGER-I` case is straightforward: `certState` and `govSt` are unchanged,
+`SUBLEDGERS` is a no-op, and only the `UTXOW` step affects `getCoin`, which it
+preserves via `utxow-pov-invalid`.
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Dijkstra.Specification.Transaction
+open import Ledger.Dijkstra.Specification.Abstract
+
+module Ledger.Dijkstra.Specification.Ledger.Properties.PoV
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs) (open AbstractFunctions abs)
+  where
+
+open import Ledger.Prelude
+open import Ledger.Dijkstra.Specification.Certs govStructure
+open import Ledger.Dijkstra.Specification.Entities txs
+open import Ledger.Dijkstra.Specification.Gov govStructure
+open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
+open import Ledger.Dijkstra.Specification.Utxo txs abs
+open import Ledger.Dijkstra.Specification.Utxow txs abs
+open import Ledger.Dijkstra.Specification.Ledger txs abs
+
+open import Ledger.Dijkstra.Specification.Entities.Properties.PoV txs
+-- open import Ledger.Dijkstra.Specification.Utxo.Properties.PoV txs abs
+-- open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
+
+open import Interface.STS
+open import Data.Nat.Properties
+  using (+-comm; +-assoc; +-0-monoid; +-identityʳ; +-cancelʳ-≡)
+open import Data.Integer using (ℤ; 0ℤ; _-_; _⊖_)
+open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n) renaming (+-comm to +ℤ-comm)
+open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
+
+open RewardAddress
+open ≡-Reasoning
+
+instance
+  _ = +-0-monoid
+```
+-->
+
+## The `LEDGER-PoV` module
+
+`LEDGER-pov`{.AgdaFunction} threads through five groups of module
+parameters:
+
++  the three set/map identities from `ApplyToRewards-PoV`{.AgdaModule}
+   (`∪ˡ-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique`);
++  the UTxO arithmetic / freshness assumptions and batch-wide invariants
+   (`balance-∪`, `split-balance`, `noMintTx`, `noMintSubTx`, `outs-disjoint`,
+   `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`,
+   `utxow-pov-invalid`, `UTXOW-V-mechanical`, `UTXOW-batch-balance-coin`) — the #1186
+   obligations;
++  the Certs facts (`CERTS-pov`, `batch-cert-deposits-bridge`) — the #1210 obligations;
++  the governance-deposit facts (`rmOrphanDRepVotes-coinFromGovDeposit`,
+   `GOVS-coinFromGovDeposit`) — for a future `Gov.Properties.PoV`;
++  the no-truncation withdrawal bounds (`ENTITIES-wdrls-bounded`,
+   `SUBENTITIES-wdrls-bounded`) — the phantom-withdrawal gap (see the #1256 review),
+   to be discharged by a spec-side premise or a batch-threading invariant.
+
+All are stated with detailed provenance notes in comments and are to be discharged in
+follow-up work.  This parameter list is the frozen interface between this proof and
+the follow-up PRs.
+
+```agda
+noMintingSubTxs : TopLevelTx → Type
+noMintingSubTxs tx = ∀ stx → stx ∈ˡ SubTransactionsOf tx → coin (MintedValueOf stx) ≡ 0
+
+-- The right injections of a list of sums.  Used (at `GovVote ⊎ GovProposal`) to
+-- extract the proposals from a mixed `GOVS` input list for the
+-- `GOVS-coinFromGovDeposit` gov-deposit accounting parameter below.  Stated generically
+-- to avoid the doubly-imported `GovVote`/`GovProposal` names.
+proposalsOf : ∀ {A B : Type} → List (A ⊎ B) → List B
+proposalsOf []            = []
+proposalsOf (inj₁ _ ∷ xs) = proposalsOf xs
+proposalsOf (inj₂ p ∷ xs) = p ∷ proposalsOf xs
+
+
+module LEDGER-PoV
+  (tx : TopLevelTx) (let open Tx tx; open TxBody txBody)
+
+  -- ApplyToRewards-PoV parameters
+  ( ∪ˡ-lookup-preserve :
+      (m : Rewards) (c : Credential) (v : Coin) (c' : Credential)
+      → c' ≢ c → lookupᵐ? (❴ c , v ❵ ∪ˡ m) c' ≡ lookupᵐ? m c' )
+
+  ( sum-map-proj₂≡getCoin :
+      (m : RewardAddress ⇀ Coin)
+      → sum (map proj₂ (setToList (m ˢ))) ≡ getCoin m )
+
+  ( setToList-Unique :
+      (m : RewardAddress ⇀ Coin)
+      → ∀[ a ∈ dom (m ˢ) ] NetworkIdOf a ≡ NetworkId
+      → Unique (map (stake ∘ proj₁) (setToList (m ˢ))) )
+
+  -- UTXOW-PoV parameters
+  ( balance-∪ : ∀ {u u' : UTxO} → disjoint (dom u) (dom u')
+              → cbalance (u ∪ˡ u') ≡ cbalance u + cbalance u' )
+  ( split-balance : ∀ (u : UTxO) (keys : ℙ TxIn)
+                  → cbalance u ≡ cbalance (u ∣ keys ᶜ) + cbalance (u ∣ keys) )
+  ( noMintTx : coin (MintedValueOf tx) ≡ 0 )
+  ( noMintSubTx : noMintingSubTxs tx )
+  ( outs-disjoint : ∀ {u : UTxO}
+                  → TxIdOf tx ∉ mapˢ proj₁ (dom u)
+                  → disjoint (dom (u ∣ SpendInputsOf tx ᶜ)) (dom (outs tx)) )
+
+  -- Per-step SUBUTXOW coin equation.  A local proof would require, in
+  -- addition to `balance-∪` and `split-balance`, a batch-wide
+  -- "spend inputs preserved" invariant (the running UTxO agrees with
+  -- the snapshot on every sub-tx's spend inputs) and freshness of each
+  -- sub-tx's TxId relative to the running UTxO.
+  ( subutxow-step-coin : ∀ {Γ : SubUTxOEnv} {s₀ s₁ : UTxOState} {stx : SubLevelTx}
+      → IsTopLevelValidFlagOf Γ ≡ true
+      → Γ ⊢ s₀ ⇀⦇ stx ,SUBUTXOW⦈ s₁
+      → getCoin s₀ + cbalance (outs stx) + DonationsOf stx
+        ≡ getCoin s₁ + cbalance (UTxOOf Γ ∣ SpendInputsOf stx) )
+
+  -- Batch-wide invariants on the post-SUBLEDGERS UTxO state.  Both
+  -- follow from batch-wide input disjointness and TxId freshness,
+  -- which the outer UTXO rule establishes at the batch level but
+  -- doesn't expose per-step.
+  ( utxo₁-tx-spend-eq : {subΓ : SubLedgerEnv} {s : LedgerState}
+        {utxoSt₁ : UTxOState} {govSt₁ : GovState} {certState₁ : CertState}
+      → SubLedgerEnv.isTopLevelValid subΓ ≡ true
+      → SubLedgerEnv.utxo₀ subΓ ≡ UTxOOf (UTxOStateOf s)
+      → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
+      → cbalance (UTxOOf utxoSt₁ ∣ SpendInputsOf tx)
+        ≡ cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx) )
+  ( fresh-top-tx-id : {subΓ : SubLedgerEnv} {s : LedgerState}
+        {utxoSt₁ : UTxOState} {govSt₁ : GovState} {certState₁ : CertState}
+      → SubLedgerEnv.isTopLevelValid subΓ ≡ true
+      → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
+      → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
+
+  -- Certs-PoV stubs (discharged later by #1210).  These were the `Certs.Properties.PoV`
+  -- provider lemmas; under the top-down plan they are module parameters here.
+  ( CERTS-pov : ∀ {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
+  -- Batch-wide cert-deposit bridge (discharged later by #1210).  The closed-form
+  -- deposit accounting over *all* batch certs (`allDCerts tx`, with `newCertDeposits`
+  -- threading the pre-batch registered-pool set) balances against the actual
+  -- `coinFromDeposits` evolution from the pre-batch cert state `CertStateOf ls₀` to
+  -- the post-`ENTITIES` cert state `cs₂`, in ℕ form:
+  --
+  --     D₀ + newCertDeposits ≡ D₂ + refundCertDeposits
+  --
+  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over the
+  -- sub-txs, then the top-level `ENTITIES`); composing the per-step cert bridges
+  -- across the batch is #1210's responsibility, so the `LEDGER-pov` consumer takes
+  -- the combined equation as given.
+  ( batch-cert-deposits-bridge :
+      ∀ {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
+      → SubLedgerEnv.isTopLevelValid Γsub ≡ true
+      → Γsub ⊢ ls₀ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ls₁
+      → Γe ⊢ CertStateOf ls₁ ⇀⦇ tx ,ENTITIES⦈ cs₂
+      → coinFromDeposits (CertStateOf ls₀)
+          + newCertDeposits (PParamsOf Γe) (dom (PoolsOf (CertStateOf ls₀))) (allDCerts tx)
+        ≡ coinFromDeposits cs₂
+          + refundCertDeposits (PParamsOf Γe) (allDCerts tx) )
+
+  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see the #1256
+  -- review).  `applyWithdrawals` subtracts with `_∸_`, so the ENTITIES/SUBENTITIES
+  -- value-flow equations need each withdrawal amount bounded by the account's balance
+  -- in the *input* state of the step that consumes it.  The spec's premises bound
+  -- withdrawals only against the pre-batch `rewards₀` (except top-level legacy mode),
+  -- so these facts are assumed here, to be discharged by a spec-side premise or a
+  -- batch-threading invariant in the follow-up to that discussion.
+  ( ENTITIES-wdrls-bounded : ∀ {Γe : EntitiesEnv} {cs cs' : CertState}
+      → Γe ⊢ cs ⇀⦇ tx ,ENTITIES⦈ cs'
+      → ∀[ (addr , amt) ∈ (WithdrawalsOf tx) ˢ ]
+          amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
+  ( SUBENTITIES-wdrls-bounded : ∀ {Γe : SubEntitiesEnv} {cs cs' : CertState} {stx : SubLevelTx}
+      → Γe ⊢ cs ⇀⦇ stx ,SUBENTITIES⦈ cs'
+      → ∀[ (addr , amt) ∈ (WithdrawalsOf stx) ˢ ]
+          amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
+
+  -- Governance-deposit accounting (to be discharged by a future `Gov.Properties.PoV`).
+  -- `rmOrphanDRepVotes` only rewrites `votes.gvDRep`, never `GovActionState.deposit`,
+  -- so it leaves `coinFromGovDeposit` unchanged.
+  ( rmOrphanDRepVotes-coinFromGovDeposit :
+      ∀ (cs : CertState) (g : GovState)
+      → coinFromGovDeposit (rmOrphanDRepVotes cs g) ≡ coinFromGovDeposit g )
+  -- Per-`GOVS`-step gov-deposit growth equals the `govProposalsDeposits` of the step's
+  -- proposals (`GOV-Propose` stores `deposit = pp .govActionDeposit`; no `GOV-Vote` or
+  -- in-`LEDGER` removal changes a deposit).  Used by `SUBLEDGERS-gov-coin` (the sub-tx
+  -- GOVS steps) and `gov-acc` (the top-level GOVS step).
+  ( GOVS-coinFromGovDeposit :
+      ∀ {Γ : GovEnv} {govSt govSt′ : GovState} {props}
+      → Γ ⊢ govSt ⇀⦇ props ,GOVS⦈ govSt′
+      → coinFromGovDeposit govSt′
+        ≡ coinFromGovDeposit govSt + govProposalsDeposits (PParamsOf Γ) (proposalsOf props) )
+
+  -- Utxo/Utxow-PoV facts (discharged later by #1186; module-parameter stubs).
+  -- Invalid top-level tx: the UTXOW step preserves UTxO coin.
+  ( utxow-pov-invalid : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
+      → IsValidFlagOf tx ≡ false
+      → getCoin s₀ ≡ getCoin s₁ )
+  -- Valid top-level tx, mechanical single-tx coin equation (spend inputs resolved
+  -- against the running UTxO; TxId freshness lets `outs tx` split off cleanly).
+  ( UTXOW-V-mechanical : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
+      → IsValidFlagOf tx ≡ true
+      → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf s₀))
+      → getCoin s₀ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+        ≡ getCoin s₁ + cbalance (UTxOOf s₀ ∣ SpendInputsOf tx) )
+  -- Closed-form coin projection of the batch balance `consumedBatch ≡ producedBatch`
+  -- (#1186 discharges this from the spec premise; the minted terms drop by
+  -- `noMintTx`/`noMintSubTx`).  The cert-deposit summands are in the spec's *closed
+  -- form* — `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with the
+  -- pool set drawn from the environment's pre-batch `pools₀` — keeping this a pure
+  -- UTxO obligation (no post-batch cert states).  `bat'` converts it to the chain's
+  -- top/sub two-level `posPart`/`negPart` form via `batch-cert-deposits-bridge`
+  -- (#1210) together with `posNeg-deposits`.  The governance-deposit summands
+  -- (`govProposalsDeposits`, top and per-sub) sit on the produced side, matching
+  -- `producedTx`.
+  ( UTXOW-batch-balance-coin : ∀ {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
+      → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
+      → cbalance (UTxOOf Γ' ∣ SpendInputsOf tx) + getCoin (WithdrawalsOf tx)
+          + sum (map (λ stx → cbalance (UTxOOf Γ' ∣ SpendInputsOf stx) + getCoin (WithdrawalsOf stx))
+                     (SubTransactionsOf tx))
+          + refundCertDeposits (PParamsOf Γ') (allDCerts tx)
+        ≡ cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + getCoin (DirectDepositsOf tx)
+          + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx + getCoin (DirectDepositsOf stx))
+                     (SubTransactionsOf tx))
+          + newCertDeposits (PParamsOf Γ') (dom (PoolsOf Γ')) (allDCerts tx)
+          + ( govProposalsDeposits (PParamsOf Γ') (ListOfGovProposalsOf tx)
+            + sum (map (λ stx → govProposalsDeposits (PParamsOf Γ') (ListOfGovProposalsOf stx))
+                       (SubTransactionsOf tx)) ) )
+  where
+
+  open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique CERTS-pov
+  -- open UTXOW-PoV tx (λ {u} {u'} → balance-∪ {u} {u'}) split-balance noMintTx noMintSubTx
+  --   (λ {u} → outs-disjoint {u})
+```
+
+The `λ {u}{u'} → balance-∪ {u}{u'}` and `λ {u} → outs-disjoint {u}` η-wrappers are
+needed because passing the assumptions directly triggers Agda to eta-expand the `{u
+u' : UTxO}` implicits through `UTxO`'s `Σ _ left-unique` record structure, leaving
+the `left-unique` field as an unresolved meta.
+
+## Small arithmetic helpers
+
+```agda
+  swap-right : ∀ a b c → a + b + c ≡ a + c + b
+  swap-right a b c = trans (+-assoc a b c)
+                           (trans (cong (a +_) (+-comm b c)) (sym (+-assoc a c b)))
+
+  -- Per-sub-tx withdrawal and direct-deposit totals.
+  wdrwl : SubLevelTx → Coin
+  wdrwl = getCoin ∘ WithdrawalsOf
+
+  ddwl : SubLevelTx → Coin
+  ddwl = getCoin ∘ DirectDepositsOf
+```
+
+## Deposit-change interface
+
+The cert-deposit change is the integer delta of `coinFromDeposits`{.AgdaFunction} at
+the top and sub levels.  The `LEDGER-V` chain tracks the deposit pots in this
+two-level `posPart`/`negPart` form; `bat'` obtains it from the closed-form
+`UTXOW-batch-balance-coin`{.AgdaFunction} parameter via the
+`batch-cert-deposits-bridge`{.AgdaFunction} and `posNeg-deposits`{.AgdaFunction}.
+
+```agda
+  DepositsChange : Type
+  DepositsChange = ℤ × ℤ            -- (top-level Δ , sub-level Δ)
+
+  DepositsChangeTopOf : DepositsChange → ℤ
+  DepositsChangeTopOf = proj₁
+
+  DepositsChangeSubOf : DepositsChange → ℤ
+  DepositsChangeSubOf = proj₂
+
+  calculateDepositsChange : CertState → CertState → CertState → DepositsChange
+  calculateDepositsChange cs₀ cs₁ cs₂ =
+      (coinFromDeposits cs₂ ⊖ coinFromDeposits cs₁)
+    , (coinFromDeposits cs₁ ⊖ coinFromDeposits cs₀)
+
+  -- ℕ-level posPart/negPart cancellation: `b + posPart (a ⊖ b)` and
+  -- `a + negPart (a ⊖ b)` both equal `a ⊔ b`.
+  posPart-negPart-sym : ∀ (a b : ℕ) → b + posPart (a ⊖ b) ≡ a + negPart (a ⊖ b)
+  posPart-negPart-sym a       zero    = sym (+-identityʳ a)
+  posPart-negPart-sym zero    (suc b) = +-identityʳ (suc b)
+  posPart-negPart-sym (suc a) (suc b) = begin
+      suc b + posPart (suc a ⊖ suc b)  ≡⟨ cong (λ z → suc b + posPart z) ([1+m]⊖[1+n]≡m⊖n a b) ⟩
+      suc b + posPart (a ⊖ b)          ≡⟨ cong suc (posPart-negPart-sym a b) ⟩
+      suc a + negPart (a ⊖ b)          ≡˘⟨ cong (λ z → suc a + negPart z) ([1+m]⊖[1+n]≡m⊖n a b) ⟩
+      suc a + negPart (suc a ⊖ suc b)  ∎
+    where open ≡-Reasoning
+```
+
+## `posNeg-deposits`
+
+The deposit accounting identity used in the `LEDGER-V` chain.  Both sides express the
+same quantity (the sum of deposits across the batch), just rephrased to expose
+`posPart` vs `negPart` of the top-level and sub-level deposit changes.
+
+```agda
+  posNeg-deposits : (cs₀ cs₁ cs₂ : CertState)
+    → let dc = calculateDepositsChange cs₀ cs₁ cs₂ in
+      coinFromDeposits cs₀ + posPart (DepositsChangeTopOf dc) + posPart (DepositsChangeSubOf dc)
+      ≡ coinFromDeposits cs₂ + negPart (DepositsChangeTopOf dc) + negPart (DepositsChangeSubOf dc)
+  posNeg-deposits cs₀ cs₁ cs₂ = begin
+      coin₀ + pt + psp   ≡⟨ swap-right coin₀ pt psp ⟩
+      coin₀ + psp + pt   ≡⟨ cong (_+ pt) (posPart-negPart-sym coin₁ coin₀) ⟩
+      coin₁ + ns  + pt   ≡⟨ swap-right coin₁ ns pt ⟩
+      coin₁ + pt  + ns   ≡⟨ cong (_+ ns) (posPart-negPart-sym coin₂ coin₁) ⟩
+      coin₂ + nt  + ns   ∎
+    where
+    coin₀ = coinFromDeposits cs₀
+    coin₁ = coinFromDeposits cs₁
+    coin₂ = coinFromDeposits cs₂
+    psp = posPart (coin₁ ⊖ coin₀)   -- DepositsChangeSubOf dc
+    ns  = negPart (coin₁ ⊖ coin₀)
+    pt  = posPart (coin₂ ⊖ coin₁)   -- DepositsChangeTopOf dc
+    nt  = negPart (coin₂ ⊖ coin₁)
+```
+
+## `SUBLEDGERS-utxo-coin`
+
+Induct over the `SUBLEDGERS` reflexive-transitive closure, threading the
+per-`SUBUTXOW` coin equation:
+
+```agda
+  SUBLEDGERS-utxo-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → getCoin (UTxOStateOf s₀) + sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) stxs)
+      ≡ getCoin (UTxOStateOf s₁) + sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) stxs)
+
+  -- Base case: empty list.  `Id-nop` unifies s₀ ≡ s₁ and both sums are 0.
+  SUBLEDGERS-utxo-coin _ (BS-base Id-nop) = refl
+
+  -- SUBLEDGER-I ruled out by isV : isTopLevelValid ≡ true.
+  SUBLEDGERS-utxo-coin isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  -- Inductive step: combine the per-step SUBUTXOW balance with the IH.
+  SUBLEDGERS-utxo-coin {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (isV' , subutxowStep , _ , _)) rest) =
+    begin
+      U₀ + (p-stx + p-sum)    ≡⟨ sym (+-assoc U₀ p-stx p-sum) ⟩
+      U₀ + p-stx + p-sum      ≡⟨ cong (_+ p-sum) step-P-C ⟩
+      U₁ + c-stx + p-sum      ≡⟨ +-assoc U₁ c-stx p-sum ⟩
+      U₁ + (c-stx + p-sum)    ≡⟨ cong (U₁ +_) (+-comm c-stx p-sum) ⟩
+      U₁ + (p-sum + c-stx)    ≡⟨ sym (+-assoc U₁ p-sum c-stx) ⟩
+      U₁ + p-sum + c-stx      ≡⟨ cong (_+ c-stx) ih ⟩
+      Uₙ + c-sum + c-stx      ≡⟨ +-assoc Uₙ c-sum c-stx ⟩
+      Uₙ + (c-sum + c-stx)    ≡⟨ cong (Uₙ +_) (+-comm c-sum c-stx) ⟩
+      Uₙ + (c-stx + c-sum)    ∎
+    where
+    U₀ = getCoin (UTxOStateOf s₀)
+    U₁ = getCoin (UTxOStateOf s₁)
+    Uₙ = getCoin (UTxOStateOf sₙ)
+
+    p-stx = cbalance (outs stx) + DonationsOf stx
+    c-stx = cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)
+    p-sum = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx) sigs)
+    c-sum = sum (map (λ stx → cbalance (SubLedgerEnv.utxo₀ Γ ∣ SpendInputsOf stx)) sigs)
+
+    -- Single-step coin equation from the SUBUTXOW step assumption.
+    step-eq : U₀ + cbalance (outs stx) + DonationsOf stx ≡ U₁ + c-stx
+    step-eq = subutxow-step-coin isV' subutxowStep
+
+    step-P-C : U₀ + p-stx ≡ U₁ + c-stx
+    step-P-C = trans (sym (+-assoc U₀ (cbalance (outs stx)) (DonationsOf stx))) step-eq
+
+    ih : U₁ + p-sum ≡ Uₙ + c-sum
+    ih = SUBLEDGERS-utxo-coin isV rest
+```
+
+## `SUBLEDGERS-certs-pov`
+
+Parallel induction over `SUBLEDGERS`, composing per-sub-transaction `SUBENTITIES-pov`
+invocations.  The `NetworkId` witnesses and domain conditions are premises of the
+`SUBENTITIES` rule itself; only the no-truncation bound is external, supplied by the
+`SUBENTITIES-wdrls-bounded` module parameter.
+
+```agda
+  SUBLEDGERS-certs-pov : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
+      ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
+
+  SUBLEDGERS-certs-pov _ (BS-base Id-nop) = refl
+
+  SUBLEDGERS-certs-pov isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-certs-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) =
+    begin
+      coinFromRewards (CertStateOf s₀) + (getCoin (DirectDepositsOf stx) + sum (map ddwl sigs))
+        ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s₀))
+                        (getCoin (DirectDepositsOf stx))
+                        (sum (map ddwl sigs))) ⟩
+      (coinFromRewards (CertStateOf s₀) + getCoin (DirectDepositsOf stx)) + sum (map ddwl sigs)
+        ≡⟨ cong (_+ sum (map ddwl sigs))
+                (SUBENTITIES-pov (SUBENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+      (coinFromRewards (CertStateOf s₁) + getCoin (WithdrawalsOf stx)) + sum (map ddwl sigs)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf s₁))
+                      (getCoin (WithdrawalsOf stx))
+                      (sum (map ddwl sigs)) ⟩
+      (coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)) + getCoin (WithdrawalsOf stx)
+        ≡⟨ cong (_+ getCoin (WithdrawalsOf stx)) ih ⟩
+      (coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)) + getCoin (WithdrawalsOf stx)
+        ≡⟨ swap-right (coinFromRewards (CertStateOf sₙ))
+                      (sum (map wdrwl sigs))
+                      (getCoin (WithdrawalsOf stx)) ⟩
+      (coinFromRewards (CertStateOf sₙ) + getCoin (WithdrawalsOf stx)) + sum (map wdrwl sigs)
+        ≡⟨ +-assoc (coinFromRewards (CertStateOf sₙ))
+                   (getCoin (WithdrawalsOf stx))
+                   (sum (map wdrwl sigs)) ⟩
+      coinFromRewards (CertStateOf sₙ) + (getCoin (WithdrawalsOf stx) + sum (map wdrwl sigs))
+        ∎
+    where
+    ih : coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)
+         ≡ coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)
+    ih = SUBLEDGERS-certs-pov isV rest
+```
+
+## `SUBLEDGERS-gov-coin`
+
+Induct over `SUBLEDGERS`, threading the per-`GOVS` gov-deposit growth: each
+`SUBLEDGER-V` step grows `coinFromGovDeposit`{.AgdaFunction} by the
+`govProposalsDeposits`{.AgdaFunction} of the sub-transaction's proposals (via the
+`GOVS-coinFromGovDeposit`{.AgdaFunction} parameter applied to the step's `GOVS`
+premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
+
+```agda
+  -- `proposalsOf (GovProposals+Votes t)` recovers exactly the proposals of `t`.
+  proposalsOf-Proposals+Votes : ∀ {ℓ} (t : Tx ℓ)
+    → proposalsOf (GovProposals+Votes t) ≡ ListOfGovProposalsOf t
+  proposalsOf-Proposals+Votes t = go (ListOfGovProposalsOf t) (ListOfGovVotesOf t)
+    where
+    drop-votes : ∀ {A B : Type} (vs : List A)
+      → proposalsOf {A = A} {B = B} (map inj₁ vs) ≡ []
+    drop-votes []       = refl
+    drop-votes (_ ∷ vs) = drop-votes vs
+    go : ∀ {A B : Type} (ps : List B) (vs : List A)
+       → proposalsOf (map inj₂ ps ++ map inj₁ vs) ≡ ps
+    go []       vs = drop-votes vs
+    go (p ∷ ps) vs = cong (p ∷_) (go ps vs)
+
+  SUBLEDGERS-gov-coin : ∀ {Γ : SubLedgerEnv} {s₀ s₁ : LedgerState} {stxs : List SubLevelTx}
+    → SubLedgerEnv.isTopLevelValid Γ ≡ true
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → coinFromGovDeposit (GovStateOf s₁)
+      ≡ coinFromGovDeposit (GovStateOf s₀)
+        + sum (map (λ stx → govProposalsDeposits (SubLedgerEnv.pparams Γ) (ListOfGovProposalsOf stx)) stxs)
+
+  SUBLEDGERS-gov-coin _ (BS-base Id-nop) = sym (+-identityʳ _)
+
+  SUBLEDGERS-gov-coin isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-gov-coin {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (_ , _ , _ , govStep)) rest) =
+    begin
+      coinFromGovDeposit (GovStateOf sₙ)
+        ≡⟨ ih ⟩
+      coinFromGovDeposit (GovStateOf s₁) + g-sum
+        ≡⟨ cong (_+ g-sum) step-gov ⟩
+      coinFromGovDeposit (GovStateOf s₀) + g-stx + g-sum
+        ≡⟨ +-assoc (coinFromGovDeposit (GovStateOf s₀)) g-stx g-sum ⟩
+      coinFromGovDeposit (GovStateOf s₀) + (g-stx + g-sum)
+        ∎
+    where
+    pp = SubLedgerEnv.pparams Γ
+    g-stx = govProposalsDeposits pp (ListOfGovProposalsOf stx)
+    g-sum = sum (map (λ stx → govProposalsDeposits pp (ListOfGovProposalsOf stx)) sigs)
+
+    step-gov : coinFromGovDeposit (GovStateOf s₁) ≡ coinFromGovDeposit (GovStateOf s₀) + g-stx
+    step-gov = trans (GOVS-coinFromGovDeposit govStep)
+                     (cong (λ ps → coinFromGovDeposit (GovStateOf s₀) + govProposalsDeposits pp ps)
+                           (proposalsOf-Proposals+Votes stx))
+
+    ih : coinFromGovDeposit (GovStateOf sₙ) ≡ coinFromGovDeposit (GovStateOf s₁) + g-sum
+    ih = SUBLEDGERS-gov-coin isV rest
+```
+
+## `LEDGER-pov`
+
+```agda
+  LEDGER-pov : {Γ : LedgerEnv} {s s' : LedgerState}
+    → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
+```
+
+### `LEDGER-I` case (invalid transaction)
+
+`SUBLEDGERS` is a no-op when `IsValidFlagOf tx ≡ false`, so `certState` and `govSt`
+are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
+`utxow-pov-invalid`.
+
+```agda
+  LEDGER-pov {Γ} {s} (LEDGER-I (invalid , _ , utxoStep)) =
+    cong (λ u → u + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
+                  + coinFromGovDeposit (GovStateOf s))
+         (utxow-pov-invalid utxoStep invalid)
+```
+
+### `LEDGER-V` case (valid transaction)
+
+The proof is a single equational chain over `LedgerState` coin totals.  Setting
+`U = getCoin (UTxOState)`, `R = coinFromRewards`, `D = coinFromDeposits`,
+`G = coinFromGovDeposit`, and `allDirectDeps` / `allWdrls` for the top-level and
+sub-level totals of direct deposits and withdrawals respectively, the goal
+`getCoin s ≡ getCoin s'` is
+
+    U₀ + R₀ + D₀ + G₀  ≡  U₂ + R₂ + D₂ + G'
+
+where `G₀ = coinFromGovDeposit govState₀` and — since the final `LEDGER-V` `GovState`
+is `rmOrphanDRepVotes certState₂ govState₂` and `rmOrphanDRepVotes` preserves
+`coinFromGovDeposit` (parameter `rmOrphanDRepVotes-coinFromGovDeposit`) —
+`G' = coinFromGovDeposit govState₂`.
+
+The body assembles the four-summand goal from two `where`-lemmas: `three-summand`
+(`U₀+R₀+D₀ ≡ U₂+R₂+D₂+totGov`, the UTxO/rewards/cert-deposit totals with the
+produced-side gov deposits surfacing as `totGov`) and `gov-acc` (`totGov+G₀ ≡ G'`,
+the gov-deposit accounting).
+
+```agda
+  LEDGER-pov {Γ} {s}
+    (LEDGER-V {utxoState₁ = us₁} {govState₁ = govSt₁} {certState₁ = cs₁}
+              {certState₂ = cs₂} {govState₂ = govSt₂} {utxoState₂ = us₂}
+              (valid , subStep , entitiesStep , govStep , utxoStep)) =
+    begin
+      U₀ + R₀ + D₀ + G₀
+        ≡⟨ cong (_+ G₀) three-summand ⟩
+      U₂ + R₂ + D₂ + totGov + G₀
+        ≡⟨ +-assoc (U₂ + R₂ + D₂) totGov G₀ ⟩
+      U₂ + R₂ + D₂ + (totGov + G₀)
+        ≡⟨ cong (U₂ + R₂ + D₂ +_) gov-acc ⟩
+      U₂ + R₂ + D₂ + G'
+        ∎
+    where
+```
+
+The proof uses a handful of arithmetic shuffles — `abcd-to-acdb`, the five
+`arithmetic-N` helpers, and `mid-extract`/`rearr3`/`outer-rearr` (for the gov summand)
+— all pure `+`-monoid rearrangements.  Commutative steps go through `swap-right`, so
+`solve-macro` (a *non-normalising* monoid solver) cannot discharge them directly; they
+are stated explicitly to keep the chain readable.
+
+```agda
+      abcd-to-acdb : ∀ a b c d → a + b + c + d ≡ a + c + d + b
+      abcd-to-acdb a b c d = begin
+        a + b + c + d     ≡⟨ cong (_+ d) (+-assoc a b c) ⟩
+        a + (b + c) + d   ≡⟨ cong (λ x → a + x + d) (+-comm b c) ⟩
+        a + (c + b) + d   ≡⟨ cong (_+ d) (sym (+-assoc a c b)) ⟩
+        a + c + b + d     ≡⟨ +-assoc (a + c) b d ⟩
+        a + c + (b + d)   ≡⟨ cong ((a + c) +_) (+-comm b d) ⟩
+        a + c + (d + b)   ≡⟨ sym (+-assoc (a + c) d b) ⟩
+        a + c + d + b     ∎
+
+      U₀ U₁ U₂ : Coin
+      U₀ = getCoin (UTxOStateOf s)
+      U₁ = getCoin us₁
+      U₂ = getCoin us₂
+
+      D₀ D₂ : Coin
+      D₀ = coinFromDeposits (CertStateOf s)
+      D₂ = coinFromDeposits cs₂
+
+      R₀ R₂ : Coin
+      R₀ = coinFromRewards (CertStateOf s)
+      R₂ = coinFromRewards cs₂
+
+      -- Governance-deposit summands of the LedgerState totals.  G₀ is the initial
+      -- GovState's deposit; G' is the final state's (`rmOrphanDRepVotes cs₂ govSt₂`),
+      -- which `rmOrphanDRepVotes-coinFromGovDeposit` collapses to `coinFromGovDeposit
+      -- govSt₂`.  (Used by the `gov-acc` lemma.)
+      G₀ G' : Coin
+      G₀ = coinFromGovDeposit (GovStateOf s)
+      G' = coinFromGovDeposit (rmOrphanDRepVotes cs₂ govSt₂)
+
+      subDirectDepsCoin : Coin
+      subDirectDepsCoin = sum (map ddwl (SubTransactionsOf tx))
+
+      allDirectDeps : Coin
+      allDirectDeps = getCoin (DirectDepositsOf tx) + subDirectDepsCoin
+
+      subWdrlsCoin : Coin
+      subWdrlsCoin = sum (map wdrwl (SubTransactionsOf tx))
+
+      allWdrls : Coin
+      allWdrls = getCoin (WithdrawalsOf tx) + subWdrlsCoin
+
+      -- Total governance-action deposits introduced by the batch (top + per-sub),
+      -- matching the `govProposalsDeposits` summands on the produced side of the
+      -- batch balance and the gov-deposit growth `G' − G₀`.
+      topGov subGovSum totGov : Coin
+      topGov    = govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf tx)
+      subGovSum = sum (map (λ stx → govProposalsDeposits (LedgerEnv.pparams Γ) (ListOfGovProposalsOf stx))
+                           (SubTransactionsOf tx))
+      totGov    = topGov + subGovSum
+
+      -- Pure +-monoid rearrangements for threading the gov summand.
+      mid-extract : ∀ a b c d → a + (b + d) + c ≡ a + b + c + d
+      mid-extract a b c d = trans (cong (_+ c) (sym (+-assoc a b d)))
+                                  (swap-right (a + b) d c)
+
+      rearr3 : ∀ a b c → a + b + c ≡ c + b + a
+      rearr3 a b c = begin
+        a + b + c   ≡⟨ swap-right a b c ⟩
+        a + c + b   ≡⟨ cong (_+ b) (+-comm a c) ⟩
+        c + a + b   ≡⟨ swap-right c a b ⟩
+        c + b + a   ∎
+
+      outer-rearr : ∀ u a d g r → u + a + d + g + r ≡ u + r + d + g + a
+      outer-rearr u a d g r = begin
+        u + a + d + g + r   ≡⟨ swap-right (u + a + d) g r ⟩
+        u + a + d + r + g   ≡⟨ cong (_+ g) (swap-right (u + a) d r) ⟩
+        u + a + r + d + g   ≡⟨ cong (λ x → x + d + g) (swap-right u a r) ⟩
+        u + r + a + d + g   ≡⟨ cong (_+ g) (swap-right (u + r) a d) ⟩
+        u + r + d + a + g   ≡⟨ swap-right (u + r + d) a g ⟩
+        u + r + d + g + a   ∎
+```
+
+The "combined" `ENTITIES-pov` invocation: pre-batch `certState` + all direct deposits
+(top + sub) ≡ post-`ENTITIES` `certState` + all withdrawals (top + sub).  This is the
+key step where direct deposits cancel between the UTxO and CertState sides of the
+ledger.  (The `NetworkId` and domain conditions are premises of the `ENTITIES` rule
+itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
+
+```agda
+      combined-certs : coinFromRewards (CertStateOf s) + allDirectDeps
+                     ≡ coinFromRewards cs₂ + allWdrls
+      combined-certs =
+        begin
+          coinFromRewards (CertStateOf s) + allDirectDeps
+            ≡⟨ cong (coinFromRewards (CertStateOf s) +_)
+                    (+-comm (getCoin (DirectDepositsOf tx)) subDirectDepsCoin) ⟩
+          coinFromRewards (CertStateOf s) + (subDirectDepsCoin + getCoin (DirectDepositsOf tx))
+            ≡⟨ sym (+-assoc (coinFromRewards (CertStateOf s))
+                            subDirectDepsCoin
+                            (getCoin (DirectDepositsOf tx))) ⟩
+          coinFromRewards (CertStateOf s) + subDirectDepsCoin + getCoin (DirectDepositsOf tx)
+            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx))
+                    (SUBLEDGERS-certs-pov valid subStep) ⟩
+          coinFromRewards cs₁ + subWdrlsCoin + getCoin (DirectDepositsOf tx)
+            ≡⟨ swap-right (coinFromRewards cs₁) subWdrlsCoin (getCoin (DirectDepositsOf tx)) ⟩
+          coinFromRewards cs₁ + getCoin (DirectDepositsOf tx) + subWdrlsCoin
+            ≡⟨ cong (_+ subWdrlsCoin)
+                    (ENTITIES-pov (ENTITIES-wdrls-bounded entitiesStep) entitiesStep) ⟩
+          coinFromRewards cs₂ + getCoin (WithdrawalsOf tx) + subWdrlsCoin
+            ≡⟨ +-assoc (coinFromRewards cs₂) (getCoin (WithdrawalsOf tx)) subWdrlsCoin ⟩
+          coinFromRewards cs₂ + (getCoin (WithdrawalsOf tx) + subWdrlsCoin)
+            ∎
+```
+
+`step-i`: introduce `allDirectDeps`, then rewrite using `combined-certs`.
+
+```agda
+      step-i : (U₀ + R₀ + D₀) + allDirectDeps ≡ U₀ + R₂ + allWdrls + D₀
+      step-i =
+        begin
+          U₀ + R₀ + D₀ + allDirectDeps    ≡⟨ swap-right (U₀ + R₀) D₀ allDirectDeps ⟩
+          U₀ + R₀ + allDirectDeps + D₀    ≡⟨ cong (_+ D₀) (+-assoc U₀ R₀ allDirectDeps) ⟩
+          U₀ + (R₀ + allDirectDeps) + D₀  ≡⟨ cong (λ x → U₀ + x + D₀) combined-certs ⟩
+          U₀ + (R₂ + allWdrls) + D₀       ≡⟨ cong (_+ D₀) (sym (+-assoc U₀ R₂ allWdrls)) ⟩
+          U₀ + R₂ + allWdrls + D₀         ∎
+
+      dc : DepositsChange
+      dc = calculateDepositsChange (CertStateOf s) cs₁ cs₂
+
+      dct dcs : ℤ
+      dct = DepositsChangeTopOf dc
+      dcs = DepositsChangeSubOf dc
+
+      posneg : D₀ + posPart dct + posPart dcs ≡ D₂ + negPart dct + negPart dcs
+      posneg = posNeg-deposits (CertStateOf s) cs₁ cs₂
+```
+
+`UTXOW-V-mechanical` composed with the batch-wide "spend inputs preserved" invariant:
+
+```agda
+      mech : U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+           ≡ U₂ + cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx)
+      mech = trans (UTXOW-V-mechanical utxoStep valid (fresh-top-tx-id valid subStep))
+                   (cong (U₂ +_) (utxo₁-tx-spend-eq valid refl subStep))
+
+      Ctop Csub : Coin
+      Ctop = cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf tx)
+      Csub = sum (map (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx))
+                      (SubTransactionsOf tx))
+
+      Psub PsubDD : Coin
+      Psub = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx)
+                      (SubTransactionsOf tx))
+      PsubDD = sum (map (λ stx → cbalance (outs stx) + DonationsOf stx + getCoin (DirectDepositsOf stx))
+                        (SubTransactionsOf tx))
+
+      -- The additive constant on both sides of the inner chain.
+      E : Coin
+      E = Ctop + Psub + posPart dct + posPart dcs
+```
+
+The batch balance, rephrased to expose direct deposits and bring withdrawals together:
+
+```agda
+      bat' : Ctop + allWdrls + Csub + negPart dct + negPart dcs
+           ≡ cbalance (outs tx) + TxFeesOf tx + DonationsOf tx
+             + allDirectDeps + Psub + posPart dct + posPart dcs + totGov
+      bat' =
+        begin
+          Ctop + allWdrls + Csub + negPart dct + negPart dcs
+            ≡⟨⟩
+          Ctop + (Wtop + subWdrlsCoin) + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + Csub + negPart dct + negPart dcs)
+                    (sym (+-assoc Ctop Wtop subWdrlsCoin)) ⟩
+          Ctop + Wtop + subWdrlsCoin + Csub + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
+                    (swap-right (Ctop + Wtop) subWdrlsCoin Csub) ⟩
+          Ctop + Wtop + Csub + subWdrlsCoin + negPart dct + negPart dcs
+            ≡⟨ cong (λ x → x + negPart dct + negPart dcs)
+                    (+-assoc (Ctop + Wtop) Csub subWdrlsCoin) ⟩
+          Ctop + Wtop + (Csub + subWdrlsCoin) + negPart dct + negPart dcs
+            ≡˘⟨ cong (λ x → Ctop + Wtop + x + negPart dct + negPart dcs)
+                     (sum-map-+ (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx))
+                                wdrwl (SubTransactionsOf tx)) ⟩
+          Ctop + Wtop + CsubW + negPart dct + negPart dcs
+            ≡⟨ convert ⟩
+          O + F + DN + DDtop + posPart dct + PsubDD + posPart dcs + totGov
+            ≡⟨ cong (λ x → O + F + DN + DDtop + posPart dct + x + posPart dcs + totGov)
+                    (sum-map-+ (λ stx → cbalance (outs stx) + DonationsOf stx)
+                               (λ stx → getCoin (DirectDepositsOf stx))
+                               (SubTransactionsOf tx)) ⟩
+          O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs + totGov
+            ≡⟨ cong (_+ totGov) reshuffle-to-DD ⟩
+          O + F + DN + allDirectDeps + Psub + posPart dct + posPart dcs + totGov
+            ∎
+        where
+        O     = cbalance (outs tx)
+        F     = TxFeesOf tx
+        DN    = DonationsOf tx
+        DDtop = getCoin (DirectDepositsOf tx)
+        Wtop  = getCoin (WithdrawalsOf tx)
+        CsubW = sum (map (λ stx → cbalance (UTxOOf (UTxOStateOf s) ∣ SpendInputsOf stx)
+                                + getCoin (WithdrawalsOf stx))
+                         (SubTransactionsOf tx))
+
+        pp = LedgerEnv.pparams Γ
+
+        -- Abstract net-conversion: reconcile the closed-form balance (`bal`, with
+        -- cert deposits as `PZ`/`NZ`) with the chain's two-level form, using the
+        -- batch bridge (`sf`) and the two-level deposit identity (`pn`).  Cancels
+        -- the constant `D0 + PZ` on the right.
+        net-arith : ∀ (A B G PZ NZ Pt Ps Nt Ns D0 D2 : ℕ)
+          → A + NZ ≡ B + PZ + G
+          → D0 + PZ ≡ D2 + NZ
+          → D0 + Pt + Ps ≡ D2 + Nt + Ns
+          → A + Nt + Ns ≡ B + Pt + Ps + G
+        net-arith A B G PZ NZ Pt Ps Nt Ns D0 D2 bal sf pn =
+          +-cancelʳ-≡ (D0 + PZ) (A + Nt + Ns) (B + Pt + Ps + G) big
+          where
+          rearr-X : (A + Nt + Ns) + (D2 + NZ) ≡ (A + NZ) + (Nt + Ns + D2)
+          rearr-X = begin
+            (A + Nt + Ns) + (D2 + NZ)   ≡˘⟨ +-assoc (A + Nt + Ns) D2 NZ ⟩
+            A + Nt + Ns + D2 + NZ        ≡⟨ swap-right (A + Nt + Ns) D2 NZ ⟩
+            A + Nt + Ns + NZ + D2        ≡⟨ cong (_+ D2) (swap-right (A + Nt) Ns NZ) ⟩
+            A + Nt + NZ + Ns + D2        ≡⟨ cong (λ w → w + Ns + D2) (swap-right A Nt NZ) ⟩
+            A + NZ + Nt + Ns + D2        ≡⟨ +-assoc (A + NZ + Nt) Ns D2 ⟩
+            A + NZ + Nt + (Ns + D2)      ≡⟨ +-assoc (A + NZ) Nt (Ns + D2) ⟩
+            A + NZ + (Nt + (Ns + D2))    ≡⟨ cong (A + NZ +_) (sym (+-assoc Nt Ns D2)) ⟩
+            (A + NZ) + (Nt + Ns + D2)    ∎
+          rearr-Y : Nt + Ns + D2 ≡ D2 + Nt + Ns
+          rearr-Y = trans (+-comm (Nt + Ns) D2) (sym (+-assoc D2 Nt Ns))
+          rearr-Z : (B + PZ + G) + (D0 + Pt + Ps) ≡ (B + Pt + Ps + G) + (D0 + PZ)
+          rearr-Z = begin
+            (B + PZ + G) + (D0 + Pt + Ps)   ≡˘⟨ +-assoc (B + PZ + G) (D0 + Pt) Ps ⟩
+            (B + PZ + G) + (D0 + Pt) + Ps    ≡˘⟨ cong (_+ Ps) (+-assoc (B + PZ + G) D0 Pt) ⟩
+            (B + PZ + G) + D0 + Pt + Ps      ≡⟨ cong (λ w → w + D0 + Pt + Ps) (swap-right B PZ G) ⟩
+            B + G + PZ + D0 + Pt + Ps        ≡⟨ cong (λ w → w + Pt + Ps) (swap-right (B + G) PZ D0) ⟩
+            B + G + D0 + PZ + Pt + Ps        ≡⟨ cong (_+ Ps) (swap-right (B + G + D0) PZ Pt) ⟩
+            B + G + D0 + Pt + PZ + Ps        ≡⟨ swap-right (B + G + D0 + Pt) PZ Ps ⟩
+            B + G + D0 + Pt + Ps + PZ        ≡⟨ cong (λ w → w + Ps + PZ) (swap-right (B + G) D0 Pt) ⟩
+            B + G + Pt + D0 + Ps + PZ        ≡⟨ cong (λ w → w + PZ) (swap-right (B + G + Pt) D0 Ps) ⟩
+            B + G + Pt + Ps + D0 + PZ        ≡⟨ cong (λ w → w + Ps + D0 + PZ) (swap-right B G Pt) ⟩
+            B + Pt + G + Ps + D0 + PZ        ≡⟨ cong (λ w → w + D0 + PZ) (swap-right (B + Pt) G Ps) ⟩
+            B + Pt + Ps + G + D0 + PZ        ≡⟨ +-assoc (B + Pt + Ps + G) D0 PZ ⟩
+            (B + Pt + Ps + G) + (D0 + PZ)    ∎
+          big : (A + Nt + Ns) + (D0 + PZ) ≡ (B + Pt + Ps + G) + (D0 + PZ)
+          big = begin
+            (A + Nt + Ns) + (D0 + PZ)     ≡⟨ cong (A + Nt + Ns +_) sf ⟩
+            (A + Nt + Ns) + (D2 + NZ)     ≡⟨ rearr-X ⟩
+            (A + NZ) + (Nt + Ns + D2)     ≡⟨ cong (_+ (Nt + Ns + D2)) bal ⟩
+            (B + PZ + G) + (Nt + Ns + D2) ≡⟨ cong ((B + PZ + G) +_) rearr-Y ⟩
+            (B + PZ + G) + (D2 + Nt + Ns) ≡˘⟨ cong ((B + PZ + G) +_) pn ⟩
+            (B + PZ + G) + (D0 + Pt + Ps) ≡⟨ rearr-Z ⟩
+            (B + Pt + Ps + G) + (D0 + PZ) ∎
+
+        -- The #1186 closed-form batch balance (cert deposits in the spec's closed
+        -- form, over `allDCerts tx` against the pre-batch registered-pool set).
+        closedEq : Ctop + Wtop + CsubW + refundCertDeposits pp (allDCerts tx)
+                 ≡ O + F + DN + DDtop + PsubDD
+                   + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx) + totGov
+        closedEq = UTXOW-batch-balance-coin utxoStep
+
+        -- The #1210 batch cert-deposit bridge, in ℕ form:
+        -- pre-batch deposits + new deposits ≡ post-batch deposits + refunds.
+        bridgeEq : D₀ + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx)
+                 ≡ D₂ + refundCertDeposits pp (allDCerts tx)
+        bridgeEq = batch-cert-deposits-bridge valid subStep entitiesStep
+
+        -- Convert the closed-form balance to the chain's two-level posPart/negPart
+        -- form, via `net-arith` fed the bridge (`bridgeEq`) and the two-level
+        -- deposit identity (`posneg`).
+        convert : Ctop + Wtop + CsubW + negPart dct + negPart dcs
+                ≡ O + F + DN + DDtop + posPart dct + PsubDD + posPart dcs + totGov
+        convert = begin
+          Ctop + Wtop + CsubW + negPart dct + negPart dcs
+            ≡⟨ net-arith (Ctop + Wtop + CsubW) (O + F + DN + DDtop + PsubDD) totGov
+                         (newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx))
+                         (refundCertDeposits pp (allDCerts tx))
+                         (posPart dct) (posPart dcs) (negPart dct) (negPart dcs) D₀ D₂
+                         closedEq bridgeEq posneg ⟩
+          O + F + DN + DDtop + PsubDD + posPart dct + posPart dcs + totGov
+            ≡⟨ cong (λ w → w + posPart dcs + totGov)
+                    (swap-right (O + F + DN + DDtop) PsubDD (posPart dct)) ⟩
+          O + F + DN + DDtop + posPart dct + PsubDD + posPart dcs + totGov
+            ∎
+
+        reshuffle-to-DD :
+            O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
+          ≡ O + F + DN + (DDtop + subDirectDepsCoin) + Psub + posPart dct + posPart dcs
+        reshuffle-to-DD = begin
+          O + F + DN + DDtop + posPart dct + (Psub + subDirectDepsCoin) + posPart dcs
+            ≡⟨ cong (_+ posPart dcs) (sym (+-assoc (O + F + DN + DDtop + posPart dct) Psub subDirectDepsCoin)) ⟩
+          O + F + DN + DDtop + posPart dct + Psub + subDirectDepsCoin + posPart dcs
+            ≡⟨ cong (_+ posPart dcs) (swap-right (O + F + DN + DDtop + posPart dct) Psub subDirectDepsCoin) ⟩
+          O + F + DN + DDtop + posPart dct + subDirectDepsCoin + Psub + posPart dcs
+            ≡⟨ cong (λ x → x + Psub + posPart dcs) (swap-right (O + F + DN + DDtop) (posPart dct) subDirectDepsCoin) ⟩
+          O + F + DN + DDtop + subDirectDepsCoin + posPart dct + Psub + posPart dcs
+            ≡⟨ cong (_+ posPart dcs) (swap-right (O + F + DN + DDtop + subDirectDepsCoin) (posPart dct) Psub) ⟩
+          O + F + DN + DDtop + subDirectDepsCoin + Psub + posPart dct + posPart dcs
+            ≡⟨ cong (λ x → x + Psub + posPart dct + posPart dcs) (+-assoc (O + F + DN) DDtop subDirectDepsCoin) ⟩
+          O + F + DN + (DDtop + subDirectDepsCoin) + Psub + posPart dct + posPart dcs
+            ∎
+```
+
+The main inner chain, showing LHS + E ≡ RHS + E:
+
+```agda
+      LHS+E≡RHS+E : U₀ + allWdrls + D₀ + E ≡ U₂ + allDirectDeps + D₂ + totGov + E
+      LHS+E≡RHS+E = begin
+        U₀ + allWdrls + D₀ + E
+          ≡⟨⟩
+        U₀ + allWdrls + D₀ + (Ctop + Psub + posPart dct + posPart dcs)
+          ≡⟨ arithmetic-1 U₀ allWdrls D₀ ⟩
+        U₀ + allWdrls + D₀ + Ctop + Psub + posPart dct + posPart dcs
+          ≡⟨ arithmetic-2 U₀ allWdrls D₀ ⟩
+        U₀ + Psub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
+          ≡⟨ cong (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
+                  (subst (λ u →   U₀ + Psub
+                              ≡ U₁ + sum (map (λ stx → cbalance (u ∣ SpendInputsOf stx))
+                                              (SubTransactionsOf tx)))
+                         (refl {x = UTxOOf (UTxOStateOf s)})
+                         (SUBLEDGERS-utxo-coin valid subStep)) ⟩
+        U₁ + Csub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
+          ≡⟨ cong (λ x → (U₁ + Csub) + allWdrls + x + Ctop) posneg ⟩
+        U₁ + Csub + allWdrls + (D₂ + negPart dct + negPart dcs) + Ctop
+          ≡⟨ arithmetic-3 U₁ Csub allWdrls ⟩
+        U₁ + (Ctop + allWdrls + Csub + negPart dct + negPart dcs) + D₂
+          ≡⟨ cong (λ x → U₁ + x + D₂) bat' ⟩
+        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs + totGov) + D₂
+          ≡⟨ mid-extract U₁ (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs) D₂ totGov ⟩
+        U₁ + (cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs) + D₂ + totGov
+          ≡⟨ cong (_+ totGov) (arithmetic-4 U₁ (cbalance (outs tx)) (TxFeesOf tx)) ⟩
+        U₁ + cbalance (outs tx) + TxFeesOf tx + DonationsOf tx + allDirectDeps + Psub + posPart dct + posPart dcs + D₂ + totGov
+          ≡⟨ cong (_+ totGov) (cong (λ x → x + allDirectDeps + Psub + posPart dct + posPart dcs + D₂) mech) ⟩
+        U₂ + Ctop + allDirectDeps + Psub + posPart dct + posPart dcs + D₂ + totGov
+          ≡⟨ cong (_+ totGov) (arithmetic-5 U₂ Ctop allDirectDeps) ⟩
+        U₂ + allDirectDeps + D₂ + Ctop + Psub + posPart dct + posPart dcs + totGov
+          ≡˘⟨ cong (_+ totGov) (arithmetic-1 U₂ allDirectDeps D₂) ⟩
+        U₂ + allDirectDeps + D₂ + E + totGov
+          ≡⟨ swap-right (U₂ + allDirectDeps + D₂) E totGov ⟩
+        U₂ + allDirectDeps + D₂ + totGov + E
+          ∎
+        where
+```
+
+The five `arithmetic-N` helpers are pure `+`-monoid rearrangements, each unfolded
+explicitly:
+
+```agda
+        arithmetic-1 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + (d + e + f + g) ≡ a + b + c + d + e + f + g
+        arithmetic-1 a b c {d}{e}{f}{g} = begin
+          a + b + c + (d + e + f + g)  ≡˘⟨ +-assoc (a + b + c) (d + e + f) g ⟩
+          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+          a + b + c + d + e + f + g    ∎
+
+        arithmetic-2 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + d + e + f + g ≡ a + e + b + (c + f + g) + d
+        arithmetic-2 a b c {d}{e}{f}{g} = begin
+          a + b + c + d + e + f + g    ≡⟨ cong (λ x → x + f + g) (swap-right (a + b + c) d e) ⟩
+          a + b + c + e + d + f + g    ≡⟨ cong (_+ g) (swap-right (a + b + c + e) d f) ⟩
+          a + b + c + e + f + d + g    ≡⟨ swap-right (a + b + c + e + f) d g ⟩
+          a + b + c + e + f + g + d    ≡⟨ cong (λ x → x + f + g + d) (swap-right (a + b) c e) ⟩
+          a + b + e + c + f + g + d    ≡⟨ cong (λ x → x + c + f + g + d) (swap-right a b e) ⟩
+          a + e + b + c + f + g + d    ≡⟨ cong (_+ d) reassoc-middle ⟩
+          a + e + b + (c + f + g) + d  ∎
+          where
+          reassoc-middle : a + e + b + c + f + g ≡ a + e + b + (c + f + g)
+          reassoc-middle = trans (+-assoc (a + e + b + c) f g)
+                                 (trans (+-assoc (a + e + b) c (f + g))
+                                        (cong (a + e + b +_) (sym (+-assoc c f g))))
+
+        arithmetic-3 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + (d + e + f) + g ≡ a + (g + c + b + e + f) + d
+        arithmetic-3 a b c {d}{e}{f}{g} = begin
+          a + b + c + (d + e + f) + g  ≡˘⟨ cong (_+ g) (+-assoc (a + b + c) (d + e) f) ⟩
+          a + b + c + (d + e) + f + g  ≡˘⟨ cong (λ x → x + f + g) (+-assoc (a + b + c) d e) ⟩
+          a + b + c + d + e + f + g    ≡⟨ swap-right (a + b + c + d + e) f g ⟩
+          a + b + c + d + e + g + f    ≡⟨ cong (_+ f) (swap-right (a + b + c + d) e g) ⟩
+          a + b + c + d + g + e + f    ≡⟨ cong (λ x → x + e + f) (swap-right (a + b + c) d g) ⟩
+          a + b + c + g + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + b) c g) ⟩
+          a + b + g + c + d + e + f    ≡⟨ cong (λ x → x + c + d + e + f) (swap-right a b g) ⟩
+          a + g + b + c + d + e + f    ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + g) b c) ⟩
+          a + g + c + b + d + e + f    ≡⟨ cong (_+ f) (swap-right (a + g + c + b) d e) ⟩
+          a + g + c + b + e + d + f    ≡⟨ swap-right (a + g + c + b + e) d f ⟩
+          a + g + c + b + e + f + d    ≡⟨ cong (λ x → x + b + e + f + d) (+-assoc a g c) ⟩
+          a + (g + c) + b + e + f + d  ≡⟨ cong (λ x → x + e + f + d) (+-assoc a (g + c) b) ⟩
+          a + (g + c + b) + e + f + d  ≡⟨ cong (λ x → x + f + d) (+-assoc a (g + c + b) e) ⟩
+          a + (g + c + b + e) + f + d  ≡⟨ cong (_+ d) (+-assoc a (g + c + b + e) f) ⟩
+          a + (g + c + b + e + f) + d  ∎
+
+        arithmetic-4 : ∀ a b c {d}{e}{f}{g}{h}{i}
+          → a + (b + c + d + e + f + g + h) + i ≡ a + b + c + d + e + f + g + h + i
+        arithmetic-4 a b c {d}{e}{f}{g}{h}{i} = cong (_+ i) $
+          begin
+          a + (b + c + d + e + f + g + h)  ≡˘⟨ +-assoc a _ h ⟩
+          a + (b + c + d + e + f + g) + h  ≡˘⟨ cong (_+ h) (+-assoc a _ g) ⟩
+          a + (b + c + d + e + f) + g + h  ≡˘⟨ cong (λ x → x + g + h) (+-assoc a _ f) ⟩
+          a + (b + c + d + e) + f + g + h  ≡˘⟨ cong (λ x → x + f + g + h) (+-assoc a _ e) ⟩
+          a + (b + c + d) + e + f + g + h  ≡˘⟨ cong (λ x → x + e + f + g + h) (+-assoc a _ d) ⟩
+          a + (b + c) + d + e + f + g + h  ≡˘⟨ cong (λ x → x + d + e + f + g + h) (+-assoc a b c) ⟩
+          a + b + c + d + e + f + g + h    ∎
+
+        arithmetic-5 : ∀ a b c {d}{e}{f}{g}
+          → a + b + c + d + e + f + g ≡ a + c + g + b + d + e + f
+        arithmetic-5 a b c {d}{e}{f}{g} = begin
+          a + b + c + d + e + f + g  ≡⟨ cong (λ x → x + d + e + f + g) (swap-right a b c) ⟩
+          a + c + b + d + e + f + g  ≡⟨ swap-right (a + c + b + d + e) f g ⟩
+          a + c + b + d + e + g + f  ≡⟨ cong (_+ f) (swap-right (a + c + b + d) e g) ⟩
+          a + c + b + d + g + e + f  ≡⟨ cong (λ x → x + e + f) (swap-right (a + c + b) d g) ⟩
+          a + c + b + g + d + e + f  ≡⟨ cong (λ x → x + d + e + f) (swap-right (a + c) b g) ⟩
+          a + c + g + b + d + e + f  ∎
+```
+
+Finally, `step-ii`: extract the actual equation from `LHS+E≡RHS+E` by cancelling `E`
+on both sides:
+
+```agda
+      step-ii : U₀ + allWdrls + D₀ + R₂ ≡ U₂ + allDirectDeps + D₂ + totGov + R₂
+      step-ii = cong (_+ R₂)
+                     (+-cancelʳ-≡ E (U₀ + allWdrls + D₀) (U₂ + allDirectDeps + D₂ + totGov)
+                                  LHS+E≡RHS+E)
+
+      -- The three LedgerState totals (UTxO + rewards + cert-deposits): the batch's
+      -- gov deposits surface as `+ totGov` on the produced side.
+      three-summand : U₀ + R₀ + D₀ ≡ U₂ + R₂ + D₂ + totGov
+      three-summand =
+        +-cancelʳ-≡ allDirectDeps (U₀ + R₀ + D₀) (U₂ + R₂ + D₂ + totGov)
+          (begin
+            U₀ + R₀ + D₀ + allDirectDeps           ≡⟨ step-i ⟩
+            U₀ + R₂ + allWdrls + D₀                ≡⟨ abcd-to-acdb U₀ R₂ allWdrls D₀ ⟩
+            U₀ + allWdrls + D₀ + R₂                ≡⟨ step-ii ⟩
+            U₂ + allDirectDeps + D₂ + totGov + R₂  ≡⟨ outer-rearr U₂ allDirectDeps D₂ totGov R₂ ⟩
+            U₂ + R₂ + D₂ + totGov + allDirectDeps  ∎)
+
+      -- Gov-deposit accounting: the batch's total gov deposits exactly account for
+      -- the growth from the initial gov state's deposit (G₀) to the final one (G').
+      gov-acc : totGov + G₀ ≡ G'
+      gov-acc =
+        begin
+          totGov + G₀                          ≡⟨ rearr3 topGov subGovSum G₀ ⟩
+          G₀ + subGovSum + topGov              ≡˘⟨ cong (_+ topGov) (SUBLEDGERS-gov-coin valid subStep) ⟩
+          coinFromGovDeposit govSt₁ + topGov   ≡˘⟨ govStep-eq ⟩
+          coinFromGovDeposit govSt₂            ≡˘⟨ rmOrphanDRepVotes-coinFromGovDeposit cs₂ govSt₂ ⟩
+          G'                                   ∎
+        where
+        govStep-eq : coinFromGovDeposit govSt₂ ≡ coinFromGovDeposit govSt₁ + topGov
+        govStep-eq = trans (GOVS-coinFromGovDeposit govStep)
+                           (cong (λ ps → coinFromGovDeposit govSt₁
+                                       + govProposalsDeposits (LedgerEnv.pparams Γ) ps)
+                                 (proposalsOf-Proposals+Votes tx))
+```

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -22,7 +22,7 @@ Recall (from `Ledger.lagda.md`) that `getCoin (LedgerState)` is
     + coinFromDeposits (CertStateOf s)
     + coinFromGovDeposit (GovStateOf s)
 
-This is the sum of UTxO coin, the cert-state rewards balance
+This is the sum of UTxO coin, the `CertState`{.AgdaRecord} rewards balance
 (`coinFromRewards`{.AgdaFunction}), the deposits from `DState`{.AgdaRecord},
 `PState`{.AgdaRecord}, and `GState`{.AgdaRecord} (`coinFromDeposits`{.AgdaFunction}),
 and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}); the two

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/PoV.lagda.md
@@ -9,8 +9,9 @@ This module proves the top-level preservation-of-value (PoV) theorem for the Dij
 `LEDGER`{.AgdaDatatype} rule.  If
 
 +  `Γ` is a ledger environment,
-+  `tx` is top-level transaction, and
-+  `s` and `s'` are ledger states related by `LEDGER`{.AgdaDatatype},
++  `tx` is a top-level transaction,
++  `s` and `s'` are ledger states related by `LEDGER`{.AgdaDatatype}, and
++  `s` satisfies `PoolDepositsRegistered`{.AgdaFunction} (see `Certs`{.AgdaModule}),
 
 then `getCoin s ≡ getCoin s'`.
 
@@ -24,56 +25,20 @@ Recall (from `Ledger.lagda.md`) that `getCoin (LedgerState)` is
 This is the sum of UTxO coin, the cert-state rewards balance
 (`coinFromRewards`{.AgdaFunction}), the deposits from `DState`{.AgdaRecord},
 `PState`{.AgdaRecord}, and `GState`{.AgdaRecord} (`coinFromDeposits`{.AgdaFunction}),
-and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}).
+and the governance-action deposits (`coinFromGovDeposit`{.AgdaFunction}); the two
+middle summands are exactly `getCoin (CertStateOf s)`.
 
-Note `getCoin (CertState)` itself now sums the rewards balance *and* the deposit pots
-(`coinFromRewards + coinFromDeposits`), so the two middle summands are exactly
-`getCoin (CertStateOf s)`.
+The `LEDGER-V` chain accounts for all four summands.  The cert deposits cancel via
+the direct-deposit trick (see *Proof Strategy*), and the gov-deposit growth
+`G' − G₀` is matched against the produced-side `totGov` (the `gov-acc` lemma, from
+`SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
 
-`getCoin` on a `LedgerState` has the four summands above — UTxO coin, rewards
-balance, the cert-deposit pots (`coinFromDeposits`), and the gov-action deposits
-(`coinFromGovDeposit`) — and the `LEDGER-V` chain accounts for all four.  The cert
-deposits cancel via the direct-deposit trick (see *Proof Strategy*), and the
-gov-deposit growth `G' − G₀` is matched against the produced-side `totGov` (the
-`gov-acc` lemma, from `SUBLEDGERS-gov-coin` + `GOVS-coinFromGovDeposit`).
-
-??? note "**Status: complete**"
-
-    `LEDGER-pov`{.AgdaFunction} typechecks end-to-end under `--safe` (no
-    postulates or holes).  Following the top-down plan, this module proves only the
-    top-level `LEDGER` preservation-of-value statement and leaves the supporting facts
-    as *module parameters*, discharged downstream:
-
-    +  **Certs-PoV** (`CERTS-pov`, `batch-cert-deposits-bridge`).
-
-    +  **Utxo/Utxow-PoV** (`utxow-pov-invalid`, `UTXOW-V-mechanical`,
-       `UTXOW-batch-balance-coin`, and the UTxO algebra `balance-∪`, `split-balance`,
-       `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`, etc.).
-
-       `UTXOW-batch-balance-coin` is the coin projection of the spec's
-       `consumedBatch ≡ producedBatch` premise, with the produced-side
-       `govProposalsDeposits` collected into a single trailing `totGov` term.
-       Its cert-deposit summands are obtained from `refundCertDeposits` and
-       `newCertDeposits` over `allDCerts tx`, against the pre-batch registered-pool
-       set, keeping it a pure UTxO obligation; `bat'` converts these to the chain's
-       top/sub two-level form using the `batch-cert-deposits-bridge` and
-       `posNeg-deposits`.
-
-    +  **Gov-deposit accounting** (`rmOrphanDRepVotes-coinFromGovDeposit`,
-       `GOVS-coinFromGovDeposit`), to be supplied by a future `Gov.Properties.PoV`.
-
-    +  **No-truncation bounds** (`ENTITIES-wdrls-bounded`, `SUBENTITIES-wdrls-bounded`).
-
-       Each withdrawal amount is bounded by the account's balance in the input state of
-       the `ENTITIES`/`SUBENTITIES` step that consumes it.
-
-       **N.B.**  The premises of the spec transition rules bound withdrawals only
-       against the *pre-batch* snapshot `rewards₀` (except top-level legacy mode,
-       which forces exact-balance withdrawals), which does not by itself bound them
-       against the input state of a later step in the batch. This is the
-       phantom-withdrawal gap.[^1] As such, these module parameters should be
-       discharged in the follow-up to that discussion, either by spec rule premises
-       or by a batch-threading invariant.
+The `PoolDepositsRegistered`{.AgdaFunction} hypothesis is necessary, not an artifact
+of the proof: the batch balance charges `newCertDeposits`{.AgdaFunction} against the
+registered-pool set, while `POOL-reg`{.AgdaInductiveConstructor}'s left-biased update
+silently keeps a stale entry for an unregistered pool; at a state with such an entry,
+a pool registration destroys the charged deposit and the theorem is false.  On-chain
+states satisfy the hypothesis by construction.
 
 ## Proof Strategy
 
@@ -84,21 +49,24 @@ The Dijkstra `LEDGER-pov`{.AgdaFunction} does not decompose into independent
 may individually transfer value between UTxO and CertState without local balancing.
 
 Instead, the `LEDGER-V` proof is a single equational chain at the
-`LedgerState`{.AgdaRecord} level, with the cancellation of total direct deposits as
-the central trick — direct-deposit value appears both on the UTxO side (via
+`LedgerState`{.AgdaRecord} level, and cancellation of the *total* direct deposits is
+the key to the proof.  Direct-deposit value appears both on the UTxO side (via
 `producedBatch`) and on the CertState side (via `applyDirectDeposits` inside
 `ENTITIES`) and cancels in the total.
 
-Concretely, the proof uses three helper lemmas.
+Concretely, the proof composes four inductions over the `SUBLEDGERS`{.AgdaDatatype}
+reflexive-transitive closure, plus one arithmetic identity.
 
-+  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** inducts over the `SUBLEDGERS`{.AgdaDatatype}
-   reflexive-transitive closure, threading the per-`SUBUTXOW` coin equation
-   (`subutxow-step-coin`).
-+  **`SUBLEDGERS-certs-pov`{.AgdaFunction}** is parallel induction over
-   `SUBLEDGERS`{.AgdaDatatype}, composing per-sub-transaction
-   `SUBENTITIES-pov`{.AgdaFunction} invocations.
-+  **`posNeg-deposits`{.AgdaFunction}** equationally relates the pre-/post-batch deposit
-   totals to the `posPart`/`negPart` of `calculateDepositsChange`.
++  **`SUBLEDGERS-utxo-coin`{.AgdaFunction}** inducts over the subtransaction list,
+   applying the per-`SUBUTXOW` coin equation (`subutxow-step-coin`) at each step.
++  **`SUBLEDGERS-rewards-pov`{.AgdaFunction}** composes per-sub-transaction
+   `SUBENTITIES-pov`{.AgdaFunction} invocations (the rewards flow).
++  **`SUBLEDGERS-deposits`{.AgdaFunction}** (with `SUBLEDGERS-registered`{.AgdaFunction})
+   telescopes the per-step closed-form deposit accounting into the batch-wide
+   equation consumed by `bat'`.
++  **`SUBLEDGERS-gov-coin`{.AgdaFunction}** accumulates the per-`GOVS` gov-deposit growth.
++  **`posNeg-deposits`{.AgdaFunction}** relates the pre-/post-batch deposit totals to
+   the `posPart`/`negPart` of `calculateDepositsChange`.
 
 The `LEDGER-I` case is straightforward; `certState` and `govSt` are unchanged,
 `SUBLEDGERS` is a no-op, and only the `UTXOW` step affects `getCoin`, which it
@@ -122,6 +90,7 @@ open import Data.Nat.Properties
 open import Data.Nat.Tactic.RingSolver using (solve-∀; solve)
 open import Data.Integer using (ℤ; _⊖_)
 open import Data.Integer.Properties using ([1+m]⊖[1+n]≡m⊖n)
+open import Data.List.Properties using (++-assoc)
 open import Data.List.Relation.Unary.Unique.Propositional using (Unique)
 
 open import Ledger.Prelude
@@ -136,10 +105,6 @@ open import Ledger.Dijkstra.Specification.Utxow txs abs
 
 open import Ledger.Dijkstra.Specification.Entities.Properties.PoV txs
 
--- We will import the following once the UTXO/UTXOW PoV proofs land:
--- open import Ledger.Dijkstra.Specification.Utxo.Properties.PoV txs abs
--- open import Ledger.Dijkstra.Specification.Utxow.Properties.PoV txs abs
-
 open import Interface.STS
 
 open RewardAddress
@@ -152,25 +117,24 @@ instance
 
 ## The `LEDGER-PoV` module
 
-`LEDGER-pov`{.AgdaFunction} currently depends on module parameters from the following
-groups:
+The supporting facts about the auxiliary transition systems are module parameters,
+in five groups:
 
-+  the three set/map identities from `ApplyToRewards-PoV`{.AgdaModule}
++  the set/map identities consumed by `ApplyToRewards-PoV`{.AgdaModule}
    (`∪ˡ-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique`);
-+  the UTxO arithmetic / freshness assumptions and batch-wide invariants
++  the UTxO facts: coin equations for the `UTXOW`/`SUBUTXOW` steps and batch-wide
+   freshness/disjointness invariants
    (`balance-∪`, `split-balance`, `noMintTx`, `noMintSubTx`, `outs-disjoint`,
    `subutxow-step-coin`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id`,
    `utxow-pov-invalid`, `UTXOW-V-mechanical`, `UTXOW-batch-balance-coin`);
-+  the Certs facts (`CERTS-pov`, `batch-cert-deposits-bridge`);
++  the Certs facts: value accounting for a single `CERTS`{.AgdaDatatype} run
+   (`CERTS-rewards-pov`, `CERTS-deposits-pov`, `CERTS-deposits-registered`,
+   `CERTS-new-thread`, `refundCertDeposits-++`);
 +  the governance-deposit facts (`rmOrphanDRepVotes-coinFromGovDeposit`,
-   `GOVS-coinFromGovDeposit`) from a future `Gov.Properties.PoV`;
+   `GOVS-coinFromGovDeposit`);
 +  the no-truncation withdrawal bounds (`ENTITIES-wdrls-bounded`,
-   `SUBENTITIES-wdrls-bounded`), the phantom-withdrawal gap,[^1]
-   to be discharged by a spec-side premise or a batch-threading invariant.
-
-All are stated with detailed provenance notes in comments and are to be discharged in
-follow-up work.  This parameter list is the frozen interface between this proof and
-the follow-ups.
+   `SUBENTITIES-wdrls-bounded`); see `Entities.Properties.PoV`{.AgdaModule} for why
+   these are not consequences of the rules' own premises.
 
 ```agda
 noMintingSubTxs : TopLevelTx → Type
@@ -237,37 +201,41 @@ module LEDGER-PoV
       → subΓ ⊢ s ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoSt₁ , govSt₁ , certState₁ ⟧ˡ
       → TxIdOf tx ∉ mapˢ proj₁ (dom (UTxOOf utxoSt₁)) )
 
-  -- Certs-PoV stubs to be discharged in follow-up PR
-  ( CERTS-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+  -- Value accounting for a single CERTS run (consumed via `ENTITIES-PoV`):
+  -- rewards preservation; closed-form deposit accounting (which needs the
+  -- pool-deposit registration invariant, see `PoolDepositsRegistered` in `Certs`);
+  -- preservation of that invariant; and the `newCertDeposits` split at a CERTS-run
+  -- boundary, against the run's final pool set — what lets per-step accounting
+  -- compose across a batch.
+  ( CERTS-rewards-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
       → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s' → coinFromRewards s ≡ coinFromRewards s' )
 
-  -- Batch-wide cert-deposit bridge (discharged later).  The closed-form
-  -- deposit accounting over *all* batch certs balances against actual
-  -- `coinFromDeposits` evolution from pre-batch cert state `CertStateOf ls₀` to
-  -- post-`ENTITIES` cert state `cs₂`:
-  --
-  --     D₀ + newCertDeposits ≡ D₂ + refundCertDeposits
-  --
-  -- The premises pin `cs₂` to the batch's cert evolution (`SUBLEDGERS` over sub-txs,
-  -- then top-level `ENTITIES`); composing per-step cert bridges across the batch is
-  -- follow-up (CERTS PoV) work.
-  ( batch-cert-deposits-bridge :
-      {Γsub : SubLedgerEnv} {ls₀ ls₁ : LedgerState} {Γe : EntitiesEnv} {cs₂ : CertState}
-      → SubLedgerEnv.isTopLevelValid Γsub ≡ true
-      → Γsub ⊢ ls₀ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ls₁
-      → Γe ⊢ CertStateOf ls₁ ⇀⦇ tx ,ENTITIES⦈ cs₂
-      → coinFromDeposits (CertStateOf ls₀)
-          + newCertDeposits (PParamsOf Γe) (dom (PoolsOf (CertStateOf ls₀))) (allDCerts tx)
-        ≡ coinFromDeposits cs₂
-          + refundCertDeposits (PParamsOf Γe) (allDCerts tx) )
+  ( CERTS-deposits-pov : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → coinFromDeposits s  + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+      ≡ coinFromDeposits s' + refundCertDeposits (PParamsOf Γ) dCerts )
 
-  -- No-truncation withdrawal bounds (the phantom-withdrawal gap; see review of #1256).
-  -- `applyWithdrawals` subtracts with `_∸_`, so ENTITIES/SUBENTITIES value-flow
-  -- equations need each withdrawal amount bounded by account's balance in the
-  -- *input* state of the step that consumes it.  Premises bound withdrawals only
-  -- against the pre-batch `rewards₀` (except top-level legacy mode), so these facts
-  -- are assumed here, to be discharged by a spec-side premise or a batch-threading
-  -- invariant in follow-up to that discussion.
+  ( CERTS-deposits-registered : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → PoolDepositsRegistered s
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → PoolDepositsRegistered s' )
+
+  ( CERTS-new-thread : {Γ : CertEnv} {s s' : CertState} {dCerts : List DCert}
+      → Γ ⊢ s ⇀⦇ dCerts ,CERTS⦈ s'
+      → (ys : List DCert)
+      → newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) (dCerts ++ ys)
+      ≡ newCertDeposits (PParamsOf Γ) (dom (PoolsOf s)) dCerts
+        + newCertDeposits (PParamsOf Γ) (dom (PoolsOf s')) ys )
+
+  -- `refundCertDeposits` is a plain fold over the certificate list; it distributes
+  -- over concatenation.
+  ( refundCertDeposits-++ : (pp' : PParams) (xs ys : List DCert)
+      → refundCertDeposits pp' (xs ++ ys)
+      ≡ refundCertDeposits pp' xs + refundCertDeposits pp' ys )
+
+  -- No-truncation withdrawal bounds; see `Entities.Properties.PoV` for why these
+  -- are hypotheses rather than consequences of the rules' own premises.
   ( ENTITIES-wdrls-bounded : {Γe : EntitiesEnv} {cs cs' : CertState}
       → Γe ⊢ cs ⇀⦇ tx ,ENTITIES⦈ cs'
       → ∀[ (addr , amt) ∈ (WithdrawalsOf tx) ˢ ]
@@ -277,9 +245,9 @@ module LEDGER-PoV
       → ∀[ (addr , amt) ∈ (WithdrawalsOf stx) ˢ ]
           amt ≤ maybe id 0 (lookupᵐ? (RewardsOf cs) (stake addr)) )
 
-  -- Governance-deposit accounting (to be discharged by future `Gov.Properties.PoV`).
-  -- `rmOrphanDRepVotes` only rewrites `votes.gvDRep`, never `GovActionState.deposit`,
-  -- so it leaves `coinFromGovDeposit` unchanged.
+  -- Governance-deposit accounting.  `rmOrphanDRepVotes` only rewrites
+  -- `votes.gvDRep`, never `GovActionState.deposit`, so it leaves
+  -- `coinFromGovDeposit` unchanged.
   ( rmOrphanDRepVotes-coinFromGovDeposit :
       (cs : CertState) (g : GovState)
       → coinFromGovDeposit (rmOrphanDRepVotes cs g) ≡ coinFromGovDeposit g )
@@ -292,7 +260,7 @@ module LEDGER-PoV
       → coinFromGovDeposit govSt′
         ≡ coinFromGovDeposit govSt + govProposalsDeposits (PParamsOf Γ) (proposalsOf props) )
 
-  -- Utxo/Utxow-PoV facts (discharged later) --
+  -- Utxo/Utxow-PoV facts --
 
   -- Invalid top-level tx: the UTXOW step preserves UTxO coin.
   ( utxow-pov-invalid : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
@@ -308,11 +276,11 @@ module LEDGER-PoV
         ≡ getCoin s₁ + cbalance (UTxOOf s₀ ∣ SpendInputsOf tx) )
 
   -- Closed-form coin projection of the batch balance `consumedBatch ≡ producedBatch`
-  -- (discharged by UTXO/UTXOW PoV; minted terms drop by `noMintTx`/`noMintSubTx`).
-  -- cert-deposit summands are in spec's *closed form*:
-  -- `refundCertDeposits`/`newCertDeposits` over `allDCerts tx`, with pool set drawn
-  -- from environment's pre-batch `pools₀`, keeping this a pure UTxO obligation.
-  -- governance-deposit summands sit on produced side, matching `producedTx`.
+  -- (the minted terms drop by `noMintTx`/`noMintSubTx`).  The cert-deposit summands
+  -- are in the spec's *closed form* — `refundCertDeposits`/`newCertDeposits` over
+  -- `allDCerts tx`, with the pool set drawn from the environment's pre-batch
+  -- `pools₀` — keeping this a pure UTxO obligation.  The governance-deposit summands
+  -- sit on the produced side, matching `producedTx`.
   ( UTXOW-batch-balance-coin : {Γ' : UTxOEnv} {s₀ s₁ : UTxOState}
       → Γ' ⊢ s₀ ⇀⦇ tx ,UTXOW⦈ s₁
       → cbalance (UTxOOf Γ' ∣ SpendInputsOf tx) + getCoin (WithdrawalsOf tx)
@@ -328,10 +296,9 @@ module LEDGER-PoV
                        (SubTransactionsOf tx)) ) )
   where
 
-  open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique CERTS-pov
-
-  -- When UTXOW PoV proof lands, we'll uncomment the following line, adding appropriate args.
-  -- open UTXOW-PoV ...
+  open ENTITIES-PoV ∪ˡ-lookup-preserve sum-map-proj₂≡getCoin setToList-Unique
+                    CERTS-rewards-pov CERTS-deposits-pov CERTS-deposits-registered
+                    CERTS-new-thread
 ```
 
 ## Small arithmetic helpers
@@ -341,7 +308,7 @@ ring solver over the commutative semiring of naturals (`Data.Nat.Tactic.RingSolv
 `solve-∀`{.AgdaMacro} proves a closed, universally quantified equation outright, and
 the in-context `solve`{.AgdaMacro} (applied to the list of atoms) proves an equation
 whose variables are already in scope; this is needed where a lemma's trailing
-variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binders.[^2]
+variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binders.[^1]
 
 ```agda
   swap-right : ∀ a b c → a +ᴺ b +ᴺ c ≡ a +ᴺ c +ᴺ b
@@ -360,8 +327,9 @@ variables are implicit, since `solve-∀`{.AgdaMacro} only handles visible binde
 The cert-deposit change is the integer delta of `coinFromDeposits`{.AgdaFunction} at
 the top and sub levels.  The `LEDGER-V` chain tracks the deposit pots in this
 two-level `posPart`/`negPart` form; `bat'` obtains it from the closed-form
-`UTXOW-batch-balance-coin`{.AgdaFunction} parameter via the
-`batch-cert-deposits-bridge`{.AgdaFunction} and `posNeg-deposits`{.AgdaFunction}.
+`UTXOW-batch-balance-coin`{.AgdaFunction} parameter via the batch-wide deposit
+accounting (`bridgeEq`, composed by `SUBLEDGERS-deposits`{.AgdaFunction}) and
+`posNeg-deposits`{.AgdaFunction}.
 
 ```agda
   DepositsChange : Type
@@ -421,8 +389,8 @@ same quantity (the sum of deposits across the batch), just rephrased to expose
 
 ## `SUBLEDGERS-utxo-coin`
 
-Induct over the `SUBLEDGERS` reflexive-transitive closure, threading the
-per-`SUBUTXOW` coin equation:
+Induct over the `SUBLEDGERS` reflexive-transitive closure, applying the
+per-`SUBUTXOW` coin equation at each step:
 
 ```agda
   SUBLEDGERS-utxo-coin :
@@ -477,7 +445,7 @@ per-`SUBUTXOW` coin equation:
     ih = SUBLEDGERS-utxo-coin isV rest
 ```
 
-## `SUBLEDGERS-certs-pov`
+## `SUBLEDGERS-rewards-pov`
 
 Parallel induction over `SUBLEDGERS`, composing per-sub-transaction `SUBENTITIES-pov`
 invocations.  The `NetworkId` witnesses and domain conditions are premises of the
@@ -487,7 +455,7 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
 ```agda
   open SubLedgerEnv
 
-  SUBLEDGERS-certs-pov :
+  SUBLEDGERS-rewards-pov :
     {Γ : SubLedgerEnv}
     {s₀ s₁ : LedgerState}
     {stxs : List SubLevelTx}
@@ -496,12 +464,12 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     →  coinFromRewards (CertStateOf s₀) + sum (map ddwl stxs)
        ≡ coinFromRewards (CertStateOf s₁) + sum (map wdrwl stxs)
 
-  SUBLEDGERS-certs-pov _ (BS-base Id-nop) = refl
+  SUBLEDGERS-rewards-pov _ (BS-base Id-nop) = refl
 
-  SUBLEDGERS-certs-pov isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
+  SUBLEDGERS-rewards-pov isV (BS-ind (SUBLEDGER-I (isI , _)) _) =
     ⊥-elim (case trans (sym isV) isI of λ ())
 
-  SUBLEDGERS-certs-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+  SUBLEDGERS-rewards-pov {Γ} isV (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
     (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) =
     begin
       coinFromRewards (CertStateOf s₀) + (getCoin (DirectDepositsOf stx) + sum (map ddwl sigs))
@@ -522,7 +490,110 @@ invocations.  The `NetworkId` witnesses and domain conditions are premises of th
     where
     ih : coinFromRewards (CertStateOf s₁) + sum (map ddwl sigs)
          ≡ coinFromRewards (CertStateOf sₙ) + sum (map wdrwl sigs)
-    ih = SUBLEDGERS-certs-pov isV rest
+    ih = SUBLEDGERS-rewards-pov isV rest
+```
+
+## `SUBLEDGERS-deposits`
+
+Composing the per-step deposit accounting across the batch.
+`refund-concatMap`{.AgdaFunction} distributes `refundCertDeposits`{.AgdaFunction}
+over the batch's certificate lists; `SUBLEDGERS-registered`{.AgdaFunction} threads
+the pool-deposit registration invariant; and `SUBLEDGERS-deposits`{.AgdaFunction}
+telescopes the per-step closed forms, using
+`SUBENTITIES-new-thread`{.AgdaFunction} to split `newCertDeposits`{.AgdaFunction} at
+each step boundary — necessary because the pool set a `regpool` is charged against
+evolves through the batch.  The trailing certificate list `ys`{.AgdaBound}
+generalises the statement so the induction goes through; the `LEDGER-V` proof
+instantiates it with the top-level transaction's certificates.
+
+```agda
+  refund-concatMap : (pp' : PParams) (stxs : List SubLevelTx)
+    → refundCertDeposits pp' (concatMap DCertsOf stxs)
+    ≡ sum (map (refundCertDeposits pp' ∘ DCertsOf) stxs)
+  refund-concatMap pp' []           = refl
+  refund-concatMap pp' (stx ∷ stxs) =
+    trans (refundCertDeposits-++ pp' (DCertsOf stx) (concatMap DCertsOf stxs))
+          (cong (refundCertDeposits pp' (DCertsOf stx) +_) (refund-concatMap pp' stxs))
+
+  SUBLEDGERS-registered :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
+    → Γ .isTopLevelValid ≡ true
+    → PoolDepositsRegistered (CertStateOf s₀)
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → PoolDepositsRegistered (CertStateOf s₁)
+
+  SUBLEDGERS-registered _ registered (BS-base Id-nop) = registered
+
+  SUBLEDGERS-registered isV _ (BS-ind (SUBLEDGER-I (isI , _)) _) =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-registered isV registered (BS-ind (SUBLEDGER-V (_ , _ , entitiesStep , _)) rest) =
+    SUBLEDGERS-registered isV (SUBENTITIES-deposits-registered registered entitiesStep) rest
+
+  SUBLEDGERS-deposits :
+    {Γ : SubLedgerEnv}
+    {s₀ s₁ : LedgerState}
+    {stxs : List SubLevelTx}
+    → Γ .isTopLevelValid ≡ true
+    → PoolDepositsRegistered (CertStateOf s₀)
+    → Γ ⊢ s₀ ⇀⦇ stxs ,SUBLEDGERS⦈ s₁
+    → (ys : List DCert)
+    → coinFromDeposits (CertStateOf s₀)
+        + newCertDeposits (Γ .pparams) (dom (PoolsOf (CertStateOf s₀))) (concatMap DCertsOf stxs ++ ys)
+    ≡ coinFromDeposits (CertStateOf s₁)
+        + sum (map (refundCertDeposits (Γ .pparams) ∘ DCertsOf) stxs)
+        + newCertDeposits (Γ .pparams) (dom (PoolsOf (CertStateOf s₁))) ys
+
+  SUBLEDGERS-deposits {Γ} {s₀ = s₀} _ _ (BS-base Id-nop) ys =
+    cong (_+ newCertDeposits (Γ .pparams) (dom (PoolsOf (CertStateOf s₀))) ys)
+         (sym (+-identityʳ (coinFromDeposits (CertStateOf s₀))))
+
+  SUBLEDGERS-deposits isV _ (BS-ind (SUBLEDGER-I (isI , _)) _) ys =
+    ⊥-elim (case trans (sym isV) isI of λ ())
+
+  SUBLEDGERS-deposits {Γ} isV registered (BS-ind {s = s₀} {s' = s₁} {sigs} {s'' = sₙ}
+    (SUBLEDGER-V {stx = stx} (_ , _ , entitiesStep , _)) rest) ys =
+    begin
+      D₀ + new P₀ ((DCertsOf stx ++ concatMap DCertsOf sigs) ++ ys)
+        ≡⟨ cong (λ l → D₀ + new P₀ l) (++-assoc (DCertsOf stx) (concatMap DCertsOf sigs) ys) ⟩
+      D₀ + new P₀ (DCertsOf stx ++ (concatMap DCertsOf sigs ++ ys))
+        ≡⟨ cong (D₀ +_) (SUBENTITIES-new-thread entitiesStep (concatMap DCertsOf sigs ++ ys)) ⟩
+      D₀ + (new P₀ (DCertsOf stx) + new P₁ (concatMap DCertsOf sigs ++ ys))
+        ≡˘⟨ +-assoc D₀ (new P₀ (DCertsOf stx)) (new P₁ (concatMap DCertsOf sigs ++ ys)) ⟩
+      D₀ + new P₀ (DCertsOf stx) + new P₁ (concatMap DCertsOf sigs ++ ys)
+        ≡⟨ cong (_+ new P₁ (concatMap DCertsOf sigs ++ ys))
+                (SUBENTITIES-deposits-pov registered entitiesStep) ⟩
+      D₁ + refund₀ + new P₁ (concatMap DCertsOf sigs ++ ys)
+        ≡⟨ swap-right D₁ refund₀ (new P₁ (concatMap DCertsOf sigs ++ ys)) ⟩
+      D₁ + new P₁ (concatMap DCertsOf sigs ++ ys) + refund₀
+        ≡⟨ cong (_+ refund₀) (SUBLEDGERS-deposits isV registered₁ rest ys) ⟩
+      Dₙ + refundSum + new Pₙ ys + refund₀
+        ≡⟨ resh Dₙ refundSum (new Pₙ ys) refund₀ ⟩
+      Dₙ + (refund₀ + refundSum) + new Pₙ ys
+        ∎
+    where
+    new : ℙ KeyHash → List DCert → Coin
+    new = newCertDeposits (Γ .pparams)
+
+    D₀ D₁ Dₙ refund₀ refundSum : Coin
+    D₀ = coinFromDeposits (CertStateOf s₀)
+    D₁ = coinFromDeposits (CertStateOf s₁)
+    Dₙ = coinFromDeposits (CertStateOf sₙ)
+    refund₀   = refundCertDeposits (Γ .pparams) (DCertsOf stx)
+    refundSum = sum (map (refundCertDeposits (Γ .pparams) ∘ DCertsOf) sigs)
+
+    P₀ P₁ Pₙ : ℙ KeyHash
+    P₀ = dom (PoolsOf (CertStateOf s₀))
+    P₁ = dom (PoolsOf (CertStateOf s₁))
+    Pₙ = dom (PoolsOf (CertStateOf sₙ))
+
+    registered₁ : PoolDepositsRegistered (CertStateOf s₁)
+    registered₁ = SUBENTITIES-deposits-registered registered entitiesStep
+
+    resh : ∀ a b c d → a +ᴺ b +ᴺ c +ᴺ d ≡ a +ᴺ (d +ᴺ b) +ᴺ c
+    resh = solve-∀
 ```
 
 ## `SUBLEDGERS-gov-coin`
@@ -593,8 +664,12 @@ premise).  `SUBLEDGER-I` is ruled out by the top-level validity flag.
 
 ## `LEDGER-pov`
 
+The pool-deposit registration hypothesis concerns the initial state only; it is
+threaded through the batch by `SUBLEDGERS-registered`{.AgdaFunction} where needed.
+
 ```agda
   LEDGER-pov : {Γ : LedgerEnv} {s s' : LedgerState}
+    → PoolDepositsRegistered (CertStateOf s)
     → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
 ```
 
@@ -605,7 +680,7 @@ are unchanged.  Only the `UTXOW` step affects `getCoin`, and it preserves it via
 `utxow-pov-invalid`.
 
 ```agda
-  LEDGER-pov {Γ} {s} (LEDGER-I (invalid , _ , utxoStep)) =
+  LEDGER-pov {Γ} {s} _ (LEDGER-I (invalid , _ , utxoStep)) =
     cong  ( λ u → u  + coinFromRewards (CertStateOf s) + coinFromDeposits (CertStateOf s)
                      + coinFromGovDeposit (GovStateOf s) )
           ( utxow-pov-invalid utxoStep invalid )
@@ -634,7 +709,7 @@ The body assembles the four-summand goal from two `where`-lemmas.
 +  **`gov-acc`**: `totGov+G₀ ≡ G'`, the gov-deposit accounting.
 
 ```agda
-  LEDGER-pov {Γ} {s}
+  LEDGER-pov {Γ} {s} registered₀
     (LEDGER-V {utxoState₁ = us₁} {govState₁ = govSt₁} {certState₁ = cs₁}
               {certState₂ = cs₂} {govState₂ = govSt₂} {utxoState₂ = us₂}
               (valid , subStep , entitiesStep , govStep , utxoStep)) =
@@ -734,7 +809,7 @@ itself; the no-truncation bound comes from `ENTITIES-wdrls-bounded`.)
           coinFromRewards (CertStateOf s) + (subDirectDepsCoin + getCoin (DirectDepositsOf tx))
             ≡˘⟨ +-assoc (coinFromRewards (CertStateOf s)) subDirectDepsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards (CertStateOf s) + subDirectDepsCoin + getCoin (DirectDepositsOf tx)
-            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx)) (SUBLEDGERS-certs-pov valid subStep) ⟩
+            ≡⟨ cong (_+ getCoin (DirectDepositsOf tx)) (SUBLEDGERS-rewards-pov valid subStep) ⟩
           coinFromRewards cs₁ + subWdrlsCoin + getCoin (DirectDepositsOf tx)
             ≡⟨ swap-right (coinFromRewards cs₁) subWdrlsCoin (getCoin (DirectDepositsOf tx)) ⟩
           coinFromRewards cs₁ + getCoin (DirectDepositsOf tx) + subWdrlsCoin
@@ -865,18 +940,53 @@ The batch balance, rephrased to expose direct deposits and bring withdrawals tog
             (B + PZ + G) + (D0 + Pt + Ps) ≡⟨ rearr-Z ⟩
             (B + Pt + Ps + G) + (D0 + PZ) ∎
 
-        -- The #1186 closed-form batch balance (cert deposits in the spec's closed
-        -- form, over `allDCerts tx` against the pre-batch registered-pool set).
+        -- The closed-form batch balance (cert deposits in the spec's closed form,
+        -- over `allDCerts tx` against the pre-batch registered-pool set).
         closedEq : Ctop + Wtop + CsubW + refundCertDeposits pp (allDCerts tx)
                  ≡ O + F + DN + DDtop + PsubDD
                    + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx) + totGov
         closedEq = UTXOW-batch-balance-coin utxoStep
 
-        -- The #1210 batch cert-deposit bridge, in ℕ form:
-        -- pre-batch deposits + new deposits ≡ post-batch deposits + refunds.
+        -- Batch-wide cert-deposit accounting, in ℕ form: pre-batch deposits + new
+        -- deposits ≡ post-batch deposits + refunds.  Composed from the per-step
+        -- SUBENTITIES/ENTITIES deposit equations: `SUBLEDGERS-deposits` telescopes
+        -- the sub-transactions (leaving the top-level certificates as the trailing
+        -- list), `ENTITIES-deposits-pov` accounts for the top-level step, and the
+        -- refunds recombine via `refund-concatMap`/`refundCertDeposits-++`.
         bridgeEq : D₀ + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx)
                  ≡ D₂ + refundCertDeposits pp (allDCerts tx)
-        bridgeEq = batch-cert-deposits-bridge valid subStep entitiesStep
+        bridgeEq = begin
+          D₀ + newCertDeposits pp (dom (PoolsOf (CertStateOf s))) (allDCerts tx)
+            ≡⟨ SUBLEDGERS-deposits valid registered₀ subStep (DCertsOf tx) ⟩
+          D₁' + refundSubs + newCertDeposits pp P₁ (DCertsOf tx)
+            ≡⟨ swap-right D₁' refundSubs (newCertDeposits pp P₁ (DCertsOf tx)) ⟩
+          D₁' + newCertDeposits pp P₁ (DCertsOf tx) + refundSubs
+            ≡⟨ cong (_+ refundSubs) (ENTITIES-deposits-pov registered₁ entitiesStep) ⟩
+          D₂ + refundCertDeposits pp (DCertsOf tx) + refundSubs
+            ≡⟨ swap-right D₂ (refundCertDeposits pp (DCertsOf tx)) refundSubs ⟩
+          D₂ + refundSubs + refundCertDeposits pp (DCertsOf tx)
+            ≡˘⟨ cong (λ x → D₂ + x + refundCertDeposits pp (DCertsOf tx))
+                     (refund-concatMap pp (SubTransactionsOf tx)) ⟩
+          D₂ + refundCertDeposits pp (concatMap DCertsOf (SubTransactionsOf tx))
+             + refundCertDeposits pp (DCertsOf tx)
+            ≡⟨ +-assoc D₂ (refundCertDeposits pp (concatMap DCertsOf (SubTransactionsOf tx)))
+                          (refundCertDeposits pp (DCertsOf tx)) ⟩
+          D₂ + ( refundCertDeposits pp (concatMap DCertsOf (SubTransactionsOf tx))
+               + refundCertDeposits pp (DCertsOf tx) )
+            ≡˘⟨ cong (D₂ +_)
+                     (refundCertDeposits-++ pp (concatMap DCertsOf (SubTransactionsOf tx)) (DCertsOf tx)) ⟩
+          D₂ + refundCertDeposits pp (allDCerts tx)
+            ∎
+          where
+          D₁' refundSubs : Coin
+          D₁' = coinFromDeposits cs₁
+          refundSubs = sum (map (refundCertDeposits pp ∘ DCertsOf) (SubTransactionsOf tx))
+
+          P₁ : ℙ KeyHash
+          P₁ = dom (PoolsOf cs₁)
+
+          registered₁ : PoolDepositsRegistered cs₁
+          registered₁ = SUBLEDGERS-registered valid registered₀ subStep
 
         -- Convert the closed-form balance to the chain's two-level posPart/negPart
         -- form, via `net-arith` fed the bridge (`bridgeEq`) and the two-level
@@ -923,10 +1033,7 @@ The main inner chain, showing LHS + E ≡ RHS + E:
           ≡⟨ arithmetic-2 U₀ allWdrls D₀ ⟩
         U₀ + Psub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
           ≡⟨ cong  (λ x → x + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop)
-                   (subst  (λ u → U₀ + Psub ≡ U₁ + sum (map  (λ stx → cbalance (u ∣ SpendInputsOf stx))
-                                                             (SubTransactionsOf tx)))
-                           (refl {x = UTxOOf (UTxOStateOf s)})
-                           (SUBLEDGERS-utxo-coin valid subStep)) ⟩
+                           (SUBLEDGERS-utxo-coin valid subStep) ⟩
         U₁ + Csub + allWdrls + (D₀ + posPart dct + posPart dcs) + Ctop
           ≡⟨ cong (λ x → (U₁ + Csub) + allWdrls + x + Ctop) posneg ⟩
         U₁ + Csub + allWdrls + (D₂ + negPart dct + negPart dcs) + Ctop
@@ -1021,9 +1128,7 @@ on both sides:
                                   (proposalsOf-Proposals+Votes tx))
 ```
 
-[^1]: See the review of PR #1256.
-
-[^2]: One wrinkle: the solver recognises the ring's operations *syntactically*, so
+[^1]: One wrinkle: the solver recognises the ring's operations *syntactically*, so
       the `Ledger.Prelude` overloaded `_+_` (a `HasAdd`{.AgdaRecord} method, which merely
       *reduces* to `Data.Nat._+_`) defeats it.  The solver-facing statements are therefore
       written with the raw natural-number addition, imported as `_+ᴺ_` — definitionally

--- a/src/Ledger/Prelude.lagda.md
+++ b/src/Ledger/Prelude.lagda.md
@@ -48,7 +48,7 @@ open import abstract-set-theory.Axiom.Set.Map.Extra public
 
 import Data.Integer as ℤ
 open import Data.Integer using (0ℤ) public
-open import Data.Nat.Properties using (+-identityʳ)
+open import Data.Nat.Properties using (+-comm; +-assoc ; +-identityʳ)
 import Data.Rational as ℚ
 open import Data.Rational using (ℚ)
 
@@ -105,6 +105,16 @@ indexedSumL-proj₂-zero ((a , v) ∷ xs) all-zero =
   trans (cong (_+ indexedSumL proj₂ xs) (all-zero (Prelude.Init.here refl)))
         (indexedSumL-proj₂-zero xs (all-zero ∘ Prelude.Init.there))
 
++-interleave : {a b c d : ℕ} → a + b + (c + d) ≡ a + c + (b + d)
++-interleave {a}{b}{c}{d} = begin
+  a + b + (c + d)  ≡⟨ +-assoc a b (c + d) ⟩
+  a + (b + (c + d))  ≡⟨ cong (a +_) (sym (+-assoc b c d)) ⟩
+  a + (b + c + d)    ≡⟨ cong (λ y → a + (y + d)) (+-comm b c) ⟩
+  a + (c + b + d)    ≡⟨ cong (a +_) (+-assoc c b d) ⟩
+  a + (c + (b + d))  ≡⟨ sym (+-assoc a c (b + d)) ⟩
+  a + c + (b + d)  ∎
+  where open ≡-Reasoning
+
 module _ {A : Type} ⦃ _ : DecEq A ⦄ where
 
   -- A coin singleton has the coin you expect.
@@ -136,7 +146,7 @@ module _ {A : Type} ⦃ _ : DecEq A ⦄ where
   ∪ˡsingleton∈dom : (m : A ⇀ Coin) {(a , c) : A × Coin}
     → a ∈ dom m → getCoin (m ∪ˡ ❴ (a , c) ❵ᵐ) ≡ getCoin m
   ∪ˡsingleton∈dom m {(a , c)} a∈dom =
-    ≡ᵉ-getCoin (m ∪ˡ ❴ (a , c) ❵ᵐ) m (singleton-∈-∪ˡ {m = m} a∈dom)
+    ≡ᵉ-getCoin (m ∪ˡ ❴ (a , c) ❵) m (singleton-∈-∪ˡ {m = m} a∈dom)
 
   -- If a is *not* in domain of m, left-biased union with singleton adds cleanly.
   ∪ˡsingleton∉dom : (m : A ⇀ Coin) {(a , c) : A × Coin}
@@ -187,4 +197,14 @@ opaque
 
   setToList-∈ : ∀ {A : Type} {a : A} {X : ℙ A} → a ∈ˡ setToList X → a ∈ X
   setToList-∈ = id
+
+sum-map-+ : ∀ {A : Type} (f g : A → ℕ) (xs : List A)
+  → sum (map (λ x → f x + g x) xs) ≡ sum (map f xs) + sum (map g xs)
+sum-map-+ _ _ [] = refl
+sum-map-+ f g (x ∷ xs) =
+  begin
+  f x + g x + sum (map (λ x → f x + g x) xs)    ≡⟨ cong (f x + g x +_) (sum-map-+ f g xs) ⟩
+  f x + g x + (sum (map f xs) + sum (map g xs)) ≡⟨ +-interleave {f x} ⟩
+  f x + sum (map f xs) + (g x + sum (map g xs)) ∎
+  where open ≡-Reasoning
 ```

--- a/src/Ledger/Prelude.lagda.md
+++ b/src/Ledger/Prelude.lagda.md
@@ -144,7 +144,7 @@ module _ {A : Type} ⦃ _ : DecEq A ⦄ where
   -- If a is already in domain of m, left-biased union with singleton at a
   -- leaves total unchanged (existing entry wins).
   ∪ˡsingleton∈dom : (m : A ⇀ Coin) {(a , c) : A × Coin}
-    → a ∈ dom m → getCoin (m ∪ˡ ❴ (a , c) ❵ᵐ) ≡ getCoin m
+    → a ∈ dom m → getCoin (m ∪ˡ ❴ (a , c) ❵) ≡ getCoin m
   ∪ˡsingleton∈dom m {(a , c)} a∈dom =
     ≡ᵉ-getCoin (m ∪ˡ ❴ (a , c) ❵) m (singleton-∈-∪ˡ {m = m} a∈dom)
 

--- a/src/Ledger/Prelude.lagda.md
+++ b/src/Ledger/Prelude.lagda.md
@@ -107,12 +107,12 @@ indexedSumL-proj₂-zero ((a , v) ∷ xs) all-zero =
 
 +-interleave : {a b c d : ℕ} → a + b + (c + d) ≡ a + c + (b + d)
 +-interleave {a}{b}{c}{d} = begin
-  a + b + (c + d)  ≡⟨ +-assoc a b (c + d) ⟩
+  a + b + (c + d)    ≡⟨ +-assoc a b (c + d) ⟩
   a + (b + (c + d))  ≡⟨ cong (a +_) (sym (+-assoc b c d)) ⟩
   a + (b + c + d)    ≡⟨ cong (λ y → a + (y + d)) (+-comm b c) ⟩
   a + (c + b + d)    ≡⟨ cong (a +_) (+-assoc c b d) ⟩
   a + (c + (b + d))  ≡⟨ sym (+-assoc a c (b + d)) ⟩
-  a + c + (b + d)  ∎
+  a + c + (b + d)    ∎
   where open ≡-Reasoning
 
 module _ {A : Type} ⦃ _ : DecEq A ⦄ where


### PR DESCRIPTION
## Description

### Property proved

The Dijkstra `LEDGER` rule preserves value.

> `getCoin s ≡ getCoin s'`,  *assuming* `PoolDepositsRegistered (CertStateOf s)`

where `getCoin (LedgerState)` sums UTxO coin, the rewards balance, the cert-deposit pots, and the gov-action deposits.


### New hypothesis

`POOL-reg` adds the pool deposit with a *left-biased* union.

At a state holding a stale pot entry for an unregistered pool, registering that pool destroys the deposit of the batch balance; preservation is genuinely false there, not merely unprovable.

`PoolDepositsRegistered` asserts that every pool-deposit entry belongs to a registered pool, defined in `Certs`.

This precludes a state holding a stale pot entry for an unregistered pool.  Moreover, this condition holds on-chain by construction, so a chain-level reachability argument discharges it.

### Shape of the proof

There are no per-rule PoV theorems to compose here: Dijkstra's only balance premise is batch-wide.

So `LEDGER-V` is a single `LedgerState`-level equational chain, resting on three cancellations:

1.  total direct-deposit value cancels between the UTxO side (`producedBatch`) and the CertState side (`applyDirectDeposits` in `ENTITIES`);
2.  the batch-wide cert-deposit accounting (`SUBLEDGERS-deposits`, telescoping the per-step closed forms) reconciles the deposit pots against the batch balance;
3.  gov-deposit growth is matched against the produced-side `govProposalsDeposits`.

Everything below `LEDGER` is left as a module parameter, so this PR proves exactly what `LEDGER-pov` needs and the parameter list is a frozen contract for the follow-ups.

### What lands

+  `Ledger/Properties/PoV.lagda.md`: `LEDGER-pov`, the four `SUBLEDGERS` inductions, `posNeg-deposits`; 

+  `Entities/Properties/PoV.lagda.md`: per-transaction accounting for the post-#1256 tx-signal rules, split by `getCoin (CertState)` component, combining to *coin in + direct deposits + new deposits ≡ coin out + withdrawals + refunds*; 

+  `Entities/Properties/ApplyToRewardsPoV.lagda.md`: the withdrawal / direct-deposit fold lemmas.

**Spec changes**, each forced by the accounting.

+  `Ledger.lagda.md`: `getCoin (LedgerState)` gains `coinFromGovDeposit`; Gov-action deposits live in `GovActionState.deposit`, not `GState.deposits`, yet the `UTXO` batch balance charges `govProposalsDeposits` on the produced side; without this summand the total is not preserved.

+  `Certs.lagda.md`: `getCoin (CertState)` is now total (rewards balance *plus* the three deposit pots), with `coinFromRewards`/`coinFromDeposits` projections, and the new `PoolDepositsRegistered` invariant.

+  `Prelude.lagda.md`: era-independent sum lemmas (`+-interleave`, `sum-map-+`).

### Assumptions: module parameters left open

| Group                    | Issue | PR      | Parameters                                                                                                                  |
| ------------------------ | ----- | ------- | -------------------------------------------------------------------------------------------------------------------- |
| **Certs-PoV**            | #1185 | #1210   | `CERTS-rewards-pov`, `CERTS-deposits-pov`, `CERTS-deposits-registered`, `CERTS-new-thread`, `refundCertDeposits-++`         |
| **Utxo/Utxow-PoV**       | #1186 | #1189   | `UTXOW-batch-balance-coin`, `UTXOW-V-mechanical`, `utxow-pov-invalid`, `subutxow-step-coin`, `balance-∪`, `split-balance`, `outs-disjoint`, `noMintTx`, `noMintSubTx`, `utxo₁-tx-spend-eq`, `fresh-top-tx-id` |
| **Gov-PoV**              | #1276 | #1278   | `GOVS-coinFromGovDeposit`, `rmOrphanDRepVotes-coinFromGovDeposit` |
| **Withdrawal bounds**    | #1275 |   `*`     | `ENTITIES-wdrls-bounded`, `SUBENTITIES-wdrls-bounded` |
| **Reachability**         |   `*`   |   `*`     | `PoolDepositsRegistered` for on-chain initial states |
| **Set/map identities**   |   `*`   |   `*`     | `∪ˡ-lookup-preserve`, `sum-map-proj₂≡getCoin`, `setToList-Unique` (`agda-sets` candidates) |

`*` = TODO (nothing filed yet)

Three of these deserve a word on *why* they are shaped the way they are.

+  `CERTS-deposits-pov` states the deposit accounting in closed form, `D + newCertDeposits (dom pools) certs ≡ D' + refundCertDeposits certs`, under a `PoolDepositsRegistered` premise, without which `POOL-reg`'s left-biased update falsifies it.  `CERTS-new-thread` splits `newCertDeposits` over `xs ++ ys` at a run boundary with the `ys` half against the run's *final* pool set; that is precisely what lets per-run accounting compose across a batch.
+  The whole-batch composition of the Certs facts is **not** assumed; `SUBLEDGERS-deposits` derives it.
+  `UTXOW-batch-balance-coin` keeps cert deposits in the spec's closed form, so it stays a pure UTxO obligation with no post-batch cert states in it.
+  The withdrawal bounds are assumed rather than derived because of **a real spec gap**: the premises bound withdrawals only against the pre-batch `rewards₀` (except top-level legacy mode), which does not bound them against the input state of a *later* step in the batch; the **phantom-withdrawal gap** flagged in the #1256 review.  Needs a spec-side premise or a batch-threading invariant.

## Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
🧑 Curated and revised by @williamdemeo
