### PR TITLE
Change accountBalances by certState to Ledger/Subledger env

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -45,9 +45,9 @@ record SubLedgerEnv : Type where
     enactState       : EnactState
     treasury         : Treasury
     utxo₀            : UTxO
-    isTopLevelValid  : Bool
+    certState        : CertState
     allScripts       : ℙ Script
-    accountBalances  : Rewards
+    isTopLevelValid  : Bool
 
 record LedgerEnv : Type where
   field
@@ -81,8 +81,8 @@ instance
   HasTreasury-SubLedgerEnv : HasTreasury SubLedgerEnv
   HasTreasury-SubLedgerEnv .TreasuryOf = SubLedgerEnv.treasury
 
-  HasAccountBalances-SubLedgerEnv : HasAccountBalances SubLedgerEnv
-  HasAccountBalances-SubLedgerEnv .AccountBalancesOf = SubLedgerEnv.accountBalances
+  -- HasAccountBalances-SubLedgerEnv : HasAccountBalances SubLedgerEnv
+  -- HasAccountBalances-SubLedgerEnv .AccountBalancesOf = SubLedgerEnv.accountBalances
 
 ```
 -->
@@ -211,7 +211,7 @@ instance
 private variable
   utxo₀                             : UTxO
   utxoState₀ utxoState₁ utxoState₂  : UTxOState
-  certState₀ certState₁ certState₂  : CertState
+  certState certState₀ certState₁ certState₂  : CertState
   govState₀  govState₁  govState₂   : GovState
   tx                                : TopLevelTx
   stx                               : SubLevelTx
@@ -289,17 +289,17 @@ data _⊢_⇀⦇_,SUBLEDGER⦈_ : SubLedgerEnv → LedgerState → SubLevelTx �
 
   SUBLEDGER-V :
       ∙ isTopLevelValid ≡ true
-      ∙ ⟦ slot , pp , treasury , utxo₀ , isTopLevelValid , allScripts , accountBalances ⟧ ⊢ utxoState₀ ⇀⦇ stx ,SUBUTXOW⦈ utxoState₁
+      ∙ ⟦ slot , pp , treasury , utxo₀ , certState , allScripts , isTopLevelValid ⟧ ⊢ utxoState₀ ⇀⦇ stx ,SUBUTXOW⦈ utxoState₁
       ∙ ⟦ epoch slot , pp , ListOfGovVotesOf stx , WithdrawalsOf stx , allColdCreds govState₀ enactState , DirectDepositsOf stx ⟧ ⊢ certState₀ ⇀⦇ DCertsOf stx ,ENTITIES⦈ certState₁
       ∙ ⟦ TxIdOf stx , epoch slot , pp , ppolicy , enactState , certState₁ , dom (RewardsOf certState₁) ⟧ ⊢ govState₀ ⇀⦇ GovProposals+Votes stx ,GOVS⦈ govState₁
         ────────────────────────────────
-        ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , isTopLevelValid , allScripts , accountBalances ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ stx ,SUBLEDGER⦈ ⟦ utxoState₁ , govState₁ , certState₁ ⟧
+        ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , certState , allScripts , isTopLevelValid ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ stx ,SUBLEDGER⦈ ⟦ utxoState₁ , govState₁ , certState₁ ⟧
 
   SUBLEDGER-I :
       ∙ isTopLevelValid ≡ false
-      ∙ ⟦ slot , pp , treasury , utxo₀ , isTopLevelValid , allScripts , accountBalances ⟧ ⊢ utxoState₀ ⇀⦇ stx ,SUBUTXOW⦈ utxoState₀
+      ∙ ⟦ slot , pp , treasury , utxo₀ , certState , allScripts , isTopLevelValid  ⟧ ⊢ utxoState₀ ⇀⦇ stx ,SUBUTXOW⦈ utxoState₀
         ────────────────────────────────
-        ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , isTopLevelValid , allScripts , accountBalances ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ stx ,SUBLEDGER⦈ ⟦ utxoState₀ , govState₀ , certState₀ ⟧
+        ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , certState , allScripts , isTopLevelValid ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ stx ,SUBLEDGER⦈ ⟦ utxoState₀ , govState₀ , certState₀ ⟧
 
 _⊢_⇀⦇_,SUBLEDGERS⦈_ : SubLedgerEnv → LedgerState → List SubLevelTx → LedgerState → Type
 _⊢_⇀⦇_,SUBLEDGERS⦈_ = ReflexiveTransitiveClosure {sts = _⊢_⇀⦇_,SUBLEDGER⦈_}
@@ -315,10 +315,10 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LedgerEnv → LedgerState → TopLevelTx → Ledg
          allScripts = getAllScripts tx utxo₀
     in
       ∙ IsValidFlagOf tx ≡ true
-      ∙ ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , IsValidFlagOf tx , allScripts , RewardsOf certState₀ ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoState₁ , govState₁ , certState₁ ⟧
+      ∙ ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , certState₀ , allScripts , IsValidFlagOf tx ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoState₁ , govState₁ , certState₁ ⟧
       ∙ ⟦ epoch slot , pp , ListOfGovVotesOf tx , WithdrawalsOf tx , allColdCreds govState₁ enactState , DirectDepositsOf tx ⟧ ⊢ certState₁ ⇀⦇ DCertsOf tx ,ENTITIES⦈ certState₂
       ∙ ⟦ TxIdOf tx , epoch slot , pp , ppolicy , enactState , certState₂ , dom (RewardsOf certState₂) ⟧ ⊢ govState₁ ⇀⦇ GovProposals+Votes tx ,GOVS⦈ govState₂
-      ∙ ⟦ slot , pp , treasury , utxo₀ , certState₀ , allScripts , RewardsOf certState₀ ⟧ ⊢ utxoState₁ ⇀⦇ tx ,UTXOW⦈ utxoState₂
+      ∙ ⟦ slot , pp , treasury , utxo₀ , certState₀ , allScripts ⟧ ⊢ utxoState₁ ⇀⦇ tx ,UTXOW⦈ utxoState₂
         ────────────────────────────────
         ⟦ slot , ppolicy , pp , enactState , treasury ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ tx ,LEDGER⦈ ⟦ utxoState₂ , rmOrphanDRepVotes certState₂ govState₂ , certState₂ ⟧
 
@@ -330,8 +330,8 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LedgerEnv → LedgerState → TopLevelTx → Ledg
          allScripts = getAllScripts tx utxo₀
     in
       ∙ IsValidFlagOf tx ≡ false
-      ∙ ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , IsValidFlagOf tx , allScripts , RewardsOf certState₀ ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoState₀ , govState₀ , certState₀ ⟧
-      ∙ ⟦ slot , pp , treasury , utxo₀ , certState₀ , allScripts , RewardsOf certState₀ ⟧ ⊢ utxoState₀ ⇀⦇ tx ,UTXOW⦈ utxoState₁
+      ∙ ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , certState₀ , allScripts , IsValidFlagOf tx ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoState₀ , govState₀ , certState₀ ⟧
+      ∙ ⟦ slot , pp , treasury , utxo₀ , certState₀ , allScripts ⟧ ⊢ utxoState₀ ⇀⦇ tx ,UTXOW⦈ utxoState₁
         ────────────────────────────────
         ⟦ slot , ppolicy , pp , enactState , treasury ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ tx ,LEDGER⦈ ⟦ utxoState₁ , govState₀ , certState₀ ⟧
 

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -80,10 +80,6 @@ instance
 
   HasTreasury-SubLedgerEnv : HasTreasury SubLedgerEnv
   HasTreasury-SubLedgerEnv .TreasuryOf = SubLedgerEnv.treasury
-
-  -- HasAccountBalances-SubLedgerEnv : HasAccountBalances SubLedgerEnv
-  -- HasAccountBalances-SubLedgerEnv .AccountBalancesOf = SubLedgerEnv.accountBalances
-
 ```
 -->
 ```agda
@@ -222,7 +218,6 @@ private variable
   treasury                          : Treasury
   isTopLevelValid                   : Bool
   allScripts                        : ℙ Script
-  accountBalances                   : Rewards
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/Computational.lagda.md
@@ -106,12 +106,12 @@ instance
       completeEntities = complete {STS = _⊢_⇀⦇_,ENTITIES⦈_}
 
     module go
-      (Γ   : SubLedgerEnv) (let open SubLedgerEnv Γ)
+      (Γ   : SubLedgerEnv) (let open SubLedgerEnv Γ renaming (certState to certState'))
       (s   : LedgerState)  (let open LedgerState s)
       (stx : SubLevelTx)
       where
       subUtxoΓ : SubUTxOEnv
-      subUtxoΓ = ⟦ slot , pparams , treasury , utxo₀ , isTopLevelValid , allScripts , accountBalances ⟧
+      subUtxoΓ = ⟦ slot , pparams , treasury , utxo₀ , certState' , allScripts , isTopLevelValid ⟧
 
       certΓ : CertEnv
       certΓ = ⟦ epoch slot , pparams , ListOfGovVotesOf stx , WithdrawalsOf stx , allColdCreds govSt enactState , DirectDepositsOf stx ⟧
@@ -220,7 +220,7 @@ instance
       allScripts = getAllScripts txTop utxo₀
 
       subΓ : SubLedgerEnv
-      subΓ = ⟦ slot , ppolicy , pparams , enactState , treasury , utxo₀ , IsValidFlagOf txTop , allScripts , RewardsOf certState ⟧
+      subΓ = ⟦ slot , ppolicy , pparams , enactState , treasury , utxo₀ , certState , allScripts , IsValidFlagOf txTop ⟧
 
       certΓ : GovState → CertEnv
       certΓ govSt' = ⟦ epoch slot , pparams , ListOfGovVotesOf txTop , WithdrawalsOf txTop , allColdCreds govSt' enactState , DirectDepositsOf txTop ⟧
@@ -229,7 +229,7 @@ instance
       govΓ certSt = ⟦ TxIdOf txTop , epoch slot , pparams , ppolicy , enactState , certSt , dom (RewardsOf certSt) ⟧
 
       utxoΓ : UTxOEnv
-      utxoΓ = ⟦ slot , pparams , treasury , utxo₀ , certState , allScripts , RewardsOf certState ⟧
+      utxoΓ = ⟦ slot , pparams , treasury , utxo₀ , certState , allScripts ⟧
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -467,7 +467,7 @@ The [CIP][1] states:
    are disjoint.
 
 4. Direct deposit targets must be registered accounts (their credentials
-   must appear in `dom accountBalances`).
+   must appear in `dom (RewardsOf Γ)`).
 
 5. Each balance interval assertion must hold against the pre-batch account
    balances; this is a Phase-1 validity condition.

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -79,7 +79,6 @@ record UTxOEnv : Type where
     utxo₀             : UTxO
     certState         : CertState
     allScripts        : ℙ Script
-    accountBalances   : Rewards
 
 record SubUTxOEnv : Type where
   field
@@ -87,9 +86,9 @@ record SubUTxOEnv : Type where
     pparams          : PParams
     treasury         : Treasury
     utxo₀            : UTxO
-    isTopLevelValid  : Bool
+    certState        : CertState
     allScripts       : ℙ Script
-    accountBalances  : Rewards
+    isTopLevelValid  : Bool
 ```
 
 The `UTxOEnv`{.AgdaRecord} carries
