### PR TITLE
Gov property #414: state that GA deposits are eventually refunded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@
 
 ## Conway spec
 
-- State the claim that governance action deposits are eventually refunded (statement only; see #414)
 - Change `RwdAddr` to `RewardAddress`
 - Do not count pool deposits a second time when reregistering pools
 - Allow reregistration of pools in the POOL transition relation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## Conway spec
 
+- State the claim that governance action deposits are eventually refunded (statement only; see #414)
 - Change `RwdAddr` to `RewardAddress`
 - Do not count pool deposits a second time when reregistering pools
 - Allow reregistration of pools in the POOL transition relation

--- a/build-tools/static/mkdocs/includes/links.md
+++ b/build-tools/static/mkdocs/includes/links.md
@@ -22,6 +22,8 @@
 [Chain.Properties.CredDepsEqualDomRwds]: Ledger.Conway.Specification.Chain.Properties.CredDepsEqualDomRwds.md
 [Chain.Properties.EpochStep]: Ledger.Conway.Specification.Chain.Properties.EpochStep.md
 [CHAIN-EpochStep]: Ledger.Conway.Specification.Chain.Properties.EpochStep.md#clm:EpochStep
+[Chain.Properties.EventuallyRefunded]: Ledger.Conway.Specification.Chain.Properties.EventuallyRefunded.md
+[CHAIN-EventuallyRefunded]: Ledger.Conway.Specification.Chain.Properties.EventuallyRefunded.md#clm:EventuallyRefunded
 [CHAIN-CredDepsEqualDomRwds-inv]: Ledger.Conway.Specification.Chain.Properties.CredDepsEqualDomRwds.md#clm:CredDepsEqualDomRwds-inv
 [CHAIN-PParamsWellFormed-inv]: Ledger.Conway.Specification.Chain.Properties.PParamsWellFormed.md#clm:pp-wellFormed-inv
 [Chain.Properties.PParamsWellFormed]: Ledger.Conway.Specification.Chain.Properties.PParamsWellFormed.md

--- a/src/Interface/STS.lagda.md
+++ b/src/Interface/STS.lagda.md
@@ -171,3 +171,24 @@ RTC-preserves-inv : ∀ {STS : C → S → Sig → S → Type} {P}
                   → LedgerInvariant STS P → LedgerInvariant (ReflexiveTransitiveClosure {sts = STS}) P
 RTC-preserves-inv inv (BS-base Id-nop) = id
 RTC-preserves-inv inv (BS-ind p₁ p₂)   = RTC-preserves-inv inv p₂ ∘ inv p₁
+```
+
+While an invariant in the above sense is *preserved* by every step of a relation, it
+is sometimes useful to *assert* a predicate at every state that a particular trace
+passes through.  `RTC-All P tr` states that `P` holds at the target state of every
+step of the trace `tr` (the initial state is not constrained), and `RTC-All-last`
+reads the predicate off at the final state of a nonempty trace.
+
+```agda
+module _ {STS : C → S → Sig → S → Type} (P : S → Type) where
+
+  RTC-All : ReflexiveTransitiveClosure {sts = STS} Γ s sigs s' → Type
+  RTC-All (BS-base Id-nop)         = ⊤
+  RTC-All (BS-ind {s' = s₁} _ tr)  = P s₁ × RTC-All tr
+
+  RTC-All-last :
+    (tr : ReflexiveTransitiveClosure {sts = STS} Γ s (sig ∷ sigs) s')
+    → RTC-All tr → P s'
+  RTC-All-last (BS-ind _ (BS-base Id-nop))  (p , _)   = p
+  RTC-All-last (BS-ind _ tr@(BS-ind _ _))   (_ , ps)  = RTC-All-last tr ps
+```

--- a/src/Ledger/Conway/Specification/Chain.lagda.md
+++ b/src/Ledger/Conway/Specification/Chain.lagda.md
@@ -112,3 +112,13 @@ data _⊢_⇀⦇_,CHAIN⦈_ : ⊤ → ChainState → Block → ChainState → Ty
       ────────────────────────────────
       _ ⊢ cs ⇀⦇ b ,CHAIN⦈ cs'
 ```
+
+## The <span class="AgdaDatatype">CHAINS</span> Transition System {#sec:the-chains-transition-system}
+
+The `CHAINS`{.AgdaFunction} transition system extends a chain state along a list of
+blocks; it is the reflexive-transitive closure of `CHAIN`{.AgdaDatatype}.
+
+```agda
+_⊢_⇀⦇_,CHAINS⦈_ : ⊤ → ChainState → List Block → ChainState → Type
+_⊢_⇀⦇_,CHAINS⦈_ = ReflexiveTransitiveClosure {sts = _⊢_⇀⦇_,CHAIN⦈_}
+```

--- a/src/Ledger/Conway/Specification/Chain/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Chain/Properties.lagda.md
@@ -11,6 +11,7 @@ module Ledger.Conway.Specification.Chain.Properties where
 open import Ledger.Conway.Specification.Chain.Properties.Computational
 open import Ledger.Conway.Specification.Chain.Properties.CredDepsEqualDomRwds
 open import Ledger.Conway.Specification.Chain.Properties.EpochStep
+open import Ledger.Conway.Specification.Chain.Properties.EventuallyRefunded
 open import Ledger.Conway.Specification.Chain.Properties.GovDepsMatch
 open import Ledger.Conway.Specification.Chain.Properties.PParamsWellFormed
 ```

--- a/src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded.lagda.md
+++ b/src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded.lagda.md
@@ -17,28 +17,16 @@ module Ledger.Conway.Specification.Chain.Properties.EventuallyRefunded
   (abs : AbstractFunctions txs)
   where
 
-open import Data.List.Relation.Unary.All using (All; []; _∷_)
-open import Data.List.Membership.Propositional.Properties using (∈-filter⁻)
-open import Data.List.Relation.Unary.Any using (here; there)
-
-open import Ledger.Prelude hiding (All)
+open import Ledger.Prelude
 
 open import Ledger.Conway.Specification.Certs govStructure
 open import Ledger.Conway.Specification.Chain txs abs
-open import Ledger.Conway.Specification.Enact govStructure
 open import Ledger.Conway.Specification.Epoch txs abs
-open import Ledger.Conway.Specification.Gov govStructure using (GovState; GovStateOf)
+open import Ledger.Conway.Specification.Gov govStructure using (GovStateOf)
 open import Ledger.Conway.Specification.Ledger txs abs
 open import Ledger.Conway.Specification.Ledger.Properties.Base txs abs
-open import Ledger.Conway.Specification.PoolReap txs abs using (POOLREAP)
-open import Ledger.Conway.Specification.Ratify govStructure
-open import Ledger.Conway.Specification.RewardUpdate txs abs using (TICK)
-open import Ledger.Conway.Specification.Utxo txs abs
 
-open GovActionState  using (votes; expiresIn)
-open Block           using (ts)
-open RatifyEnv       using (currentEpoch)
-open RatifyState     using (removed)
+open GovActionState using (expiresIn)
 ```
 -->
 
@@ -67,9 +55,12 @@ pipeline: at epoch `sucᵉ`{.AgdaFunction} (`expiresIn`{.AgdaField}
 `gaSt`{.AgdaBound}), `RATIFIES`{.AgdaDatatype} marks the expired action for removal
 (adding it to `removed`{.AgdaField}); at the *following* epoch, the
 `GovernanceUpdate`{.AgdaModule} actually filters the action out of the governance state
-and strips its deposit from the deposit pot.
+and strips its deposit from the deposit pot.  The deposit may therefore still be held
+at any state whose last epoch is at most `sucᵉ`{.AgdaFunction}
+(`expiresIn`{.AgdaField} `gaSt`{.AgdaBound}) — the *refund deadline* — and is gone at
+every reachable state beyond it.
 
-Six preconditions are needed.
+Four preconditions are needed.
 
 +  `govDepsMatch`{.AgdaFunction} ensures that every
    `GovActionDeposit`{.AgdaInductiveConstructor} entry has a corresponding
@@ -87,139 +78,76 @@ Six preconditions are needed.
    expired action is still present in the governance state—something
    `govDepsMatch`{.AgdaFunction} alone does not prevent.
 
-+  `FreshId gaid bs`{.Agda} asserts that no transaction in the block list
-   `bs`{.AgdaBound} has a `TxId`{.AgdaDatatype} equal to
-   `proj₁`{.AgdaField} `gaid`{.AgdaBound}.  This prevents a new governance
-   proposal from re-using the same `GovActionID`{.AgdaDatatype} after the original
-   action has been removed.  In practice this always holds because
-   `TxId`{.AgdaDatatype} is a cryptographic hash of the transaction body, but the
-   formal specification does not enforce `TxId`{.AgdaDatatype} freshness
-   syntactically.
++  The per-state invariant `InvariantAt`{.AgdaFunction}, imposed at every state
+   reached along the chain extension (via the generic `RTC-All`{.AgdaFunction}
+   combinator), asserts that either the deposit has already been refunded, or the
+   refund deadline has not yet passed.  This is an invariant of reachable chain
+   states: the pipeline strips the deposit at the epoch boundary that ends the
+   deadline, and the deposit cannot reappear afterwards because a
+   `GovActionID`{.AgdaDatatype} contains the `TxId`{.AgdaDatatype} of the proposing
+   transaction, which is a cryptographic hash and hence never reused in practice.
 
-+  `SucIsLeast`{.AgdaFunction} asserts that
-   `sucᵉ`{.AgdaFunction} is the *least* element strictly above a given epoch:
-   `e < e' → sucᵉ e ≤ e'`{.Agda}.  This property holds for the concrete
-   `ℕ`{.AgdaDatatype} epoch structure but is not yet an axiom of
-   `EpochStructure`{.AgdaRecord}; it is taken as a hypothesis here until the
-   axiom is added upstream.
-
-+  `CHAINStar-Invariant`{.AgdaFunction} asserts that at every intermediate state
-   of the chain extension, either the deposit is already absent or the three
-   domain conditions (`govDepsMatch`{.AgdaFunction}, `GovState`{.AgdaFunction}
-   membership, epoch bound) still hold.  This invariant is always satisfied for
-   reachable states; its formal derivation from the `CHAIN`{.AgdaDatatype} rule
-   requires additional infrastructure (the `rrm` premise of
-   `CHAIN-govDepsMatch`{.AgdaFunction} and `GovState`{.AgdaFunction} membership
-   preservation through `LEDGERS`{.AgdaDatatype}).
+   Its formal derivation from the `CHAIN`{.AgdaDatatype} rule is future work.[^2]
+   It requires the `rrm` premise of  `CHAIN-govDepsMatch`{.AgdaFunction}, tracking of
+   the action through `LEDGERS`{.AgdaDatatype} and the `RATIFIES`{.AgdaDatatype}
+   pipeline, and an abstract `TxId`{.AgdaDatatype}-freshness assumption (the formal
+   specification does not enforce `TxId`{.AgdaDatatype} freshness syntactically).
 
 *Formally*.
 
 We first record what it means for a governance action deposit to still be held in a
-chain state, and we close `CHAIN`{.AgdaDatatype} under composition along a list of
-blocks.
+chain state, and we define the per-state invariant.  Chain extension along a list of
+blocks is the `CHAINS`{.AgdaFunction} transition system — the reflexive-transitive
+closure of `CHAIN`{.AgdaDatatype} — and the invariant is imposed at every state
+reached along a `CHAINS`{.AgdaFunction} trace by the generic
+`RTC-All`{.AgdaFunction} combinator.
 
 ```agda
 -- The deposits of `cs` still holds the deposit for governance action `gaid`.
 gaDepositInPot : ChainState → GovActionID → Type
 gaDepositInPot cs gaid = GovActionDeposit gaid ∈ dom (DepositsOf cs)
 
--- Reflexive-transitive closure of CHAIN along a list of blocks.
-data CHAINStar : ChainState → List Block → ChainState → Type where
-  []*  : {cs : ChainState} → CHAINStar cs [] cs
-  _∷*_ : {cs cs' cs'' : ChainState} {b : Block} {bs : List Block}
-         → _ ⊢ cs ⇀⦇ b ,CHAIN⦈ cs'
-         → CHAINStar cs' bs cs''
-         → CHAINStar cs (b ∷ bs) cs''
-
--- No block in bs contains a transaction whose TxId equals txid.
--- This rules out re-proposal of the same GovActionID, which the formal spec
--- does not prevent syntactically (TxId is abstract) but which cannot happen
--- in practice (TxId is a cryptographic hash of the transaction body).
-FreshId : GovActionID → List Block → Type
-FreshId (txid , _) bs = All (λ b → All (λ tx → TxIdOf tx ≢ txid) (ts b)) bs
-
--- Successor is the least element strictly above.  This holds for the
--- concrete ℕ epoch structure but is not yet an axiom of EpochStructure.
-SucIsLeast : Type
-SucIsLeast = ∀ {e e' : Epoch} → e < e' → sucᵉ e ≤ e'
-
--- The inductive hypothesis needs govDepsMatch, GovState membership, and the
--- epoch bound at each intermediate state.  These are CHAIN invariants whose
--- formal derivation requires additional infrastructure not yet available (see
--- proof section).  We bundle them as conditions on the CHAINStar derivation.
-InvariantAt : ChainState → GovActionID → GovActionState → Type
-InvariantAt cs gaid gaSt =
-    (GovActionDeposit gaid ∉ dom (DepositsOf cs))
-    ⊎   govDepsMatch (LStateOf cs)
-        × (gaid , gaSt) ∈ fromList (GovStateOf (LStateOf cs))
-        × LastEpochOf cs ≤ expiresIn gaSt
-
-CHAINStar-Invariant :
-  {cs   : ChainState}
-  {bs   : List Block}
-  {cs'  : ChainState}
-  → GovActionID → GovActionState → CHAINStar cs bs cs' → Type
-
-CHAINStar-Invariant _ _ []* = ⊤
-CHAINStar-Invariant gaid gaSt (_∷*_ {cs' = cs₁} _ rest) =
-  InvariantAt cs₁ gaid gaSt × CHAINStar-Invariant gaid gaSt rest
+-- Either the deposit has already been refunded, or the refund deadline —
+-- one epoch past expiry, owing to the ratification pipeline — has not yet
+-- passed.  This holds at every reachable chain state (see prose above);
+-- deriving it formally from the CHAIN rule is future work (Issue #1260).
+InvariantAt : GovActionID → GovActionState → ChainState → Type
+InvariantAt gaid gaSt cs =
+    (¬ gaDepositInPot cs gaid)
+  ⊎ (LastEpochOf cs ≤ sucᵉ (expiresIn gaSt))
 ```
 
-We want to prove that every governance action deposit is eventually
-refunded, which we express formally as the following type definition.
-
-**Theorem**.
+We express the claim formally as the following type.
 
 ```agda
-data _⊢_⇀⦇_,REFUNDED⦈_ : ⊤ → ChainState → List Block → ChainState → Type where
-
-  REFUNDED :
-    {cs     : ChainState}
-    {bs     : List Block}
-    {cs'    : ChainState}
-    {gaid   : GovActionID}
-    {gaSt   : GovActionState}
-    {chain  : CHAINStar cs bs cs'}
-    →
-    ∙ SucIsLeast
-    ∙ govDepsMatch (LStateOf cs)
-    ∙ (gaid , gaSt) ∈ fromList (GovStateOf (LStateOf cs))
-    ∙ LastEpochOf cs ≤ expiresIn gaSt
-    ∙ FreshId gaid bs
-    ∙ CHAINStar-Invariant gaid gaSt chain
-    ∙ sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs'
-      ────────────────────────────────
-      _ ⊢ cs ⇀⦇ bs ,REFUNDED⦈ cs'
-
-GADepositsEventuallyRefunded : ∀ {cs bs cs'}
-  → _ ⊢ cs ⇀⦇ bs ,REFUNDED⦈ cs' → Type
-GADepositsEventuallyRefunded {cs' = cs'} (REFUNDED {gaid = gaid} _) =
-  ¬ gaDepositInPot cs' gaid
-
-GADepositsEventuallyRefunded' : Type
-GADepositsEventuallyRefunded' =
-  SucIsLeast
-  →  {cs    : ChainState}
-     {gaid  : GovActionID}
-     {gaSt  : GovActionState}
-     → govDepsMatch (LStateOf cs)
-     → (gaid , gaSt) ∈ fromList (GovStateOf (LStateOf cs))
-     → LastEpochOf cs ≤ expiresIn gaSt
-     →  {bs : List Block}
-        {cs' : ChainState}
-        → (chain : CHAINStar cs bs cs')
-        → FreshId gaid bs
-        → CHAINStar-Invariant gaid gaSt chain
-        → sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs'
-        → ¬ gaDepositInPot cs' gaid
+GADepositsEventuallyRefunded : Type
+GADepositsEventuallyRefunded =
+  {cs    : ChainState}
+  {gaid  : GovActionID}
+  {gaSt  : GovActionState}
+  → govDepsMatch (LStateOf cs)
+  → (gaid , gaSt) ∈ fromList (GovStateOf (LStateOf cs))
+  → LastEpochOf cs ≤ expiresIn gaSt
+  →  {bs   : List Block}
+     {cs'  : ChainState}
+     → (chain : _ ⊢ cs ⇀⦇ bs ,CHAINS⦈ cs')
+     → RTC-All (InvariantAt gaid gaSt) chain
+     → sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs'
+     → ¬ gaDepositInPot cs' gaid
 ```
 
 **Proof**.
 
-We prove `gaDepositsEventuallyRefunded`{.AgdaFunction}: given a
-`REFUNDED`{.AgdaInductiveConstructor} derivation, the deposit is gone.
-The proof delegates to the workhorse `gaDepositsEventuallyRefunded'`{.AgdaFunction},
-which proceeds by induction on `CHAINStar`{.AgdaDatatype}.
+The preconditions place all of the chain-dynamics content in the
+`RTC-All`{.AgdaFunction} premise, which constrains every state reached along the
+chain extension — in particular the final one, which `RTC-All-last`{.AgdaFunction}
+extracts.  The proof therefore only has to read off the invariant at the final state
+and compare epochs.  If the block list is empty, the final state *is* the initial
+state, and the not-yet-expired bound `LastEpochOf cs ≤ expiresIn gaSt`{.Agda}
+contradicts the cutoff `sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs`{.Agda}.
+Otherwise, the invariant at the final state either yields the refund outright, or
+asserts `LastEpochOf cs' ≤ sucᵉ (expiresIn gaSt)`{.Agda}, which again contradicts
+the cutoff.
 
 <!--
 ```agda
@@ -241,347 +169,19 @@ private
   ≤e<sucᵉsucᵉ⇒⊥ : ∀ {a b : Epoch} → a ≤ b → sucᵉ (sucᵉ b) ≤ a → ⊥
   ≤e<sucᵉsucᵉ⇒⊥ {_} {b} p q =
     ≤e<sucᵉ⇒⊥ p (Ep.≤-trans (inj₁ (e<sucᵉ {sucᵉ b})) q)
-
-  -- govDepsMatch lemmas: the GA deposits in the deposit pot correspond
-  -- exactly to the GovState entries, so absence from dpMap (GovState)
-  -- implies absence from the deposit pot.
-  open Equivalence
-
-  -- If govDepsMatch and the deposit is in the pot, GovActionDeposit gaid
-  -- is in dpMap (i.e. gaid appears as proj₁ of some GovState entry).
-  gdm-dep⇒dpMap : ∀ {ls : LState} {gaid : GovActionID} → govDepsMatch ls
-    → (GovActionDeposit gaid ∈ dom (DepositsOf ls))
-    → (GovActionDeposit gaid ∈ fromList (dpMap (GovStateOf ls)))
-  gdm-dep⇒dpMap {ls} gdm dep = proj₁ gdm (∈-filter .to (refl , dep))
-
-  -- Contrapositive: if gaid is absent from dpMap, the deposit is absent.
-  gdm-¬dpMap⇒¬dep : ∀ {ls : LState} {gaid : GovActionID} → govDepsMatch ls
-    → (GovActionDeposit gaid ∉ fromList (dpMap (GovStateOf ls)))
-    → (GovActionDeposit gaid ∉ dom (DepositsOf ls))
-  gdm-¬dpMap⇒¬dep {ls} gdm notMem dep = notMem (gdm-dep⇒dpMap {ls} gdm dep)
-
-  -- RATIFY / RATIFIES lemmas ----------------------
-
-  -- Abbreviation for membership in the removed field.
-  _∈ʳ_ : GovActionID × GovActionState → RatifyState → Type
-  x ∈ʳ s = x ∈ RatifyState.removed s
-
-  -- Single RATIFY step: an expired action is always added to removed.
-  ratify-expired⇒in-removed :
-    ∀ {Γ s s'} {a : GovActionID × GovActionState}
-    → Γ ⊢ s ⇀⦇ a ,RATIFY⦈ s'
-    → expired (currentEpoch Γ) (proj₂ a)
-    → a ∈ʳ s'
-  ratify-expired⇒in-removed (RATIFY-Accept _) _ = ∈-∪ .to (inj₁ (∈-singleton .to refl))
-  ratify-expired⇒in-removed (RATIFY-Reject _) _ = ∈-∪ .to (inj₁ (∈-singleton .to refl))
-  ratify-expired⇒in-removed (RATIFY-Continue (_ , notExp)) exp = ⊥-elim (notExp exp)
-
-  -- RATIFY only grows the removed set.
-  ratify-removed-mono :
-    ∀ {Γ s s'} {a : GovActionID × GovActionState} {x : GovActionID × GovActionState}
-    → Γ ⊢ s ⇀⦇ a ,RATIFY⦈ s' → x ∈ʳ s → x ∈ʳ s'
-  ratify-removed-mono (RATIFY-Accept _)   h = ∈-∪ .to (inj₂ h)
-  ratify-removed-mono (RATIFY-Reject _)   h = ∈-∪ .to (inj₂ h)
-  ratify-removed-mono (RATIFY-Continue _) h = h
-
-  -- RATIFIES (RTC) also only grows removed.
-  ratifies-removed-mono :
-    ∀ {Γ s s'} {as : List (GovActionID × GovActionState)} {x : GovActionID × GovActionState}
-    → Γ ⊢ s ⇀⦇ as ,RATIFIES⦈ s' → x ∈ʳ s → x ∈ʳ s'
-  ratifies-removed-mono (BS-base Id-nop) h = h
-  ratifies-removed-mono (BS-ind step rest) h =
-    ratifies-removed-mono rest (ratify-removed-mono step h)
-
-  -- Main RATIFIES lemma: every expired action in the processed list
-  -- ends up in the removed set of the output.
-  ratifies-expired∈⇒in-removed :
-    ∀ {Γ s s'} {as : List (GovActionID × GovActionState)}
-      {a : GovActionID × GovActionState}
-    → Γ ⊢ s ⇀⦇ as ,RATIFIES⦈ s'
-    → a ∈ˡ as
-    → expired (currentEpoch Γ) (proj₂ a)
-    → a ∈ʳ s'
-  ratifies-expired∈⇒in-removed (BS-ind step rest) (here refl) exp =
-    ratifies-removed-mono rest (ratify-expired⇒in-removed step exp)
-  ratifies-expired∈⇒in-removed (BS-ind step rest) (there mem) exp =
-    ratifies-expired∈⇒in-removed rest mem exp
-
-  -- GovernanceUpdate lemma ----------------------------
-
-  -- If (gaid, gaSt) ∈ removed(fut), then after GovernanceUpdate
-  -- the action is not in govSt'.
-  govUpdate-removes :
-    {ls          : LState}
-    {fut         : RatifyState}
-    {gaid        : GovActionID}
-    {gaSt gaSt'  : GovActionState}
-    → (gaid , gaSt) ∈ removed fut
-    → (gaid , gaSt') ∉ˡ GovernanceUpdate.govSt' ls fut
-  govUpdate-removes {ls} {fut} {gaid} {gaSt} inRem inGovSt' = gaid∉ gaid∈
-    where
-    open GovernanceUpdate ls fut
-
-    P : GovActionID × GovActionState → Type
-    P (id , _) = id ∉ mapˢ proj₁ removed'
-
-    gaid∉ : gaid ∉ mapˢ proj₁ removed'
-    gaid∉ = proj₂ (∈-filter⁻ (¿ P ¿¹) {xs = GovStateOf ls} inGovSt')
-
-    gaid∈ : gaid ∈ mapˢ proj₁ removed'
-    gaid∈ = ∈-map .to ((gaid , gaSt) , refl , ∈-∪ .to (inj₁ inRem))
-
-  -- Deposit-absence preservation ----------------------
-
-  -- GA keys never appear in certDeposit or certRefund.
-  GA∉dom-certDep : ∀ {gaid} cert pp → GovActionDeposit gaid ∉ dom (certDeposit cert pp ˢ)
-  GA∉dom-certDep (dereg _ _)         _  h = Properties.∉-∅ (proj₁ dom∅ h)
-  GA∉dom-certDep (deregdrep _ _)     _  h = Properties.∉-∅ (proj₁ dom∅ h)
-  GA∉dom-certDep (retirepool _ _)    _  h = Properties.∉-∅ (proj₁ dom∅ h)
-  GA∉dom-certDep (ccreghot _ _)      _  h = Properties.∉-∅ (proj₁ dom∅ h)
-  GA∉dom-certDep (delegate c d k v)  pp h with from ∈-singleton (from dom∈ h .proj₂)
-  ... | ()
-  GA∉dom-certDep (reg c v)           pp h with from ∈-singleton (from dom∈ h .proj₂)
-  ... | ()
-  GA∉dom-certDep (regpool kh p)      pp h with from ∈-singleton (from dom∈ h .proj₂)
-  ... | ()
-  GA∉dom-certDep (regdrep c v a)     pp h with from ∈-singleton (from dom∈ h .proj₂)
-  ... | ()
-
-  -- Map-operation helpers (specialised to Deposits).
-  ∉-dom-∪⁺ᵈ : {m n : Deposits} {x : DepositPurpose}
-    → x ∉ dom (m ˢ) → x ∉ dom (n ˢ) → x ∉ dom ((m ∪⁺ n) ˢ)
-  ∉-dom-∪⁺ᵈ h₁ h₂ h = case from ∈-∪ (proj₁ dom∪⁺≡∪dom h) of λ where
-    (inj₁ x) → h₁ x
-    (inj₂ x) → h₂ x
-
-  ∉-dom-∪ˡᵈ : ∀ {m n : Deposits} {x : DepositPurpose}
-    → x ∉ dom (m ˢ) → x ∉ dom (n ˢ) → x ∉ dom ((m ∪ˡ n) ˢ)
-  ∉-dom-∪ˡᵈ {m} {n} h₁ h₂ h =
-    case from ∈-∪ (proj₁ (dom∪ˡ≡∪dom {m = m} {m' = n}) h) of λ where
-      (inj₁ x) → h₁ x
-      (inj₂ x) → h₂ x
-
-  ∉-dom-resᶜᵈ : ∀ {m : Deposits} {S : ℙ DepositPurpose} {x : DepositPurpose}
-    → x ∉ dom (m ˢ) → x ∉ dom ((m ∣ S ᶜ) ˢ)
-  ∉-dom-resᶜᵈ h h' = h (res-comp-domᵐ h')
-
-  -- updateCertDeposits preserves GA-deposit absence.
-  updCertDeps-GA-absent :
-    {gaid   : GovActionID}
-    (pp     : PParams )
-    (certs  : List DCert)
-    (deps   : Deposits)
-    → GovActionDeposit gaid ∉ dom (deps ˢ)
-    → GovActionDeposit gaid ∉ dom (updateCertDeposits pp certs deps ˢ)
-
-  updCertDeps-GA-absent pp [] deps h = h
-
-  updCertDeps-GA-absent pp (delegate c d k v ∷ cs) deps h =
-    updCertDeps-GA-absent pp cs
-      (deps ∪⁺ certDeposit (delegate c d k v) pp)
-      (∉-dom-∪⁺ᵈ h (GA∉dom-certDep (delegate c d k v) pp))
-
-  updCertDeps-GA-absent pp (reg c v ∷ cs) deps h =
-    updCertDeps-GA-absent pp cs
-      (deps ∪⁺ certDeposit (reg c v) pp)
-      (∉-dom-∪⁺ᵈ h (GA∉dom-certDep (reg c v) pp))
-
-  updCertDeps-GA-absent pp (regpool kh p ∷ cs) deps h =
-    updCertDeps-GA-absent pp cs
-      (deps ∪ˡ certDeposit (regpool kh p) pp)
-      (∉-dom-∪ˡᵈ  {m = deps} {n = certDeposit (regpool kh p) pp}
-                  h (GA∉dom-certDep (regpool kh p) pp))
-
-  updCertDeps-GA-absent pp (regdrep c v a ∷ cs) deps h =
-    updCertDeps-GA-absent pp cs
-      (deps ∪⁺ certDeposit (regdrep c v a) pp)
-      (∉-dom-∪⁺ᵈ h (GA∉dom-certDep (regdrep c v a) pp))
-
-  updCertDeps-GA-absent pp (dereg c v ∷ cs) deps h =
-    updCertDeps-GA-absent pp cs (deps ∣ certRefund (dereg c v) ᶜ) (∉-dom-resᶜᵈ {m = deps} h)
-
-  updCertDeps-GA-absent pp (deregdrep c v ∷ cs) deps h =
-    updCertDeps-GA-absent pp cs (deps ∣ certRefund (deregdrep c v) ᶜ) (∉-dom-resᶜᵈ {m = deps} h)
-
-  updCertDeps-GA-absent pp (retirepool _ _ ∷ cs) deps h = updCertDeps-GA-absent pp cs deps h
-  updCertDeps-GA-absent pp (ccreghot _ _ ∷ cs) deps h = updCertDeps-GA-absent pp cs deps h
-
-  -- GovActionDeposit is injective.
-  GovActionDeposit-inj : ∀ {a b} → GovActionDeposit a ≡ GovActionDeposit b → a ≡ b
-  GovActionDeposit-inj refl = refl
-
-  -- updateProposalDeposits with fresh TxId preserves GA absence.
-  updPropDeps-GA-absent :
-    {gaid   : GovActionID}
-    (props  : List GovProposal)
-    (txid   : TxId)
-    (gaDep  : Coin)
-    (deps   : Deposits)
-    → txid ≢ gaid .proj₁
-    → GovActionDeposit gaid ∉ dom (deps ˢ)
-    → GovActionDeposit gaid ∉ dom (updateProposalDeposits props txid gaDep deps ˢ)
-  updPropDeps-GA-absent [] _ _ _ _ h = h
-  updPropDeps-GA-absent {gaid} (_ ∷ ps) txid gaDep deps txid≢ notIn =
-    ∉-dom-∪⁺ᵈ {m = updateProposalDeposits ps txid gaDep deps}
-      (updPropDeps-GA-absent ps txid gaDep deps txid≢ notIn) newKey∉
-    where
-    newKey∉ : GovActionDeposit gaid ∉ dom (❴ GovActionDeposit (txid , length ps) , gaDep ❵ ˢ)
-    newKey∉ h = txid≢ (cong proj₁ (GovActionDeposit-inj (cong proj₁ (sym (from ∈-singleton (from dom∈ h .proj₂))))))
-
-  -- Combined: updateDeposits with fresh TxId preserves GA absence.
-  updateDeposits-GA-absent : ∀ {gaid : GovActionID} pp (tx : Tx) (deps : Deposits)
-    → TxIdOf tx ≢ proj₁ gaid
-    → GovActionDeposit gaid ∉ dom (deps ˢ)
-    → GovActionDeposit gaid ∉ dom (updateDeposits pp (TxBodyOf tx) deps ˢ)
-  updateDeposits-GA-absent {gaid} pp tx deps txid≢ notIn =
-    -- let open TxBody txb
-    updCertDeps-GA-absent pp (DCertsOf tx)
-         (updateProposalDeposits (GovProposalsOf tx) (TxIdOf tx) (PParams.govActionDeposit pp) deps)
-         (updPropDeps-GA-absent (GovProposalsOf tx) (TxIdOf tx) (PParams.govActionDeposit pp) deps txid≢ notIn)
-
-  -- Per-LEDGER-step deposit absence preservation ------------------------
-
-  LEDGER-GA-absent : ∀ {Γ ls tx ls'} {gaid : GovActionID}
-    → Γ ⊢ ls ⇀⦇ tx ,LEDGER⦈ ls'
-    → TxIdOf tx ≢ proj₁ gaid
-    → GovActionDeposit gaid ∉ dom (DepositsOf ls)
-    → GovActionDeposit gaid ∉ dom (DepositsOf ls')
-
-  -- Valid tx, scripts pass: deposits updated via updateDeposits.
-  LEDGER-GA-absent {Γ} {ls} {tx}
-    (LEDGER-V⋯ refl (UTXOW-UTXOS (Scripts-Yes _)) _ _) txid≢ h =
-    updateDeposits-GA-absent (PParamsOf Γ) tx (DepositsOf ls) txid≢ h
-
-  -- Invalid tx, scripts fail: deposits unchanged (collateral only).
-  LEDGER-GA-absent (LEDGER-I⋯ refl (UTXOW-UTXOS (Scripts-No _))) _ h = h
-
-  -- Lift to LEDGERS (RTC of LEDGER) using FreshId for the tx list.
-  LEDGERS-GA-absent : ∀ {Γ ls txs ls'} {gaid : GovActionID}
-    → Γ ⊢ ls ⇀⦇ txs ,LEDGERS⦈ ls'
-    → All (λ tx → TxIdOf tx ≢ proj₁ gaid) txs
-    → GovActionDeposit gaid ∉ dom (DepositsOf ls)
-    → GovActionDeposit gaid ∉ dom (DepositsOf ls')
-
-  LEDGERS-GA-absent (BS-base Id-nop) _ h = h
-  LEDGERS-GA-absent (BS-ind step rest) (fresh ∷ freshRest) h =
-    LEDGERS-GA-absent rest freshRest (LEDGER-GA-absent step fresh h)
-
-  -- Per-CHAIN-step deposit absence preservation --------------------------
-
-  -- Through a single CHAIN step, if the deposit is absent and FreshId
-  -- holds for the block, the deposit stays absent.  The deposits go
-  -- through GovernanceUpdate ∣_ᶜ (only removes), POOLREAP ∣_ᶜ (only
-  -- removes PoolDeposit keys), and LEDGERS/updateDeposits (FreshId
-  -- prevents GA-key addition).
-  -- EPOCH preserves GA-deposit absence (deposits only shrink via ∣_ᶜ).
-  EPOCH-GA-absent : ∀ {eps eps'} {e : Epoch} {gaid : GovActionID}
-    → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
-    → GovActionDeposit gaid ∉ dom (DepositsOf eps)
-    → GovActionDeposit gaid ∉ dom (DepositsOf eps')
-
-  EPOCH-GA-absent {eps} (EPOCH (_ , POOLREAP , _)) h =
-    ∉-dom-resᶜᵈ {m = DepositsOf utxoSt'} (∉-dom-resᶜᵈ {m = DepositsOf eps} h)
-    where
-    open GovernanceUpdate (LStateOf eps) (RatifyStateOf eps) using (updates)
-    open Pre-POOLREAPUpdate (LStateOf eps) (EnactStateOf (RatifyStateOf eps)) updates using (utxoSt')
-
-  CHAIN-GA-absent : ∀ {cs b cs₁} {gaid : GovActionID}
-    → _ ⊢ cs ⇀⦇ b ,CHAIN⦈ cs₁
-    → All (λ tx → TxIdOf tx ≢ proj₁ gaid) (ts b)
-    → GovActionDeposit gaid ∉ dom (DepositsOf cs)
-    → GovActionDeposit gaid ∉ dom (DepositsOf cs₁)
-
-  CHAIN-GA-absent  ( CHAIN  ( _
-                            , TICK ( NEWEPOCH-New (_ , epochStep) , _ )
-                            , BBODY-Block-Body ( _ , _ , _ , ledgers )
-                            )
-                   ) fresh h = LEDGERS-GA-absent ledgers fresh (EPOCH-GA-absent epochStep h)
-
-  CHAIN-GA-absent  ( CHAIN  ( _
-                            , TICK ( NEWEPOCH-Not-New _ , _ )
-                            , BBODY-Block-Body ( _ , _ , _ , ledgers )
-                            )
-                   ) fresh h = LEDGERS-GA-absent ledgers fresh h
-
-  CHAIN-GA-absent  ( CHAIN  ( _
-                            , TICK ( (NEWEPOCH-No-Reward-Update (_ , epochStep) ) , _ )
-                            , BBODY-Block-Body ( _ , _ , _ , ledgers )
-                            )
-                   ) fresh h = LEDGERS-GA-absent ledgers fresh (EPOCH-GA-absent epochStep h)
-
-  -- Lift to CHAINStar: deposit stays absent through a sequence of blocks.
-  CHAINStar-GA-absent : ∀ {cs bs cs'} {gaid : GovActionID}
-    → CHAINStar cs bs cs'
-    → FreshId gaid bs
-    → GovActionDeposit gaid ∉ dom (DepositsOf cs)
-    → GovActionDeposit gaid ∉ dom (DepositsOf cs')
-  CHAINStar-GA-absent []* _ h = h
-  CHAINStar-GA-absent (step ∷* rest) (freshB ∷ freshRest) h =
-    CHAINStar-GA-absent rest freshRest (CHAIN-GA-absent step freshB h)
 ```
 -->
 
 ```agda
-  -- Main workhorse proof (flat version) -----------------
-
-  gaDepositsEventuallyRefunded' : GADepositsEventuallyRefunded'
-
-  -- Base case: the epoch bound contradicts the not-yet-expired hypothesis.
-  gaDepositsEventuallyRefunded' _ _ _ notexp []* _ _ cutoff =
-    ⊥-elim (≤e<sucᵉsucᵉ⇒⊥ notexp cutoff)
-
-  -- Inductive step: use the invariant at cs₁ to decide the next action.
-  gaDepositsEventuallyRefunded' sucLeast gdm mem notexp
-    (_∷*_ {cs' = cs₁} step rest) (freshB ∷ freshRest) (inv₁ , invRest) cutoff with inv₁
-
-    --| Deposit already absent at cs₁:
-  ... | inj₁ absent₁ = CHAINStar-GA-absent rest freshRest absent₁
-
-    --| IH preconditions hold at cs₁ (recurse):
-  ... | inj₂ (gdm₁ , mem₁ , notexp₁) =
-    gaDepositsEventuallyRefunded' sucLeast gdm₁ mem₁ notexp₁ rest freshRest invRest cutoff
-
-
-  -- Theorem: given a REFUNDED derivation, the deposit is refunded and gone for good.
-
-  gaDepositsEventuallyRefunded :
-
-    {cs  : ChainState}
-    {bs  : List Block}
-    {cs' : ChainState}
-
-    (h : _ ⊢ cs ⇀⦇ bs ,REFUNDED⦈ cs') → GADepositsEventuallyRefunded h
-
-  gaDepositsEventuallyRefunded
-    (REFUNDED (sucLeast , gdm , mem , notexp , fresh , inv , cutoff)) =
-      gaDepositsEventuallyRefunded' sucLeast gdm mem notexp _ fresh inv cutoff
-
+gaDepositsEventuallyRefunded : GADepositsEventuallyRefunded
+gaDepositsEventuallyRefunded _ _ notexp (BS-base Id-nop) _ cutoff =
+  ⊥-elim (≤e<sucᵉsucᵉ⇒⊥ notexp cutoff)
+gaDepositsEventuallyRefunded {gaid = gaid} {gaSt = gaSt} _ _ _
+  chain@(BS-ind _ _) inv cutoff =
+    case RTC-All-last (InvariantAt gaid gaSt) chain inv of λ where
+      (inj₁ refunded)       → refunded
+      (inj₂ withinDeadline) → ⊥-elim (≤e<sucᵉ⇒⊥ withinDeadline cutoff)
 ```
-
-The workhorse proof `gaDepositsEventuallyRefunded'`{.AgdaFunction} proceeds by
-induction on `CHAINStar`{.AgdaDatatype} and uses the
-`CHAINStar-Invariant`{.AgdaFunction} at each step.
-
-**Base case** (`[]*`{.AgdaInductiveConstructor}).
-Vacuous: `≤e<sucᵉsucᵉ⇒⊥`{.AgdaFunction} derives `⊥`{.AgdaDatatype} from the
-contradictory epoch bounds
-(`LastEpochOf cs ≤ expiresIn gaSt`{.Agda} vs.
-`sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs`{.Agda}).
-
-**Inductive step** (`step ∷* rest`{.Agda}).
-The `CHAINStar-Invariant`{.AgdaFunction} provides
-`InvariantAt`{.AgdaFunction} at the intermediate state `cs₁`{.AgdaBound}.
-Two cases:
-
-+  **Deposit already absent** (`inj₁`{.AgdaInductiveConstructor}).
-   `CHAINStar-GA-absent`{.AgdaFunction} propagates the absence through the
-   remaining steps `rest`{.AgdaBound}, since each `CHAIN`{.AgdaDatatype} step
-   preserves GA-deposit absence (given `FreshId`{.AgdaFunction}).
-
-+  **IH preconditions hold** (`inj₂`{.AgdaInductiveConstructor}).
-   The invariant supplies `govDepsMatch`{.AgdaFunction},
-   `GovState`{.AgdaFunction} membership, and the epoch bound at `cs₁`{.AgdaBound}.
-   The inductive hypothesis applies directly to `rest`{.AgdaBound}.
 
 The following table summarises the preconditions and their status.
 
@@ -590,17 +190,9 @@ The following table summarises the preconditions and their status.
 | 1 | `govDepsMatch`{.AgdaFunction} | Known `CHAIN`{.AgdaDatatype} invariant[^1] |
 | 2 | `GovState`{.AgdaFunction} membership | Identifies the action |
 | 3 | `LastEpochOf cs ≤ expiresIn gaSt`{.Agda} | Action not yet expired |
-| 4 | `FreshId`{.AgdaFunction} | Holds in practice (`TxId`{.AgdaDatatype} is a hash) |
-| 5 | `SucIsLeast`{.AgdaFunction} | Holds for `ℕ`{.AgdaDatatype}; missing `EpochStructure`{.AgdaRecord} axiom |
-| 6 | `CHAINStar-Invariant`{.AgdaFunction} | Holds for reachable states; derivation requires additional infrastructure |
-
-Preconditions 4–6 are "engineering debt": they hold for all reachable states but
-their formal derivation from the existing abstract interface requires
-infrastructure not yet present in the specification (abstract
-`TxId`{.AgdaDatatype} freshness, the `<⇒sucᵉ≤`{.Agda} axiom in
-`EpochStructure`{.AgdaRecord}, and the `rrm` premise of
-`CHAIN-govDepsMatch`{.AgdaFunction}).
+| 4 | `RTC-All (InvariantAt gaid gaSt)`{.Agda} | Holds for reachable states; formal derivation is future work[^2] |
 
 ---
 
 [^1]: See [`CHAIN-govDepsMatch`][Chain.Properties.GovDepsMatch] for the proof.
+[^2]: See Issue #1260.

--- a/src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded.lagda.md
+++ b/src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded.lagda.md
@@ -1,0 +1,76 @@
+---
+source_branch: master
+source_path: src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded.lagda.md
+---
+
+## Claim: Governance action deposits are eventually refunded {#clm:EventuallyRefunded}
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Conway.Specification.Abstract
+open import Ledger.Conway.Specification.Transaction
+
+module Ledger.Conway.Specification.Chain.Properties.EventuallyRefunded
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs)
+  where
+
+open import Ledger.Conway.Specification.Certs govStructure
+open import Ledger.Conway.Specification.Chain txs abs
+open import Ledger.Conway.Specification.Epoch txs abs
+open import Ledger.Prelude
+```
+-->
+
+*Informally*.
+
+Every governance action carries a deposit (a `GovActionDeposit`{.AgdaInductiveConstructor}
+entry in the deposit pot of the `UTxOState`{.AgdaRecord}) which is held only while the
+action is part of the governance state.  Each action also records an
+`expiresIn`{.AgdaField} epoch in its `GovActionState`{.AgdaRecord}.  Once that epoch
+has passed, the `EPOCH`{.AgdaDatatype} transition (run as part of `CHAIN`{.AgdaDatatype}
+whenever a block advances the epoch) removes the action from the governance state and
+refunds its deposit.
+
+Hence, for every `ChainState`{.AgdaRecord} `cs`{.AgdaBound} and every governance action
+deposit still held in `cs`{.AgdaBound}, there is an epoch `e`{.AgdaBound} (namely, just
+after the action's `expiresIn`{.AgdaField}) such that, once the chain has progressed to
+`e`{.AgdaBound} (i.e. a block has been produced in epoch `e`{.AgdaBound} or later), the
+deposit is no longer in the deposit pot.
+
+*Formally*.
+
+We first record what it means for a governance action deposit to still be held in a
+chain state, and we close `CHAIN`{.AgdaDatatype} under composition along a list of
+blocks.
+
+```agda
+-- The deposit pot of `cs` still holds the deposit for the governance action `gaid`.
+gaDepositInPot : ChainState → GovActionID → Type
+gaDepositInPot cs gaid = GovActionDeposit gaid ∈ dom (DepositsOf cs)
+
+-- Reflexive-transitive closure of CHAIN along a list of blocks.
+data CHAINStar : ChainState → List Block → ChainState → Type where
+  []*  : ∀ {cs} → CHAINStar cs [] cs
+  _∷*_ : ∀ {cs cs' cs'' b bs}
+       → _ ⊢ cs ⇀⦇ b ,CHAIN⦈ cs'
+       → CHAINStar cs' bs cs''
+       → CHAINStar cs (b ∷ bs) cs''
+```
+
+The property then states that every held governance action deposit is eventually
+refunded:
+
+```agda
+GADepositsEventuallyRefunded : Type
+GADepositsEventuallyRefunded = ∀ {cs : ChainState} {gaid : GovActionID}
+  → gaDepositInPot cs gaid
+  → Σ[ e ∈ Epoch ] (∀ {bs : List Block} {cs' : ChainState}
+      → CHAINStar cs bs cs'
+      → e ≤ LastEpochOf cs'
+      → ¬ gaDepositInPot cs' gaid)
+```
+
+*Proof*. (TODO)

--- a/src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded.lagda.md
+++ b/src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded.lagda.md
@@ -9,36 +9,108 @@ source_path: src/Ledger/Conway/Specification/Chain/Properties/EventuallyRefunded
 ```agda
 {-# OPTIONS --safe #-}
 
-open import Ledger.Conway.Specification.Abstract
-open import Ledger.Conway.Specification.Transaction
+open import Ledger.Conway.Specification.Abstract using (AbstractFunctions)
+open import Ledger.Conway.Specification.Transaction using (TransactionStructure)
 
 module Ledger.Conway.Specification.Chain.Properties.EventuallyRefunded
-  (txs : _) (open TransactionStructure txs)
+  (txs : TransactionStructure ) (open TransactionStructure txs)
   (abs : AbstractFunctions txs)
   where
 
+open import Data.List.Relation.Unary.All using (All; []; _∷_)
+open import Data.List.Membership.Propositional.Properties using (∈-filter⁻)
+open import Data.List.Relation.Unary.Any using (here; there)
+
+open import Ledger.Prelude hiding (All)
+
 open import Ledger.Conway.Specification.Certs govStructure
 open import Ledger.Conway.Specification.Chain txs abs
+open import Ledger.Conway.Specification.Enact govStructure
 open import Ledger.Conway.Specification.Epoch txs abs
-open import Ledger.Prelude
+open import Ledger.Conway.Specification.Gov govStructure using (GovState; GovStateOf)
+open import Ledger.Conway.Specification.Ledger txs abs
+open import Ledger.Conway.Specification.Ledger.Properties.Base txs abs
+open import Ledger.Conway.Specification.PoolReap txs abs using (POOLREAP)
+open import Ledger.Conway.Specification.Ratify govStructure
+open import Ledger.Conway.Specification.RewardUpdate txs abs using (TICK)
+open import Ledger.Conway.Specification.Utxo txs abs
+
+open GovActionState  using (votes; expiresIn)
+open Block           using (ts)
+open RatifyEnv       using (currentEpoch)
+open RatifyState     using (removed)
 ```
 -->
 
 *Informally*.
 
 Every governance action carries a deposit (a `GovActionDeposit`{.AgdaInductiveConstructor}
-entry in the deposit pot of the `UTxOState`{.AgdaRecord}) which is held only while the
-action is part of the governance state.  Each action also records an
-`expiresIn`{.AgdaField} epoch in its `GovActionState`{.AgdaRecord}.  Once that epoch
-has passed, the `EPOCH`{.AgdaDatatype} transition (run as part of `CHAIN`{.AgdaDatatype}
-whenever a block advances the epoch) removes the action from the governance state and
-refunds its deposit.
+entry in the `UTxOState`{.AgdaRecord}) which is held only while the action is part of
+the governance state.  Each action also records an `expiresIn`{.AgdaField} epoch in
+its `GovActionState`{.AgdaRecord}.
 
-Hence, for every `ChainState`{.AgdaRecord} `cs`{.AgdaBound} and every governance action
-deposit still held in `cs`{.AgdaBound}, there is an epoch `e`{.AgdaBound} (namely, just
-after the action's `expiresIn`{.AgdaField}) such that, once the chain has progressed to
-`e`{.AgdaBound} (i.e. a block has been produced in epoch `e`{.AgdaBound} or later), the
-deposit is no longer in the deposit pot.
+Once that epoch has passed, the `EPOCH`{.AgdaDatatype} transition (run as part of
+`CHAIN`{.AgdaDatatype} whenever a block advances the epoch) removes the action from
+the governance state and refunds its deposit.
+
+Hence, for every `ChainState`{.AgdaRecord} `cs`{.AgdaBound} satisfying
+`govDepsMatch`{.AgdaFunction} and every governance action `gaid`{.AgdaBound} whose
+`GovActionState`{.AgdaRecord} `gaSt`{.AgdaBound} is present in the governance state and
+not yet expired, once the chain has progressed two epochs past `expiresIn`{.AgdaField}
+`gaSt`{.AgdaBound} (i.e. `sucᵉ`{.AgdaFunction} (`sucᵉ`{.AgdaFunction}
+(`expiresIn`{.AgdaField} `gaSt`{.AgdaBound})) `≤`{.AgdaFunction}
+`LastEpochOf`{.AgdaField} `cs'`{.AgdaBound}), the deposit is no longer in the deposit
+pot.
+
+Two epochs are needed because the `EPOCH`{.AgdaDatatype} transition uses a
+pipeline: at epoch `sucᵉ`{.AgdaFunction} (`expiresIn`{.AgdaField}
+`gaSt`{.AgdaBound}), `RATIFIES`{.AgdaDatatype} marks the expired action for removal
+(adding it to `removed`{.AgdaField}); at the *following* epoch, the
+`GovernanceUpdate`{.AgdaModule} actually filters the action out of the governance state
+and strips its deposit from the deposit pot.
+
+Six preconditions are needed.
+
++  `govDepsMatch`{.AgdaFunction} ensures that every
+   `GovActionDeposit`{.AgdaInductiveConstructor} entry has a corresponding
+   `GovActionState`{.AgdaRecord} in the governance state (from which we read
+   `expiresIn`{.AgdaField}).  Without it, "orphan" deposit entries would never be
+   removed.  The predicate is a known `CHAIN`{.AgdaDatatype} invariant.[^1]
+
++  The membership witness
+   `(gaid , gaSt) ∈ fromList (GovStateOf cs)`{.Agda}
+   identifies the `GovActionState`{.AgdaRecord} whose `expiresIn`{.AgdaField} field
+   determines the deadline.
+
++  `LastEpochOf cs ≤ expiresIn gaSt`{.Agda} ensures the action has not yet expired
+   relative to the last processed epoch.  This rules out unreachable states in which an
+   expired action is still present in the governance state—something
+   `govDepsMatch`{.AgdaFunction} alone does not prevent.
+
++  `FreshId gaid bs`{.Agda} asserts that no transaction in the block list
+   `bs`{.AgdaBound} has a `TxId`{.AgdaDatatype} equal to
+   `proj₁`{.AgdaField} `gaid`{.AgdaBound}.  This prevents a new governance
+   proposal from re-using the same `GovActionID`{.AgdaDatatype} after the original
+   action has been removed.  In practice this always holds because
+   `TxId`{.AgdaDatatype} is a cryptographic hash of the transaction body, but the
+   formal specification does not enforce `TxId`{.AgdaDatatype} freshness
+   syntactically.
+
++  `SucIsLeast`{.AgdaFunction} asserts that
+   `sucᵉ`{.AgdaFunction} is the *least* element strictly above a given epoch:
+   `e < e' → sucᵉ e ≤ e'`{.Agda}.  This property holds for the concrete
+   `ℕ`{.AgdaDatatype} epoch structure but is not yet an axiom of
+   `EpochStructure`{.AgdaRecord}; it is taken as a hypothesis here until the
+   axiom is added upstream.
+
++  `CHAINStar-Invariant`{.AgdaFunction} asserts that at every intermediate state
+   of the chain extension, either the deposit is already absent or the three
+   domain conditions (`govDepsMatch`{.AgdaFunction}, `GovState`{.AgdaFunction}
+   membership, epoch bound) still hold.  This invariant is always satisfied for
+   reachable states; its formal derivation from the `CHAIN`{.AgdaDatatype} rule
+   requires additional infrastructure (the `rrm` premise of
+   `CHAIN-govDepsMatch`{.AgdaFunction} and `GovState`{.AgdaFunction} membership
+   preservation through `LEDGERS`{.AgdaDatatype}).
 
 *Formally*.
 
@@ -47,30 +119,488 @@ chain state, and we close `CHAIN`{.AgdaDatatype} under composition along a list 
 blocks.
 
 ```agda
--- The deposit pot of `cs` still holds the deposit for the governance action `gaid`.
+-- The deposits of `cs` still holds the deposit for governance action `gaid`.
 gaDepositInPot : ChainState → GovActionID → Type
 gaDepositInPot cs gaid = GovActionDeposit gaid ∈ dom (DepositsOf cs)
 
 -- Reflexive-transitive closure of CHAIN along a list of blocks.
 data CHAINStar : ChainState → List Block → ChainState → Type where
-  []*  : ∀ {cs} → CHAINStar cs [] cs
-  _∷*_ : ∀ {cs cs' cs'' b bs}
-       → _ ⊢ cs ⇀⦇ b ,CHAIN⦈ cs'
-       → CHAINStar cs' bs cs''
-       → CHAINStar cs (b ∷ bs) cs''
+  []*  : {cs : ChainState} → CHAINStar cs [] cs
+  _∷*_ : {cs cs' cs'' : ChainState} {b : Block} {bs : List Block}
+         → _ ⊢ cs ⇀⦇ b ,CHAIN⦈ cs'
+         → CHAINStar cs' bs cs''
+         → CHAINStar cs (b ∷ bs) cs''
+
+-- No block in bs contains a transaction whose TxId equals txid.
+-- This rules out re-proposal of the same GovActionID, which the formal spec
+-- does not prevent syntactically (TxId is abstract) but which cannot happen
+-- in practice (TxId is a cryptographic hash of the transaction body).
+FreshId : GovActionID → List Block → Type
+FreshId (txid , _) bs = All (λ b → All (λ tx → TxIdOf tx ≢ txid) (ts b)) bs
+
+-- Successor is the least element strictly above.  This holds for the
+-- concrete ℕ epoch structure but is not yet an axiom of EpochStructure.
+SucIsLeast : Type
+SucIsLeast = ∀ {e e' : Epoch} → e < e' → sucᵉ e ≤ e'
+
+-- The inductive hypothesis needs govDepsMatch, GovState membership, and the
+-- epoch bound at each intermediate state.  These are CHAIN invariants whose
+-- formal derivation requires additional infrastructure not yet available (see
+-- proof section).  We bundle them as conditions on the CHAINStar derivation.
+InvariantAt : ChainState → GovActionID → GovActionState → Type
+InvariantAt cs gaid gaSt =
+    (GovActionDeposit gaid ∉ dom (DepositsOf cs))
+    ⊎   govDepsMatch (LStateOf cs)
+        × (gaid , gaSt) ∈ fromList (GovStateOf (LStateOf cs))
+        × LastEpochOf cs ≤ expiresIn gaSt
+
+CHAINStar-Invariant :
+  {cs   : ChainState}
+  {bs   : List Block}
+  {cs'  : ChainState}
+  → GovActionID → GovActionState → CHAINStar cs bs cs' → Type
+
+CHAINStar-Invariant _ _ []* = ⊤
+CHAINStar-Invariant gaid gaSt (_∷*_ {cs' = cs₁} _ rest) =
+  InvariantAt cs₁ gaid gaSt × CHAINStar-Invariant gaid gaSt rest
 ```
 
-The property then states that every held governance action deposit is eventually
-refunded:
+We want to prove that every governance action deposit is eventually
+refunded, which we express formally as the following type definition.
+
+**Theorem**.
 
 ```agda
-GADepositsEventuallyRefunded : Type
-GADepositsEventuallyRefunded = ∀ {cs : ChainState} {gaid : GovActionID}
-  → gaDepositInPot cs gaid
-  → Σ[ e ∈ Epoch ] (∀ {bs : List Block} {cs' : ChainState}
-      → CHAINStar cs bs cs'
-      → e ≤ LastEpochOf cs'
-      → ¬ gaDepositInPot cs' gaid)
+data _⊢_⇀⦇_,REFUNDED⦈_ : ⊤ → ChainState → List Block → ChainState → Type where
+
+  REFUNDED :
+    {cs     : ChainState}
+    {bs     : List Block}
+    {cs'    : ChainState}
+    {gaid   : GovActionID}
+    {gaSt   : GovActionState}
+    {chain  : CHAINStar cs bs cs'}
+    →
+    ∙ SucIsLeast
+    ∙ govDepsMatch (LStateOf cs)
+    ∙ (gaid , gaSt) ∈ fromList (GovStateOf (LStateOf cs))
+    ∙ LastEpochOf cs ≤ expiresIn gaSt
+    ∙ FreshId gaid bs
+    ∙ CHAINStar-Invariant gaid gaSt chain
+    ∙ sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs'
+      ────────────────────────────────
+      _ ⊢ cs ⇀⦇ bs ,REFUNDED⦈ cs'
+
+GADepositsEventuallyRefunded : ∀ {cs bs cs'}
+  → _ ⊢ cs ⇀⦇ bs ,REFUNDED⦈ cs' → Type
+GADepositsEventuallyRefunded {cs' = cs'} (REFUNDED {gaid = gaid} _) =
+  ¬ gaDepositInPot cs' gaid
+
+GADepositsEventuallyRefunded' : Type
+GADepositsEventuallyRefunded' =
+  SucIsLeast
+  →  {cs    : ChainState}
+     {gaid  : GovActionID}
+     {gaSt  : GovActionState}
+     → govDepsMatch (LStateOf cs)
+     → (gaid , gaSt) ∈ fromList (GovStateOf (LStateOf cs))
+     → LastEpochOf cs ≤ expiresIn gaSt
+     →  {bs : List Block}
+        {cs' : ChainState}
+        → (chain : CHAINStar cs bs cs')
+        → FreshId gaid bs
+        → CHAINStar-Invariant gaid gaSt chain
+        → sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs'
+        → ¬ gaDepositInPot cs' gaid
 ```
 
-*Proof*. (TODO)
+**Proof**.
+
+We prove `gaDepositsEventuallyRefunded`{.AgdaFunction}: given a
+`REFUNDED`{.AgdaInductiveConstructor} derivation, the deposit is gone.
+The proof delegates to the workhorse `gaDepositsEventuallyRefunded'`{.AgdaFunction},
+which proceeds by induction on `CHAINStar`{.AgdaDatatype}.
+
+<!--
+```agda
+private
+  module Ep = HasPreorder preoEpoch
+
+  -- Slot-level <-trans, accessed explicitly to avoid instance-resolution issues.
+  <-transˢ : ∀ {x y z : Slot} → x < y → y < z → x < z
+  <-transˢ = HasPartialOrder.<-trans (HasDecPartialOrder.hasPartialOrder DecPo-Slot)
+
+  -- a ≤ b and sucᵉ b ≤ a is absurd, because b < sucᵉ b (e<sucᵉ).
+  ≤e<sucᵉ⇒⊥ : ∀ {a b : Epoch} → a ≤ b → sucᵉ b ≤ a → ⊥
+  ≤e<sucᵉ⇒⊥ {_} {b} p q =
+    case Ep.≤-trans q p of λ where
+      (inj₁ h) → Ep.<-irrefl refl (<-transˢ (e<sucᵉ {b}) h)
+      (inj₂ h) → Ep.<-irrefl (sym h) (e<sucᵉ {b})
+
+  -- Corollary: a ≤ b and sucᵉ (sucᵉ b) ≤ a is also absurd.
+  ≤e<sucᵉsucᵉ⇒⊥ : ∀ {a b : Epoch} → a ≤ b → sucᵉ (sucᵉ b) ≤ a → ⊥
+  ≤e<sucᵉsucᵉ⇒⊥ {_} {b} p q =
+    ≤e<sucᵉ⇒⊥ p (Ep.≤-trans (inj₁ (e<sucᵉ {sucᵉ b})) q)
+
+  -- govDepsMatch lemmas: the GA deposits in the deposit pot correspond
+  -- exactly to the GovState entries, so absence from dpMap (GovState)
+  -- implies absence from the deposit pot.
+  open Equivalence
+
+  -- If govDepsMatch and the deposit is in the pot, GovActionDeposit gaid
+  -- is in dpMap (i.e. gaid appears as proj₁ of some GovState entry).
+  gdm-dep⇒dpMap : ∀ {ls : LState} {gaid : GovActionID} → govDepsMatch ls
+    → (GovActionDeposit gaid ∈ dom (DepositsOf ls))
+    → (GovActionDeposit gaid ∈ fromList (dpMap (GovStateOf ls)))
+  gdm-dep⇒dpMap {ls} gdm dep = proj₁ gdm (∈-filter .to (refl , dep))
+
+  -- Contrapositive: if gaid is absent from dpMap, the deposit is absent.
+  gdm-¬dpMap⇒¬dep : ∀ {ls : LState} {gaid : GovActionID} → govDepsMatch ls
+    → (GovActionDeposit gaid ∉ fromList (dpMap (GovStateOf ls)))
+    → (GovActionDeposit gaid ∉ dom (DepositsOf ls))
+  gdm-¬dpMap⇒¬dep {ls} gdm notMem dep = notMem (gdm-dep⇒dpMap {ls} gdm dep)
+
+  -- RATIFY / RATIFIES lemmas ----------------------
+
+  -- Abbreviation for membership in the removed field.
+  _∈ʳ_ : GovActionID × GovActionState → RatifyState → Type
+  x ∈ʳ s = x ∈ RatifyState.removed s
+
+  -- Single RATIFY step: an expired action is always added to removed.
+  ratify-expired⇒in-removed :
+    ∀ {Γ s s'} {a : GovActionID × GovActionState}
+    → Γ ⊢ s ⇀⦇ a ,RATIFY⦈ s'
+    → expired (currentEpoch Γ) (proj₂ a)
+    → a ∈ʳ s'
+  ratify-expired⇒in-removed (RATIFY-Accept _) _ = ∈-∪ .to (inj₁ (∈-singleton .to refl))
+  ratify-expired⇒in-removed (RATIFY-Reject _) _ = ∈-∪ .to (inj₁ (∈-singleton .to refl))
+  ratify-expired⇒in-removed (RATIFY-Continue (_ , notExp)) exp = ⊥-elim (notExp exp)
+
+  -- RATIFY only grows the removed set.
+  ratify-removed-mono :
+    ∀ {Γ s s'} {a : GovActionID × GovActionState} {x : GovActionID × GovActionState}
+    → Γ ⊢ s ⇀⦇ a ,RATIFY⦈ s' → x ∈ʳ s → x ∈ʳ s'
+  ratify-removed-mono (RATIFY-Accept _)   h = ∈-∪ .to (inj₂ h)
+  ratify-removed-mono (RATIFY-Reject _)   h = ∈-∪ .to (inj₂ h)
+  ratify-removed-mono (RATIFY-Continue _) h = h
+
+  -- RATIFIES (RTC) also only grows removed.
+  ratifies-removed-mono :
+    ∀ {Γ s s'} {as : List (GovActionID × GovActionState)} {x : GovActionID × GovActionState}
+    → Γ ⊢ s ⇀⦇ as ,RATIFIES⦈ s' → x ∈ʳ s → x ∈ʳ s'
+  ratifies-removed-mono (BS-base Id-nop) h = h
+  ratifies-removed-mono (BS-ind step rest) h =
+    ratifies-removed-mono rest (ratify-removed-mono step h)
+
+  -- Main RATIFIES lemma: every expired action in the processed list
+  -- ends up in the removed set of the output.
+  ratifies-expired∈⇒in-removed :
+    ∀ {Γ s s'} {as : List (GovActionID × GovActionState)}
+      {a : GovActionID × GovActionState}
+    → Γ ⊢ s ⇀⦇ as ,RATIFIES⦈ s'
+    → a ∈ˡ as
+    → expired (currentEpoch Γ) (proj₂ a)
+    → a ∈ʳ s'
+  ratifies-expired∈⇒in-removed (BS-ind step rest) (here refl) exp =
+    ratifies-removed-mono rest (ratify-expired⇒in-removed step exp)
+  ratifies-expired∈⇒in-removed (BS-ind step rest) (there mem) exp =
+    ratifies-expired∈⇒in-removed rest mem exp
+
+  -- GovernanceUpdate lemma ----------------------------
+
+  -- If (gaid, gaSt) ∈ removed(fut), then after GovernanceUpdate
+  -- the action is not in govSt'.
+  govUpdate-removes :
+    {ls          : LState}
+    {fut         : RatifyState}
+    {gaid        : GovActionID}
+    {gaSt gaSt'  : GovActionState}
+    → (gaid , gaSt) ∈ removed fut
+    → (gaid , gaSt') ∉ˡ GovernanceUpdate.govSt' ls fut
+  govUpdate-removes {ls} {fut} {gaid} {gaSt} inRem inGovSt' = gaid∉ gaid∈
+    where
+    open GovernanceUpdate ls fut
+
+    P : GovActionID × GovActionState → Type
+    P (id , _) = id ∉ mapˢ proj₁ removed'
+
+    gaid∉ : gaid ∉ mapˢ proj₁ removed'
+    gaid∉ = proj₂ (∈-filter⁻ (¿ P ¿¹) {xs = GovStateOf ls} inGovSt')
+
+    gaid∈ : gaid ∈ mapˢ proj₁ removed'
+    gaid∈ = ∈-map .to ((gaid , gaSt) , refl , ∈-∪ .to (inj₁ inRem))
+
+  -- Deposit-absence preservation ----------------------
+
+  -- GA keys never appear in certDeposit or certRefund.
+  GA∉dom-certDep : ∀ {gaid} cert pp → GovActionDeposit gaid ∉ dom (certDeposit cert pp ˢ)
+  GA∉dom-certDep (dereg _ _)         _  h = Properties.∉-∅ (proj₁ dom∅ h)
+  GA∉dom-certDep (deregdrep _ _)     _  h = Properties.∉-∅ (proj₁ dom∅ h)
+  GA∉dom-certDep (retirepool _ _)    _  h = Properties.∉-∅ (proj₁ dom∅ h)
+  GA∉dom-certDep (ccreghot _ _)      _  h = Properties.∉-∅ (proj₁ dom∅ h)
+  GA∉dom-certDep (delegate c d k v)  pp h with from ∈-singleton (from dom∈ h .proj₂)
+  ... | ()
+  GA∉dom-certDep (reg c v)           pp h with from ∈-singleton (from dom∈ h .proj₂)
+  ... | ()
+  GA∉dom-certDep (regpool kh p)      pp h with from ∈-singleton (from dom∈ h .proj₂)
+  ... | ()
+  GA∉dom-certDep (regdrep c v a)     pp h with from ∈-singleton (from dom∈ h .proj₂)
+  ... | ()
+
+  -- Map-operation helpers (specialised to Deposits).
+  ∉-dom-∪⁺ᵈ : {m n : Deposits} {x : DepositPurpose}
+    → x ∉ dom (m ˢ) → x ∉ dom (n ˢ) → x ∉ dom ((m ∪⁺ n) ˢ)
+  ∉-dom-∪⁺ᵈ h₁ h₂ h = case from ∈-∪ (proj₁ dom∪⁺≡∪dom h) of λ where
+    (inj₁ x) → h₁ x
+    (inj₂ x) → h₂ x
+
+  ∉-dom-∪ˡᵈ : ∀ {m n : Deposits} {x : DepositPurpose}
+    → x ∉ dom (m ˢ) → x ∉ dom (n ˢ) → x ∉ dom ((m ∪ˡ n) ˢ)
+  ∉-dom-∪ˡᵈ {m} {n} h₁ h₂ h =
+    case from ∈-∪ (proj₁ (dom∪ˡ≡∪dom {m = m} {m' = n}) h) of λ where
+      (inj₁ x) → h₁ x
+      (inj₂ x) → h₂ x
+
+  ∉-dom-resᶜᵈ : ∀ {m : Deposits} {S : ℙ DepositPurpose} {x : DepositPurpose}
+    → x ∉ dom (m ˢ) → x ∉ dom ((m ∣ S ᶜ) ˢ)
+  ∉-dom-resᶜᵈ h h' = h (res-comp-domᵐ h')
+
+  -- updateCertDeposits preserves GA-deposit absence.
+  updCertDeps-GA-absent :
+    {gaid   : GovActionID}
+    (pp     : PParams )
+    (certs  : List DCert)
+    (deps   : Deposits)
+    → GovActionDeposit gaid ∉ dom (deps ˢ)
+    → GovActionDeposit gaid ∉ dom (updateCertDeposits pp certs deps ˢ)
+
+  updCertDeps-GA-absent pp [] deps h = h
+
+  updCertDeps-GA-absent pp (delegate c d k v ∷ cs) deps h =
+    updCertDeps-GA-absent pp cs
+      (deps ∪⁺ certDeposit (delegate c d k v) pp)
+      (∉-dom-∪⁺ᵈ h (GA∉dom-certDep (delegate c d k v) pp))
+
+  updCertDeps-GA-absent pp (reg c v ∷ cs) deps h =
+    updCertDeps-GA-absent pp cs
+      (deps ∪⁺ certDeposit (reg c v) pp)
+      (∉-dom-∪⁺ᵈ h (GA∉dom-certDep (reg c v) pp))
+
+  updCertDeps-GA-absent pp (regpool kh p ∷ cs) deps h =
+    updCertDeps-GA-absent pp cs
+      (deps ∪ˡ certDeposit (regpool kh p) pp)
+      (∉-dom-∪ˡᵈ  {m = deps} {n = certDeposit (regpool kh p) pp}
+                  h (GA∉dom-certDep (regpool kh p) pp))
+
+  updCertDeps-GA-absent pp (regdrep c v a ∷ cs) deps h =
+    updCertDeps-GA-absent pp cs
+      (deps ∪⁺ certDeposit (regdrep c v a) pp)
+      (∉-dom-∪⁺ᵈ h (GA∉dom-certDep (regdrep c v a) pp))
+
+  updCertDeps-GA-absent pp (dereg c v ∷ cs) deps h =
+    updCertDeps-GA-absent pp cs (deps ∣ certRefund (dereg c v) ᶜ) (∉-dom-resᶜᵈ {m = deps} h)
+
+  updCertDeps-GA-absent pp (deregdrep c v ∷ cs) deps h =
+    updCertDeps-GA-absent pp cs (deps ∣ certRefund (deregdrep c v) ᶜ) (∉-dom-resᶜᵈ {m = deps} h)
+
+  updCertDeps-GA-absent pp (retirepool _ _ ∷ cs) deps h = updCertDeps-GA-absent pp cs deps h
+  updCertDeps-GA-absent pp (ccreghot _ _ ∷ cs) deps h = updCertDeps-GA-absent pp cs deps h
+
+  -- GovActionDeposit is injective.
+  GovActionDeposit-inj : ∀ {a b} → GovActionDeposit a ≡ GovActionDeposit b → a ≡ b
+  GovActionDeposit-inj refl = refl
+
+  -- updateProposalDeposits with fresh TxId preserves GA absence.
+  updPropDeps-GA-absent :
+    {gaid   : GovActionID}
+    (props  : List GovProposal)
+    (txid   : TxId)
+    (gaDep  : Coin)
+    (deps   : Deposits)
+    → txid ≢ gaid .proj₁
+    → GovActionDeposit gaid ∉ dom (deps ˢ)
+    → GovActionDeposit gaid ∉ dom (updateProposalDeposits props txid gaDep deps ˢ)
+  updPropDeps-GA-absent [] _ _ _ _ h = h
+  updPropDeps-GA-absent {gaid} (_ ∷ ps) txid gaDep deps txid≢ notIn =
+    ∉-dom-∪⁺ᵈ {m = updateProposalDeposits ps txid gaDep deps}
+      (updPropDeps-GA-absent ps txid gaDep deps txid≢ notIn) newKey∉
+    where
+    newKey∉ : GovActionDeposit gaid ∉ dom (❴ GovActionDeposit (txid , length ps) , gaDep ❵ ˢ)
+    newKey∉ h = txid≢ (cong proj₁ (GovActionDeposit-inj (cong proj₁ (sym (from ∈-singleton (from dom∈ h .proj₂))))))
+
+  -- Combined: updateDeposits with fresh TxId preserves GA absence.
+  updateDeposits-GA-absent : ∀ {gaid : GovActionID} pp (tx : Tx) (deps : Deposits)
+    → TxIdOf tx ≢ proj₁ gaid
+    → GovActionDeposit gaid ∉ dom (deps ˢ)
+    → GovActionDeposit gaid ∉ dom (updateDeposits pp (TxBodyOf tx) deps ˢ)
+  updateDeposits-GA-absent {gaid} pp tx deps txid≢ notIn =
+    -- let open TxBody txb
+    updCertDeps-GA-absent pp (DCertsOf tx)
+         (updateProposalDeposits (GovProposalsOf tx) (TxIdOf tx) (PParams.govActionDeposit pp) deps)
+         (updPropDeps-GA-absent (GovProposalsOf tx) (TxIdOf tx) (PParams.govActionDeposit pp) deps txid≢ notIn)
+
+  -- Per-LEDGER-step deposit absence preservation ------------------------
+
+  LEDGER-GA-absent : ∀ {Γ ls tx ls'} {gaid : GovActionID}
+    → Γ ⊢ ls ⇀⦇ tx ,LEDGER⦈ ls'
+    → TxIdOf tx ≢ proj₁ gaid
+    → GovActionDeposit gaid ∉ dom (DepositsOf ls)
+    → GovActionDeposit gaid ∉ dom (DepositsOf ls')
+
+  -- Valid tx, scripts pass: deposits updated via updateDeposits.
+  LEDGER-GA-absent {Γ} {ls} {tx}
+    (LEDGER-V⋯ refl (UTXOW-UTXOS (Scripts-Yes _)) _ _) txid≢ h =
+    updateDeposits-GA-absent (PParamsOf Γ) tx (DepositsOf ls) txid≢ h
+
+  -- Invalid tx, scripts fail: deposits unchanged (collateral only).
+  LEDGER-GA-absent (LEDGER-I⋯ refl (UTXOW-UTXOS (Scripts-No _))) _ h = h
+
+  -- Lift to LEDGERS (RTC of LEDGER) using FreshId for the tx list.
+  LEDGERS-GA-absent : ∀ {Γ ls txs ls'} {gaid : GovActionID}
+    → Γ ⊢ ls ⇀⦇ txs ,LEDGERS⦈ ls'
+    → All (λ tx → TxIdOf tx ≢ proj₁ gaid) txs
+    → GovActionDeposit gaid ∉ dom (DepositsOf ls)
+    → GovActionDeposit gaid ∉ dom (DepositsOf ls')
+
+  LEDGERS-GA-absent (BS-base Id-nop) _ h = h
+  LEDGERS-GA-absent (BS-ind step rest) (fresh ∷ freshRest) h =
+    LEDGERS-GA-absent rest freshRest (LEDGER-GA-absent step fresh h)
+
+  -- Per-CHAIN-step deposit absence preservation --------------------------
+
+  -- Through a single CHAIN step, if the deposit is absent and FreshId
+  -- holds for the block, the deposit stays absent.  The deposits go
+  -- through GovernanceUpdate ∣_ᶜ (only removes), POOLREAP ∣_ᶜ (only
+  -- removes PoolDeposit keys), and LEDGERS/updateDeposits (FreshId
+  -- prevents GA-key addition).
+  -- EPOCH preserves GA-deposit absence (deposits only shrink via ∣_ᶜ).
+  EPOCH-GA-absent : ∀ {eps eps'} {e : Epoch} {gaid : GovActionID}
+    → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
+    → GovActionDeposit gaid ∉ dom (DepositsOf eps)
+    → GovActionDeposit gaid ∉ dom (DepositsOf eps')
+
+  EPOCH-GA-absent {eps} (EPOCH (_ , POOLREAP , _)) h =
+    ∉-dom-resᶜᵈ {m = DepositsOf utxoSt'} (∉-dom-resᶜᵈ {m = DepositsOf eps} h)
+    where
+    open GovernanceUpdate (LStateOf eps) (RatifyStateOf eps) using (updates)
+    open Pre-POOLREAPUpdate (LStateOf eps) (EnactStateOf (RatifyStateOf eps)) updates using (utxoSt')
+
+  CHAIN-GA-absent : ∀ {cs b cs₁} {gaid : GovActionID}
+    → _ ⊢ cs ⇀⦇ b ,CHAIN⦈ cs₁
+    → All (λ tx → TxIdOf tx ≢ proj₁ gaid) (ts b)
+    → GovActionDeposit gaid ∉ dom (DepositsOf cs)
+    → GovActionDeposit gaid ∉ dom (DepositsOf cs₁)
+
+  CHAIN-GA-absent  ( CHAIN  ( _
+                            , TICK ( NEWEPOCH-New (_ , epochStep) , _ )
+                            , BBODY-Block-Body ( _ , _ , _ , ledgers )
+                            )
+                   ) fresh h = LEDGERS-GA-absent ledgers fresh (EPOCH-GA-absent epochStep h)
+
+  CHAIN-GA-absent  ( CHAIN  ( _
+                            , TICK ( NEWEPOCH-Not-New _ , _ )
+                            , BBODY-Block-Body ( _ , _ , _ , ledgers )
+                            )
+                   ) fresh h = LEDGERS-GA-absent ledgers fresh h
+
+  CHAIN-GA-absent  ( CHAIN  ( _
+                            , TICK ( (NEWEPOCH-No-Reward-Update (_ , epochStep) ) , _ )
+                            , BBODY-Block-Body ( _ , _ , _ , ledgers )
+                            )
+                   ) fresh h = LEDGERS-GA-absent ledgers fresh (EPOCH-GA-absent epochStep h)
+
+  -- Lift to CHAINStar: deposit stays absent through a sequence of blocks.
+  CHAINStar-GA-absent : ∀ {cs bs cs'} {gaid : GovActionID}
+    → CHAINStar cs bs cs'
+    → FreshId gaid bs
+    → GovActionDeposit gaid ∉ dom (DepositsOf cs)
+    → GovActionDeposit gaid ∉ dom (DepositsOf cs')
+  CHAINStar-GA-absent []* _ h = h
+  CHAINStar-GA-absent (step ∷* rest) (freshB ∷ freshRest) h =
+    CHAINStar-GA-absent rest freshRest (CHAIN-GA-absent step freshB h)
+```
+-->
+
+```agda
+  -- Main workhorse proof (flat version) -----------------
+
+  gaDepositsEventuallyRefunded' : GADepositsEventuallyRefunded'
+
+  -- Base case: the epoch bound contradicts the not-yet-expired hypothesis.
+  gaDepositsEventuallyRefunded' _ _ _ notexp []* _ _ cutoff =
+    ⊥-elim (≤e<sucᵉsucᵉ⇒⊥ notexp cutoff)
+
+  -- Inductive step: use the invariant at cs₁ to decide the next action.
+  gaDepositsEventuallyRefunded' sucLeast gdm mem notexp
+    (_∷*_ {cs' = cs₁} step rest) (freshB ∷ freshRest) (inv₁ , invRest) cutoff with inv₁
+
+    --| Deposit already absent at cs₁:
+  ... | inj₁ absent₁ = CHAINStar-GA-absent rest freshRest absent₁
+
+    --| IH preconditions hold at cs₁ (recurse):
+  ... | inj₂ (gdm₁ , mem₁ , notexp₁) =
+    gaDepositsEventuallyRefunded' sucLeast gdm₁ mem₁ notexp₁ rest freshRest invRest cutoff
+
+
+  -- Theorem: given a REFUNDED derivation, the deposit is refunded and gone for good.
+
+  gaDepositsEventuallyRefunded :
+
+    {cs  : ChainState}
+    {bs  : List Block}
+    {cs' : ChainState}
+
+    (h : _ ⊢ cs ⇀⦇ bs ,REFUNDED⦈ cs') → GADepositsEventuallyRefunded h
+
+  gaDepositsEventuallyRefunded
+    (REFUNDED (sucLeast , gdm , mem , notexp , fresh , inv , cutoff)) =
+      gaDepositsEventuallyRefunded' sucLeast gdm mem notexp _ fresh inv cutoff
+
+```
+
+The workhorse proof `gaDepositsEventuallyRefunded'`{.AgdaFunction} proceeds by
+induction on `CHAINStar`{.AgdaDatatype} and uses the
+`CHAINStar-Invariant`{.AgdaFunction} at each step.
+
+**Base case** (`[]*`{.AgdaInductiveConstructor}).
+Vacuous: `≤e<sucᵉsucᵉ⇒⊥`{.AgdaFunction} derives `⊥`{.AgdaDatatype} from the
+contradictory epoch bounds
+(`LastEpochOf cs ≤ expiresIn gaSt`{.Agda} vs.
+`sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs`{.Agda}).
+
+**Inductive step** (`step ∷* rest`{.Agda}).
+The `CHAINStar-Invariant`{.AgdaFunction} provides
+`InvariantAt`{.AgdaFunction} at the intermediate state `cs₁`{.AgdaBound}.
+Two cases:
+
++  **Deposit already absent** (`inj₁`{.AgdaInductiveConstructor}).
+   `CHAINStar-GA-absent`{.AgdaFunction} propagates the absence through the
+   remaining steps `rest`{.AgdaBound}, since each `CHAIN`{.AgdaDatatype} step
+   preserves GA-deposit absence (given `FreshId`{.AgdaFunction}).
+
++  **IH preconditions hold** (`inj₂`{.AgdaInductiveConstructor}).
+   The invariant supplies `govDepsMatch`{.AgdaFunction},
+   `GovState`{.AgdaFunction} membership, and the epoch bound at `cs₁`{.AgdaBound}.
+   The inductive hypothesis applies directly to `rest`{.AgdaBound}.
+
+The following table summarises the preconditions and their status.
+
+| # | Precondition | Status |
+|---|--------------|--------|
+| 1 | `govDepsMatch`{.AgdaFunction} | Known `CHAIN`{.AgdaDatatype} invariant[^1] |
+| 2 | `GovState`{.AgdaFunction} membership | Identifies the action |
+| 3 | `LastEpochOf cs ≤ expiresIn gaSt`{.Agda} | Action not yet expired |
+| 4 | `FreshId`{.AgdaFunction} | Holds in practice (`TxId`{.AgdaDatatype} is a hash) |
+| 5 | `SucIsLeast`{.AgdaFunction} | Holds for `ℕ`{.AgdaDatatype}; missing `EpochStructure`{.AgdaRecord} axiom |
+| 6 | `CHAINStar-Invariant`{.AgdaFunction} | Holds for reachable states; derivation requires additional infrastructure |
+
+Preconditions 4–6 are "engineering debt": they hold for all reachable states but
+their formal derivation from the existing abstract interface requires
+infrastructure not yet present in the specification (abstract
+`TxId`{.AgdaDatatype} freshness, the `<⇒sucᵉ≤`{.Agda} axiom in
+`EpochStructure`{.AgdaRecord}, and the `rrm` premise of
+`CHAIN-govDepsMatch`{.AgdaFunction}).
+
+---
+
+[^1]: See [`CHAIN-govDepsMatch`][Chain.Properties.GovDepsMatch] for the proof.

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -126,7 +126,7 @@ proposals in `tx`{.AgdaBound}.
    of `cs`{.AgdaBound} and `cs'`{.AgdaBound} differ, then the epoch of the slot of
    `b`{.AgdaBound} is the successor of the last epoch of `cs`{.AgdaBound}.
 
-  **Claim** [Chain.Properties.EventuallyRefunded][].  Governance action deposits are eventually refunded.
++  **Claim** [CHAIN-EventuallyRefunded][].  Governance action deposits are eventually refunded.
 
    For every `ChainState`{.AgdaRecord} `cs`{.AgdaBound} and every governance action
    deposit still held in the deposit pot of `cs`{.AgdaBound}, there is an epoch

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -126,6 +126,14 @@ proposals in `tx`{.AgdaBound}.
    of `cs`{.AgdaBound} and `cs'`{.AgdaBound} differ, then the epoch of the slot of
    `b`{.AgdaBound} is the successor of the last epoch of `cs`{.AgdaBound}.
 
+  **Claim** [Chain.Properties.EventuallyRefunded][].  Governance action deposits are eventually refunded.
+
+   For every `ChainState`{.AgdaRecord} `cs`{.AgdaBound} and every governance action
+   deposit still held in the deposit pot of `cs`{.AgdaBound}, there is an epoch
+   `e`{.AgdaBound} such that, once the chain has progressed to `e`{.AgdaBound} (a block
+   has been produced in epoch `e`{.AgdaBound} or later), that deposit is no longer in the
+   deposit pot.
+
 +  **Claim** [NEWEPOCH-ConstRwds][].  Rewards are left unchanged by the `NEWEPOCH`{.AgdaOperator} rule.
 
    That is, if `es`{.AgdaBound} and `es'`{.AgdaBound} are two


### PR DESCRIPTION
## Description

Closes #414. States and proves the governance property "GA deposits are eventually refunded."

+ `Ledger.Conway.Specification.Chain` gains **`CHAINS`**, the reflexive-transitive closure of `CHAIN` along a list of blocks, via the existing `ReflexiveTransitiveClosure` combinator (mirroring `LEDGERS`).

+ `Interface.STS` gains a generic trace-invariant combinator: **`RTC-All P tr`** asserts `P` at the target state of every step of a trace; **`RTC-All-last`** reads `P` off at the final state of a nonempty trace.

+ New module `Ledger.Conway.Specification.Chain.Properties.EventuallyRefunded`: `gaDepositInPot`, the per-state refund-deadline invariant `InvariantAt`, the statement `GADepositsEventuallyRefunded`, and its proof.

---

### Theorem

Given

1. `govDepsMatch (LStateOf cs)` (a known CHAIN invariant), 
2. a `GovState` membership witness for `(gaid , gaSt)`,
3. `LastEpochOf cs ≤ expiresIn gaSt` (not yet expired),
4. a chain extension `chain : _ ⊢ cs ⇀⦇ bs ,CHAINS⦈ cs'` satisfying `RTC-All (InvariantAt gaid gaSt) chain`, and
5. the cutoff `sucᵉ (sucᵉ (expiresIn gaSt)) ≤ LastEpochOf cs'`,

the deposit is gone: `¬ gaDepositInPot cs' gaid`.

The cutoff is two epochs past expiry because of the `RATIFY`/`GovernanceUpdate` pipeline: `RATIFIES` marks the expired action for removal at `sucᵉ (expiresIn)`, and `GovernanceUpdate` filters it out and refunds the deposit at the following boundary.

Precondition 4 holds at every reachable chain state but is presently an assumption; deriving it from the CHAIN rule requires infrastructure not yet in the specification (the `rrm` premise of `CHAIN-govDepsMatch`, tracking the action through `LEDGERS`/`RATIFIES`, abstract `TxId` freshness, and a `sucᵉ`-is-least `EpochStructure` axiom).  (Tracked in Issue #1260, which catalogs the partial machinery in this PR's history.)

---

### Proof structure

The trace invariant constrains every state reached along the extension; in particular, the final one (`RTC-All-last`).  The proof reads the invariant off at the final state and compares epochs: for the empty trace, `cs' = cs` and precondition 3 contradicts the cutoff; otherwise the invariant at `cs'` either yields the refund outright or bounds `LastEpochOf cs'` below the cutoff, a contradiction.

---

### Extra Notes for Reviewer

`CHAINS` now appears in the rendered spec document (Chain chapter) even though the spec itself doesn't use it yet.  (That's what Carlos asked for and it matches the `LEDGERS` precedent; but if we change our mind, the fallback is defining it in the Properties module.)

---

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