@@ -142,10 +141,6 @@ record HasDataPool {a} (A : Type a) : Type a where
   field DataPoolOf : A → DataHash ⇀ Datum
 open HasDataPool ⦃...⦄ public
 
-record HasAccountBalances {a} (A : Type a) : Type a where
-  field AccountBalancesOf : A → Rewards
-open HasAccountBalances ⦃...⦄ public
-
 record HasSlot {a} (A : Type a) : Type a where
   field SlotOf : A → Slot
 open HasSlot ⦃...⦄ public
@@ -169,8 +164,8 @@ instance
   HasScriptPool-UTxOEnv : HasScriptPool UTxOEnv
   HasScriptPool-UTxOEnv .ScriptPoolOf = UTxOEnv.allScripts
 
-  HasAccountBalances-UTxOEnv : HasAccountBalances UTxOEnv
-  HasAccountBalances-UTxOEnv .AccountBalancesOf = UTxOEnv.accountBalances
+  HasRewards-UTxOEnv : HasRewards UTxOEnv
+  HasRewards-UTxOEnv .RewardsOf = RewardsOf ∘ UTxOEnv.certState
 
   HasSlot-SubUTxOEnv : HasSlot SubUTxOEnv
   HasSlot-SubUTxOEnv .SlotOf = SubUTxOEnv.slot
@@ -190,8 +185,8 @@ instance
   HasScriptPool-SubUTxOEnv : HasScriptPool SubUTxOEnv
   HasScriptPool-SubUTxOEnv .ScriptPoolOf = SubUTxOEnv.allScripts
 
-  HasAccountBalances-SubUTxOEnv : HasAccountBalances SubUTxOEnv
-  HasAccountBalances-SubUTxOEnv .AccountBalancesOf = SubUTxOEnv.accountBalances
+  HasRewards-SubUTxOEnv : HasRewards SubUTxOEnv
+  HasRewards-SubUTxOEnv .RewardsOf = RewardsOf ∘ SubUTxOEnv.certState
 
   HasUTxO-UTxOState : HasUTxO UTxOState
   HasUTxO-UTxOState .UTxOOf = UTxOState.utxo
@@ -500,10 +495,10 @@ data _⊢_⇀⦇_,SUBUTXO⦈_ : SubUTxOEnv → UTxOState → SubLevelTx → UTxO
     ∙ ∀[ a ∈ dom (DirectDepositsOf txSub)] (NetworkIdOf a ≡ NetworkId)
     ∙ MaybeNetworkIdOf txSub ~ just NetworkId
     ∙ CurrentTreasuryOf txSub ~ just (TreasuryOf Γ)
-    ∙ mapˢ stake (dom (DirectDepositsOf txSub)) ⊆ dom (AccountBalancesOf Γ)
-    ∙ dom (BalanceIntervalsOf txSub) ⊆ dom (AccountBalancesOf Γ)
+    ∙ mapˢ stake (dom (DirectDepositsOf txSub)) ⊆ dom (RewardsOf Γ)
+    ∙ dom (BalanceIntervalsOf txSub) ⊆ dom (RewardsOf Γ)
     ∙ ∀[ (c , interval) ∈ BalanceIntervalsOf txSub ˢ ]
-        (InBalanceInterval (maybe id 0 (lookupᵐ? (AccountBalancesOf Γ) c)) interval)
+        (InBalanceInterval (maybe id 0 (lookupᵐ? (RewardsOf Γ) c)) interval)
       ────────────────────────────────
     let
        s₁ = if IsTopLevelValidFlagOf Γ
@@ -564,10 +559,10 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
     ∙ ∀[ a ∈ dom (DirectDepositsOf txTop)] (NetworkIdOf a ≡ NetworkId)
     ∙ MaybeNetworkIdOf txTop ~ just NetworkId
     ∙ CurrentTreasuryOf txTop  ~ just (TreasuryOf Γ)
-    ∙ mapˢ stake (dom (DirectDepositsOf txTop)) ⊆ dom (AccountBalancesOf Γ)
-    ∙ dom (BalanceIntervalsOf txTop) ⊆ dom (AccountBalancesOf Γ)
+    ∙ mapˢ stake (dom (DirectDepositsOf txTop)) ⊆ dom (RewardsOf Γ)
+    ∙ dom (BalanceIntervalsOf txTop) ⊆ dom (RewardsOf Γ)
     ∙ ∀[ (c , interval) ∈ BalanceIntervalsOf txTop ˢ ]
-        (InBalanceInterval (maybe id 0 (lookupᵐ? (AccountBalancesOf Γ) c)) interval)
+        (InBalanceInterval (maybe id 0 (lookupᵐ? (RewardsOf Γ) c)) interval)
     ∙ Γ ⊢ _ ⇀⦇ txTop ,UTXOS⦈ _
       ────────────────────────────────
     let


### PR DESCRIPTION
# Description

This PR replaces `accountBalances` in `LedgerEnv` and `SubledgerEnv` by `CertState`.

This change removes redundancy in `LedgerEnv` and increases consistency between `SubledgerEnv` and `LedgerEnv`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
