### PR TITLE
Gov property #417: state that a voter's last vote is applied to the GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ## Conway spec
 
-- State the claim that a voter's (last) vote in a block is applied to the governance action (statement only; see #417)
+- State and prove the claim that a voter's (last) vote in a block is applied to the governance action (see #417)
 - Change `RwdAddr` to `RewardAddress`
 - Do not count pool deposits a second time when reregistering pools
 - Allow reregistration of pools in the POOL transition relation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## Conway spec
 
+- State the claim that a voter's (last) vote in a block is applied to the governance action (statement only; see #417)
 - Change `RwdAddr` to `RewardAddress`
 - Do not count pool deposits a second time when reregistering pools
 - Allow reregistration of pools in the POOL transition relation

--- a/build-tools/static/mkdocs/includes/links.md
+++ b/build-tools/static/mkdocs/includes/links.md
@@ -56,7 +56,7 @@
 [Governance Functions]: Ledger.Conway.Specification.Gov.md#governance-functions
 [Gov-ChangePPHasGroup]: Ledger.Conway.Specification.Gov.Properties.ChangePPGroup.md#clm:ChangePPGroup
 [Gov.Properties.LastVoteApplied]: Ledger.Conway.Specification.Gov.Properties.LastVoteApplied.md
-[Gov-LastVoteApplied]: Ledger.Conway.Specification.Gov.Properties.LastVoteApplied.md#clm:LastVoteApplied
+[Gov-LastVoteApplied]: Ledger.Conway.Specification.Gov.Properties.LastVoteApplied.md
 [issues]: https://github.com/IntersectMBO/formal-ledger-specifications/issues
 [Introduction]: Ledger.Introduction.md
 [LEDGER]: Ledger.Conway.Specification.Ledger.md#ledger-transition-system
@@ -64,8 +64,9 @@
 [Ledger.Properties.GovDepsMatch]: Ledger.Conway.Specification.Ledger.Properties.GovDepsMatch.md
 [Ledger.Properties.PoV]: Ledger.Conway.Specification.Ledger.Properties.PoV.md
 [LEDGERS]: Ledger.Conway.Specification.Ledger.md#ledgers-transition-system
-[LEDGER-PoV]: Ledger.Conway.Specification.Ledger.Properties.PoV.md#thm:LEDGER-PoV
 [LEDGER-GovDepsMatch]: Ledger.Conway.Specification.Ledger.Properties.GovDepsMatch.md#lem:LedgerGovDepsMatch
+[Ledger-LastVoteApplied]: Ledger.Conway.Specification.Ledger.Properties.LastVoteApplied.md
+[LEDGER-PoV]: Ledger.Conway.Specification.Ledger.Properties.PoV.md#thm:LEDGER-PoV
 [NEWEPOCH]: Ledger.Conway.Specification.Epoch.md#sec:the-newepoch-transition-system
 [NEWEPOCH-ConstRwds]: Ledger.Conway.Specification.Epoch.Properties.ConstRwds.md#clm:NEWEPOCH-const-rwds
 [Notation]: Notation.md

--- a/build-tools/static/mkdocs/includes/links.md
+++ b/build-tools/static/mkdocs/includes/links.md
@@ -55,6 +55,7 @@
 [GOVCERT]: Ledger.Conway.Specification.Certs.md#auxiliary-govcert-transition-system
 [Governance Functions]: Ledger.Conway.Specification.Gov.md#governance-functions
 [Gov-ChangePPHasGroup]: Ledger.Conway.Specification.Gov.Properties.ChangePPGroup.md#clm:ChangePPGroup
+[Gov-LastVoteApplied]:  Ledger.Conway.Specification.Gov.Properties.LastVoteApplied.md
 [issues]: https://github.com/IntersectMBO/formal-ledger-specifications/issues
 [Introduction]: Ledger.Introduction.md
 [LEDGER]: Ledger.Conway.Specification.Ledger.md#ledger-transition-system

--- a/build-tools/static/mkdocs/includes/links.md
+++ b/build-tools/static/mkdocs/includes/links.md
@@ -55,7 +55,8 @@
 [GOVCERT]: Ledger.Conway.Specification.Certs.md#auxiliary-govcert-transition-system
 [Governance Functions]: Ledger.Conway.Specification.Gov.md#governance-functions
 [Gov-ChangePPHasGroup]: Ledger.Conway.Specification.Gov.Properties.ChangePPGroup.md#clm:ChangePPGroup
-[Gov-LastVoteApplied]:  Ledger.Conway.Specification.Gov.Properties.LastVoteApplied.md
+[Gov.Properties.LastVoteApplied]: Ledger.Conway.Specification.Gov.Properties.LastVoteApplied.md
+[Gov-LastVoteApplied]: Ledger.Conway.Specification.Gov.Properties.LastVoteApplied.md#clm:LastVoteApplied
 [issues]: https://github.com/IntersectMBO/formal-ledger-specifications/issues
 [Introduction]: Ledger.Introduction.md
 [LEDGER]: Ledger.Conway.Specification.Ledger.md#ledger-transition-system

--- a/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
+++ b/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
@@ -701,3 +701,53 @@ module _  {A B : Type}
 
       lem-del-excluded : ∀ m → ¬ P k → filterᵐ P′ (m ∣ ❴ k ❵ ᶜ) ≡ᵐ filterᵐ P′ m
       lem-del-excluded m ¬p = filterᵐ-restrict m ⟨≈⟩ restrict-singleton-filterᵐ-false m ¬p
+
+
+-- Map lemmas: lookup after insert
+
+-- Looking up a freshly inserted key returns the inserted value.
+-- Since `insert m k v = ❴ k , v ❵ᵐ ∪ˡ m` (singleton on the left),
+-- `(k , v)` is in the inserted map, and `∈⇒lookup≡just` reads it back.
+lookupᵐ?-insert : ∀ {A B : Type} ⦃ _ : DecEq A ⦄ (m : A ⇀ B) (k : A) (v : B)
+  → lookupᵐ? (insert m k v) k ≡ just v
+lookupᵐ?-insert m k v =
+  ∈⇒lookup≡just (insert m k v) k (Properties.∈-∪⁺ (inj₁ (Equivalence.to ∈-singleton refl)))
+
+-- Inserting at a *different* key preserves membership in both directions (`insert` is a
+-- left-biased union with the singleton `❴ k₀ , v₀ ❵ᵐ`, which only touches the key `k₀`).
+∈-insert-≢ : ∀ {A B : Type} ⦃ _ : DecEq A ⦄ {m : A ⇀ B} {k₀ k : A} {v₀ y : B}
+  → k₀ ≢ k → (k , y) ∈ m ˢ → (k , y) ∈ (insert m k₀ v₀) ˢ
+∈-insert-≢ {k₀ = k₀} {k} ne ky∈m =
+  Properties.∈-∪⁺ (inj₂ (Equivalence.to ∈-filter
+    ((λ k∈ → ne (sym (cong proj₁ (Equivalence.from ∈-singleton (proj₂ (Equivalence.from dom∈ k∈)))))) , ky∈m)))
+
+∈-insert-≢⁻ : ∀ {A B : Type} ⦃ _ : DecEq A ⦄ {m : A ⇀ B} {k₀ k : A} {v₀ y : B}
+  → k₀ ≢ k → (k , y) ∈ (insert m k₀ v₀) ˢ → (k , y) ∈ m ˢ
+∈-insert-≢⁻ ne ky∈ins with Properties.∈-∪⁻ ky∈ins
+... | inj₁ ky∈sing = ⊥-elim (ne (sym (cong proj₁ (Equivalence.from ∈-singleton ky∈sing))))
+... | inj₂ ky∈filt = proj₂ (Equivalence.from ∈-filter ky∈filt)
+
+-- Hence looking up a *different* key is unaffected by `insert`.  We match both `⁇` instances
+-- (so each `lookupᵐ?` reduces, as in `∈⇒lookup≡just`; the "present in one but not the other"
+-- cases are impossible by membership preservation:
+lookupᵐ?-insert-≢ : ∀ {A B : Type} ⦃ _ : DecEq A ⦄ (m : A ⇀ B) {k₀ k : A} {v₀ : B}
+  → k₀ ≢ k
+  → ⦃ i1 : (k ∈ dom ((insert m k₀ v₀) ˢ)) ⁇ ⦄ → ⦃ i2 : (k ∈ dom (m ˢ)) ⁇ ⦄
+  → lookupᵐ? (insert m k₀ v₀) k ⦃ i1 ⦄ ≡ lookupᵐ? m k ⦃ i2 ⦄
+lookupᵐ?-insert-≢ m {k₀} {k} {v₀} ne ⦃ ⁇ yes k∈ins ⦄ ⦃ ⁇ yes k∈m ⦄ =
+  let (y , ky∈m) = Equivalence.from dom∈ k∈m
+      ky∈ins : (k , y) ∈ (insert m k₀ v₀) ˢ
+      ky∈ins = ∈-insert-≢ {m = m} {v₀ = v₀} ne ky∈m
+  in trans (∈⇒lookup≡just (insert m k₀ v₀) k ky∈ins ⦃ ⁇ yes k∈ins ⦄)
+           (sym (∈⇒lookup≡just m k ky∈m ⦃ ⁇ yes k∈m ⦄))
+lookupᵐ?-insert-≢ m {k₀} {k} {v₀} ne ⦃ ⁇ yes k∈ins ⦄ ⦃ ⁇ no k∉m ⦄ =
+  let (y , ky∈ins) = Equivalence.from dom∈ k∈ins
+      ky∈m : (k , y) ∈ m ˢ
+      ky∈m = ∈-insert-≢⁻ {m = m} {v₀ = v₀} ne ky∈ins
+  in ⊥-elim (k∉m (Equivalence.to dom∈ (y , ky∈m)))
+lookupᵐ?-insert-≢ m {k₀} {k} {v₀} ne ⦃ ⁇ no k∉ins ⦄ ⦃ ⁇ yes k∈m ⦄ =
+  let (y , ky∈m) = Equivalence.from dom∈ k∈m
+      ky∈ins : (k , y) ∈ (insert m k₀ v₀) ˢ
+      ky∈ins = ∈-insert-≢ {m = m} {v₀ = v₀} ne ky∈m
+  in ⊥-elim (k∉ins (Equivalence.to dom∈ (y , ky∈ins)))
+lookupᵐ?-insert-≢ m {k₀} {k} {v₀} ne ⦃ ⁇ no k∉ins ⦄ ⦃ ⁇ no k∉m ⦄ = refl

--- a/src/Ledger/Conway/Specification/Gov/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties.lagda.md
@@ -10,4 +10,5 @@ module Ledger.Conway.Specification.Gov.Properties where
 
 open import Ledger.Conway.Specification.Gov.Properties.Computational
 open import Ledger.Conway.Specification.Gov.Properties.ChangePPGroup
+open import Ledger.Conway.Specification.Gov.Properties.LastVoteApplied
 ```

--- a/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
@@ -18,9 +18,13 @@ module Ledger.Conway.Specification.Gov.Properties.LastVoteApplied
 open import Ledger.Prelude
 open import Ledger.Conway.Specification.Gov.Actions gs hiding (yes; no)
 open import Ledger.Conway.Specification.Gov gs
+open import Data.List.Relation.Unary.Any using (here; there)
+
 open GovActionState using (votes)
-open import Data.List.Relation.Unary.Any using (Any; here; there)
-open GovVotes
+open GovVotes using (gvCC ; gvDRep ; gvSPO)
+open GovVote using (gid)
+open GovEnv using (txid ; epoch)
+open PParams using (govActionLifetime)
 ```
 -->
 
@@ -32,23 +36,21 @@ in the resulting `GovState`{.AgdaFunction}.  There is one subtlety: a voter (a
 action more than once within a single block, in which case only the *last* such vote is
 kept.  We therefore state the property in terms of the last vote a voter casts.
 
-
-
 *Formally*.
 
-We first define what it means to read back the vote a voter has recorded on an action,
+We first define what it means to read back the vote a voter recorded on an action,
 and the last vote a voter casts in a list of `GOV`{.AgdaDatatype} signals.
 
 ```agda
--- The vote (if any) that `voter` has recorded in a single GovActionState.
+-- The vote (if any) that `voter` recorded on a single GovActionState.
 votedOn : GovActionState → GovVoter → Maybe Vote
-votedOn gaSt ⟦ CC   , c  ⟧ᵍᵛ = lookupᵐ? (votes gaSt .gvCC) c
-votedOn gaSt ⟦ DRep , c  ⟧ᵍᵛ = lookupᵐ? (votes gaSt .gvDRep) c
-votedOn gaSt ⟦ SPO  , kh ⟧ᵍᵛ = lookupᵐ? (votes gaSt .gvSPO) kh
+votedOn gaSt ⟦ CC   , c  ⟧ᵍᵛ = lookupᵐ? (gaSt .votes .gvCC) c
+votedOn gaSt ⟦ DRep , c  ⟧ᵍᵛ = lookupᵐ? (gaSt .votes .gvDRep) c
+votedOn gaSt ⟦ SPO  , kh ⟧ᵍᵛ = lookupᵐ? (gaSt .votes .gvSPO) kh
 
 -- Find the GovActionState associated with an action id in a GovState.
 lookupGAState : GovState → GovActionID → Maybe GovActionState
-lookupGAState []                  aid = nothing
+lookupGAState [] aid = nothing
 lookupGAState ((aid' , gaSt) ∷ s) aid = case aid ≟ aid' of λ where
   (yes _) → just gaSt
   (no  _) → lookupGAState s aid
@@ -59,17 +61,48 @@ recordedVote s aid voter = case lookupGAState s aid of λ where
   nothing     → nothing
   (just gaSt) → votedOn gaSt voter
 
--- Fold step keeping the most recent vote `voter` cast on action `aid`.
+-- Fold step keeping the most recent vote that `voter` cast on action `aid`.
 stepVote : GovVoter → GovActionID → Maybe Vote → GovVote ⊎ GovProposal → Maybe Vote
-stepVote voter aid acc (inj₂ _)  = acc
-stepVote voter aid acc (inj₁ gv) with GovVote.voter gv ≟ voter | GovVote.gid gv ≟ aid
-... | yes _ | yes _ = just (GovVote.vote gv)
+stepVote voter aid acc (inj₁ gv) with GovVoterOf gv ≟ voter | gv .gid ≟ aid
+... | yes _ | yes _ = just (VoteOf gv)
 ... | _     | _     = acc
+stepVote voter aid acc (inj₂ _)  = acc
 
 -- The last vote `voter` cast on action `aid` in a list of GOV signals.
 lastVoteOn : GovVoter → GovActionID → List (GovVote ⊎ GovProposal) → Maybe Vote
 lastVoteOn voter aid = foldl (stepVote voter aid) nothing
 ```
+
+**Theorem**.
+
+The following is the type that codifies the property we wish to prove.
+
+```agda
+last-vote-applied-to-GA : Type
+last-vote-applied-to-GA =
+  {Γ      : GovEnv}
+  {s s'   : GovState}
+  {vps    : List (GovVote ⊎ GovProposal) }
+  {aid    : GovActionID}
+  {voter  : GovVoter}
+  {v      : Vote}
+  → Γ .txid ≢ proj₁ aid
+  → Γ ⊢ s ⇀⦇ vps ,GOVS⦈ s'
+  → lastVoteOn voter aid vps ≡ just v
+  → recordedVote s' aid voter ≡ just v
+```
+
+**Proof**.
+
+The proof (that `last-vote-applied-to-GA` is inhabited) has two ingredients.
+
+1.  A handful of *per-step* facts describing how a single `GOV`{.AgdaDatatype} signal
+    changes the vote that `recordedVote`{.AgdaFunction} reads back: a vote on the targeted
+    action and voter records it; any other vote, or a proposal, leaves it untouched.
+2.  An induction on the `GOVS`{.AgdaDatatype} derivation that chains these per-step facts
+    into the `foldl`{.AgdaFunction} that `lastVoteOn`{.AgdaFunction} computes.
+
+### 1. Fold and per-step lemmas
 
 The base case is a single `GOV`{.AgdaDatatype} vote step: the cast vote is recorded on
 the targeted action.
@@ -78,166 +111,236 @@ the targeted action.
 vote-applied-to-GA : Type
 vote-applied-to-GA = ∀ {Γ k s s'} {gv : GovVote}
   → (Γ , k) ⊢ s ⇀⦇ inj₁ gv ,GOV⦈ s'
-  → recordedVote s' (GovVote.gid gv) (GovVote.voter gv) ≡ just (GovVote.vote gv)
+  → recordedVote s' (gv .gid) (GovVoterOf gv) ≡ just (VoteOf gv)
 ```
 
-Lifting to a whole block (the `GOVS`{.AgdaFunction} closure of `GOV`{.AgdaDatatype}),
-the last vote a voter casts on an action is the one recorded in the resulting state.
-
-This needs one precondition: the action `aid`{.AgdaBound} being voted on must not have been
-*created by the current transaction*, i.e. `GovEnv.txid Γ ≢ proj₁ aid`{.AgdaBound}.  Without
-it the claim is false — a `GOVPropose`{.AgdaInductiveConstructor} in the same block mints a
-fresh action with id `(txid , k)`{.AgdaBound}; if that collides with a pre-existing
-`aid`{.AgdaBound} it is inserted (by priority) ahead of the voted entry and shadows it, so
-`recordedVote`{.AgdaFunction} no longer sees the vote.  The condition holds for every state
-reachable in the ledger (actions already in `s`{.AgdaBound} carry the ids of *earlier*
-transactions), so it only rules out voting on an action proposed within the very same
-transaction.
+Voting for `(aid , voter)` on an action that is present records exactly `v`.
 
 ```agda
-last-vote-applied-to-GA : Type
-last-vote-applied-to-GA = ∀ {Γ s s' vps} {aid : GovActionID} {voter : GovVoter} {v : Vote}
-  → GovEnv.txid Γ ≢ proj₁ aid    -- `aid` was not created by the current transaction
-  → Γ ⊢ s ⇀⦇ vps ,GOVS⦈ s'
-  → lastVoteOn voter aid vps ≡ just v
-  → recordedVote s' aid voter ≡ just v
-```
-
-*Proof*.
-
-We build the proof in three steps.
-
-1.  **Step 1**.  Replace a `GOVS`{.AgdaDatatype} derivation by the pure function it
-    computes, so the rest is reasoning about ordinary folds rather than the
-    transition system.
-2.  **Step 2** (to come).  Show `recordedVote`{.AgdaFunction} of the resulting state
-    is a `foldl`{.AgdaFunction} of `stepVote`{.AgdaFunction} over the signals.
-3.  **Step 3** (to come).  Discharge `vote-applied-to-GA`{.AgdaFunction} and
-    `last-vote-applied-to-GA`{.AgdaFunction} from Step 2.
-
-### Step 1.  The `GOVS` closure computes a pure fold {#sec:lva-proof-step1}
-
-A `GOVS`{.AgdaDatatype} derivation is the indexed reflexive-transitive closure of
-`GOV`{.AgdaDatatype}.  We first replace such a derivation by the
-`GovState`{.AgdaFunction} function it computes.  (This mirrors `STS→updateGovSt≡` in
-`Ledger.Conway.Specification.Ledger.Properties.Base`.)
-
-```agda
--- The GovState update performed by one GOV signal at trace position `k`:
--- a vote overrides the entry via `addVote`; a proposal appends a fresh action via
--- `addAction`.  These are, by construction, the outputs of the GOV-Vote and
--- GOV-Propose rules respectively.
-applyVP : GovEnv → ℕ → GovState → GovVote ⊎ GovProposal → GovState
-applyVP Γ k s (inj₁ gv) = addVote s (GovVote.gid gv) (GovVote.voter gv) (GovVote.vote gv)
-applyVP Γ k s (inj₂ gp) =
-  addAction s (PParams.govActionLifetime (PParamsOf Γ) +ᵉ GovEnv.epoch Γ)
-              (GovEnv.txid Γ , k)
-              (GovProposal.returnAddr gp) (GovProposal.action gp) (GovProposal.prevAction gp)
-
--- Fold the per-signal update across a whole block, threading the position index.
-runGOVS : GovEnv → ℕ → GovState → List (GovVote ⊎ GovProposal) → GovState
-runGOVS Γ k s [] = s
-runGOVS Γ k s (vp ∷ vps) = runGOVS Γ (suc k) (applyVP Γ k s vp) vps
-
--- A GOVS derivation computes exactly `runGOVS`.  Induct on the closure; each
--- inductive step is definitionally the recursive call, because the GOV rule's
--- output state is `applyVP` applied to that signal.
-GOVS→run≡ : (vps : List (GovVote ⊎ GovProposal)) (k : ℕ)
-  {Γ : GovEnv} {s s' : GovState}
-  → _⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS} {_⊢_⇀⦇_,GOV⦈_} (Γ , k) s vps s'
-  → s' ≡ runGOVS Γ k s vps
-GOVS→run≡ []               k (BS-base Id-nop)            = refl
-GOVS→run≡ (inj₁ gv ∷ vps)  k (BS-ind (GOV-Vote    _) h)  = GOVS→run≡ vps (suc k) h
-GOVS→run≡ (inj₂ gp ∷ vps)  k (BS-ind (GOV-Propose _) h)  = GOVS→run≡ vps (suc k) h
-```
-
-Since `Γ ⊢ s ⇀⦇ vps ,GOVS⦈ s'` unfolds to `… (Γ , 0) s vps s'`, instantiating
-`GOVS→run≡`{.AgdaFunction} at `k = 0` lets Step 2 replace the abstract result state
-`s'`{.AgdaBound} by `runGOVS Γ 0 s vps`{.AgdaFunction}.
-
-
-### Step 2. <span class="AgdaFunction">recordedVote</span> is a <span class="AgdaFunction">foldl</span> of <span class="AgdaFunction">stepVote</span> over signal
-
-**Remarks**.
-
-1.  A `recordedVote` correspondence, like,
-
-        recordedVote (runGOVS Γ k s vps) aid voter ≡ foldl (stepVote voter aid) (recordedVote s aid voter) vps
-
-    is *not* a pure consequence of `runGOVS`; we have to induct on the derivation.
-
-    It's **false** as a pure statement; counterexample:
-
-    > take `s = []`, `vps = [ inj₁ (vote aid voter v) ]`.
-    > Then `runGOVS … = addVote [] aid voter v = []` (no entry to modify), so
-    > `recordedVote` is `nothing`, yet `lastVoteOn = just v`.
-
-    To rule this out we assume the premise `(aid , ast) ∈ fromList s` of `GOV-Vote`
-    (the voted action must exist).  That premise only lives in the *derivation*, so
-    Step 2 must induct on the GOVS derivation, not on `runGOVS`.
-
-2.  `last-vote-applied-to-GA`, as stated over an arbitrary `GovState`, isn't true; it
-    needs a freshness guard.
-
-    **Counterexample**.  Let `Γ.txid = T`, and let `s` already contain an action with
-    id `(T, 5)` carrying voter's vote `v` (malformed but type-correct). Take
-
-        vps = [ vote (T,5) voter v , propose-something ]
-
-    where the proposal sits at trace position `5`, so it **re-mints** id `(T,5)` with
-    empty votes. `insertGovAction` can place that empty entry ahead of the original
-    (lower `govActionPriority`), so `lookupGAState` now finds the empty one →
-    `recordedVote s' = nothing`, while `lastVoteOn = just v`.
-
-    This is unreachable in practice (a real `s` never contains an action stamped with
-    the *current* tx's id), which is exactly why it needs to be stated as a precondition.
-    **The base case `vote-applied-to-GA` has no such issue — it's unconditionally true.**
-
-```agda
-lookupᵐ?-insert : ∀ {A B : Type} ⦃ _ : DecEq A ⦄ (m : A ⇀ B) (k : A) (v : B)
-  → lookupᵐ? (insert m k v) k ≡ just v
-lookupᵐ?-insert m k v =
-  ∈⇒lookup≡just (insert m k v) k (Properties.∈-∪⁺ (inj₁ (Equivalence.to ∈-singleton refl)))
-
 opaque
   unfolding addVote
+
+  recordedVote-addVote :
+    {s      : GovState}
+    {aid    : GovActionID}
+    {ast    : GovActionState}
+    {voter  : GovVoter}
+    {v      : Vote}
+    → (aid , ast) ∈ fromList s → recordedVote (addVote s aid voter v) aid voter ≡ just v
+
+  recordedVote-addVote {s} {aid} {ast} {voter} {v} p = go voter s (Equivalence.from ∈-fromList p)
+    where
+    go : (w : GovVoter) (t : GovState) → (aid , ast) ∈ˡ t
+       → recordedVote (addVote t aid w v) aid w ≡ just v
+    go w ((aid' , g') ∷ t) mem with aid ≟ aid'
+    ... | yes refl rewrite dec-yes (aid ≟ aid) refl .proj₂ with w
+    ...   | ⟦ CC   , c  ⟧ᵍᵛ = lookupᵐ?-insert (gvCC   (votes g')) c  v
+    ...   | ⟦ DRep , c  ⟧ᵍᵛ = lookupᵐ?-insert (gvDRep (votes g')) c  v
+    ...   | ⟦ SPO  , kh ⟧ᵍᵛ = lookupᵐ?-insert (gvSPO  (votes g')) kh v
+    go w ((aid' , g') ∷ t) mem | no aid≢ with mem
+    ...   | here refl = ⊥-elim (aid≢ refl)
+    ...   | there m   = go w t m
+```
+
+The base case follows immediately: a `GOV-Vote`{.AgdaInductiveConstructor} step exists
+only when the voted action is present, which is the premise `recordedVote-addVote` needs.
+
+```agda
+vote-applied : vote-applied-to-GA
+vote-applied (GOV-Vote (aid∈s , _)) = recordedVote-addVote aid∈s
+```
+
+Once a matching vote appears, `foldl stepVote` produces that vote regardless of the
+starting accumulator (a later matching vote overrides, a non-match keeps the accumulator).
+In particular, starting from `nothing`{.AgdaInductiveConstructor} (as `lastVoteOn`{.AgdaFunction}
+does) can be replaced by starting from any accumulator.
+
+```agda
+foldl-stepVote-nothing : ∀ {voter aid} (vps : List (GovVote ⊎ GovProposal)) (acc : Maybe Vote) {v}
+  → foldl (stepVote voter aid) nothing vps ≡ just v
+  → foldl (stepVote voter aid) acc   vps ≡ just v
+foldl-stepVote-nothing [] acc ()
+foldl-stepVote-nothing (inj₂ p ∷ vps) acc h = foldl-stepVote-nothing vps acc h
+foldl-stepVote-nothing {voter} {aid} (inj₁ gv ∷ vps) acc h
+  with GovVote.voter gv ≟ voter | gv .gid ≟ aid
+... | yes _ | yes _ = h
+... | yes _ | no  _ = foldl-stepVote-nothing vps acc h
+... | no  _ | yes _ = foldl-stepVote-nothing vps acc h
+... | no  _ | no  _ = foldl-stepVote-nothing vps acc h
+```
+
+Two per-step facts say a `GOV`{.AgdaDatatype} step that does *not* match `(aid , voter)`
+leaves its recorded vote unchanged.  First, voting on a *different action*:
+
+```agda
+opaque
+  unfolding addVote
+
   lookupGAState-addVote-≢ : ∀ s aid₀ {voter₀ v₀ aid} → aid₀ ≢ aid
     → lookupGAState (addVote s aid₀ voter₀ v₀) aid ≡ lookupGAState s aid
-  lookupGAState-addVote-≢ []                 aid₀ ne = refl
+  lookupGAState-addVote-≢ [] aid₀ ne = refl
   lookupGAState-addVote-≢ ((aid'' , g'') ∷ s) aid₀ {voter₀} {v₀} {aid} ne with aid ≟ aid''
   ... | no  _    = lookupGAState-addVote-≢ s aid₀ {voter₀} {v₀} {aid} ne
   ... | yes refl with aid ≟ aid₀
   ...   | yes refl = ⊥-elim (ne refl)
   ...   | no  _    = refl
 
-  recordedVote-addVote-≢gid : ∀ s aid₀ {voter₀ v₀ aid voter} → aid₀ ≢ aid
+  recordedVote-addVote-≢gid :
+    {s : GovState} {aid₀ : GovActionID} {voter₀ : GovVoter} {v₀ : Vote} {aid : GovActionID} {voter : GovVoter}
+    → aid₀ ≢ aid
     → recordedVote (addVote s aid₀ voter₀ v₀) aid voter ≡ recordedVote s aid voter
-  recordedVote-addVote-≢gid s aid₀ {voter₀} {v₀} {aid} {voter} ne
+  recordedVote-addVote-≢gid {s} {aid₀} {voter₀} {v₀} {aid} {voter} ne
     rewrite lookupGAState-addVote-≢ s aid₀ {voter₀} {v₀} {aid} ne = refl
-
-
-  recordedVote-addVote : (s : GovState) (aid : GovActionID) (ast : GovActionState)
-    {voter : GovVoter} {v : Vote}
-    → (aid , ast) ∈ fromList s
-    → recordedVote (addVote s aid voter v) aid voter ≡ just v
-  recordedVote-addVote s aid ast {voter} {v} p = go voter s (Equivalence.from ∈-fromList p)
-    where
-    go : (w : GovVoter) (t : GovState) → (aid , ast) ∈ˡ t
-       → recordedVote (addVote t aid w v) aid w ≡ just v
-    go w ((aid' , g') ∷ t) mem with aid ≟ aid'
-    ... | no aid≢ = case mem of λ where
-      (here refl) → ⊥-elim (aid≢ refl)
-      (there m) → go w t m
-    ... | yes refl rewrite dec-yes (aid ≟ aid) refl .proj₂ with w
-    ...   | ⟦ CC   , c  ⟧ᵍᵛ = lookupᵐ?-insert (gvCC   (votes g')) c  v
-    ...   | ⟦ DRep , c  ⟧ᵍᵛ = lookupᵐ?-insert (gvDRep (votes g')) c  v
-    ...   | ⟦ SPO  , kh ⟧ᵍᵛ = lookupᵐ?-insert (gvSPO  (votes g')) kh v
-
--- The base case (already proved).
-vote-applied : vote-applied-to-GA
-vote-applied {s = s} (GOV-Vote {aid} {ast} (aid∈s , _)) = recordedVote-addVote s aid ast aid∈s
 ```
 
-### Step 3. Discharge <span class="AgdaFunction">vote-applied-to-GA</span> and <span class="AgdaFunction">last-vote-applied-to-GA</span>
+Second, a vote on the *same action* by a *different voter*.  Once the voted entry is
+located, the recorded vote for `voter`{.AgdaBound} reads role `voter`{.AgdaBound}'s
+credential map.  A vote by `voter₀ ≢ voter`{.AgdaBound} either touches a different role's
+map (the read map is untouched — `refl`{.AgdaInductiveConstructor}) or the same role at a
+different credential (`lookupᵐ?-insert-≢`{.AgdaFunction}, the credentials differing because
+the voters do).
 
-TODO
+```agda
+  recordedVote-addVote-≢voter :
+    {s : GovState} {aid : GovActionID} {voter₀ : GovVoter} {v₀ : Vote} {voter : GovVoter}
+    → voter₀ ≢ voter
+    → recordedVote (addVote s aid voter₀ v₀) aid voter ≡ recordedVote s aid voter
+  recordedVote-addVote-≢voter {s} {aid} {voter₀} {v₀} {voter} ne = go voter₀ voter s ne
+    where
+    go : (w₀ w : GovVoter) (t : GovState) → w₀ ≢ w
+       → recordedVote (addVote t aid w₀ v₀) aid w ≡ recordedVote t aid w
+    go w₀ w [] ne′ = refl
+    go w₀ w ((aid' , g') ∷ t) ne′ with aid ≟ aid'
+    ... | no  _    = go w₀ w t ne′
+    ... | yes refl rewrite dec-yes (aid ≟ aid) refl .proj₂ with w₀ | w
+    ...   | ⟦ CC   , c₀  ⟧ᵍᵛ | ⟦ DRep , c  ⟧ᵍᵛ = refl
+    ...   | ⟦ CC   , c₀  ⟧ᵍᵛ | ⟦ SPO  , kh ⟧ᵍᵛ = refl
+    ...   | ⟦ DRep , c₀  ⟧ᵍᵛ | ⟦ CC   , c  ⟧ᵍᵛ = refl
+    ...   | ⟦ DRep , c₀  ⟧ᵍᵛ | ⟦ SPO  , kh ⟧ᵍᵛ = refl
+    ...   | ⟦ SPO  , kh₀ ⟧ᵍᵛ | ⟦ CC   , c  ⟧ᵍᵛ = refl
+    ...   | ⟦ SPO  , kh₀ ⟧ᵍᵛ | ⟦ DRep , c  ⟧ᵍᵛ = refl
+    ...   | ⟦ CC   , c₀  ⟧ᵍᵛ | ⟦ CC   , c  ⟧ᵍᵛ =
+      lookupᵐ?-insert-≢ (gvCC (votes g')) λ c₀≡c → ne′ (cong ⟦ CC   ,_⟧ᵍᵛ c₀≡c)
+    ...   | ⟦ DRep , c₀  ⟧ᵍᵛ | ⟦ DRep , c  ⟧ᵍᵛ =
+      lookupᵐ?-insert-≢ (gvDRep (votes g')) λ c₀≡c → ne′ (cong ⟦ DRep ,_⟧ᵍᵛ c₀≡c)
+    ...   | ⟦ SPO  , kh₀ ⟧ᵍᵛ | ⟦ SPO  , kh ⟧ᵍᵛ =
+      lookupᵐ?-insert-≢ (gvSPO (votes g')) λ kh₀≡kh → ne′ (cong ⟦ SPO  ,_⟧ᵍᵛ kh₀≡kh)
+```
+
+The third per-step fact concerns a `GOV-Propose`{.AgdaInductiveConstructor} step.  Proposing
+adds a fresh action via `insertGovAction`{.AgdaFunction}, a priority-ordered insert.  Looking
+up *any other* id is unaffected, since the new entry carries the fresh id and
+`insertGovAction`{.AgdaFunction} preserves the relative order of the existing entries.  This
+is where the freshness hypothesis is consumed: the proposed id `(txid , k)`{.AgdaBound}
+differs from `aid`{.AgdaBound}.
+
+```agda
+lookupGAState-insertGovAction-≢ : ∀ s (p : GovActionID × GovActionState) {aid} → proj₁ p ≢ aid
+  → lookupGAState (insertGovAction s p) aid ≡ lookupGAState s aid
+lookupGAState-insertGovAction-≢ []                 (aid₀ , ast₀) {aid} ne with aid ≟ aid₀
+... | yes refl = ⊥-elim (ne refl)
+... | no  _    = refl
+lookupGAState-insertGovAction-≢ ((gaID , astH) ∷ s) (aid₀ , ast₀) {aid} ne
+  with govActionPriority (GovActionTypeOf astH) ≤? govActionPriority (GovActionTypeOf ast₀)
+lookupGAState-insertGovAction-≢ ((gaID , astH) ∷ s) (aid₀ , ast₀) {aid} ne | yes _
+  with aid ≟ gaID
+... | yes refl = refl
+... | no  _    = lookupGAState-insertGovAction-≢ s (aid₀ , ast₀) ne
+lookupGAState-insertGovAction-≢ ((gaID , astH) ∷ s) (aid₀ , ast₀) {aid} ne | no  _
+  with aid ≟ aid₀
+... | yes refl = ⊥-elim (ne refl)
+... | no  _    = refl
+
+recordedVote-addAction-≢ :
+  {s : GovState }
+  {e : Epoch }
+  {aid₀ : GovActionID }
+  {addr : RewardAddress }
+  {a : GovAction }
+  {prev : NeedsHash (gaType a) }
+  {aid : GovActionID }
+  {voter : GovVoter}
+  → aid₀ ≢ aid
+  → recordedVote (addAction s e aid₀ addr a prev) aid voter ≡ recordedVote s aid voter
+recordedVote-addAction-≢ {s} {e} {aid₀} {addr} {a} {prev} {aid} ne
+  rewrite lookupGAState-insertGovAction-≢ s (mkGovStatePair e aid₀ addr a prev) {aid} ne = refl
+
+-- recordedVote-addAction-≢ : ∀ s e aid₀ addr a prev {aid voter} → aid₀ ≢ aid
+--   → recordedVote (addAction s e aid₀ addr a prev) aid voter ≡ recordedVote s aid voter
+-- recordedVote-addAction-≢ s e aid₀ addr a prev {aid} ne
+--   rewrite lookupGAState-insertGovAction-≢ s (mkGovStatePair e aid₀ addr a prev) {aid} ne = refl
+```
+
+### 2. Lifting to a block: induction on the <span class="AgdaDatatype">GOVS</span> derivation
+
+Lifting to a whole block (the `GOVS`{.AgdaDatatype} closure of `GOV`{.AgdaDatatype}),
+the last vote a voter casts on an action is the one recorded in the resulting state.
+
+This needs one precondition: the action `aid`{.AgdaBound} being voted on must not have been
+*created by the current transaction*, i.e. `Γ .txid ≢ proj₁ aid`.  Without
+it the claim is false.  Indeed, suppose a `GOVPropose`{.AgdaInductiveConstructor} in
+the same block yields a fresh action with id `(txid , k)`; if that collides with a
+pre-existing `aid`{.AgdaBound} it is inserted (by priority) ahead of the voted entry
+and shadows it, so `recordedVote`{.AgdaFunction} no longer sees the vote.
+
+Fortunately, `Γ .txid ≢ proj₁ aid` holds for every state reachable in the
+ledger (actions already in `s`{.AgdaBound} carry the ids of *earlier* transactions),
+so the condition only rules out voting on an action proposed within the very same
+transaction.[^1]
+
+The lifting is a direct induction on the `GOVS`{.AgdaDatatype} derivation.  At each step one
+of the per-step facts above rewrites the accumulator — a vote splits (via
+`voter ≟`/`gid ≟`) into the three `recordedVote-addVote*`{.AgdaFunction} facts, and a proposal
+uses `recordedVote-addAction-≢`{.AgdaFunction} (where the freshness hypothesis is consumed);
+`cong`{.AgdaFunction} threads the equation through the remaining fold while the induction
+hypothesis supplies the tail.
+
+Inducting on the derivation — rather than on the bare list of signals divorced from
+the state — is what makes the matching-vote case provable: the
+`GOV-Vote`{.AgdaInductiveConstructor} rule carries the proof that the voted action is
+present, which `recordedVote-addVote`{.AgdaFunction} requires.  (A pure fold over the
+signals could not know this, and indeed the claim is *false* without it: a matching
+vote on an action absent from the state would be reported by
+`stepVote`{.AgdaFunction} yet not recorded.)
+
+```agda
+lift-GOVS :
+  {Γ      : GovEnv}
+  {n      : ℕ}
+  {s s'   : GovState}
+  {vps    : List (GovVote ⊎ GovProposal)}
+  {aid    : GovActionID}
+  {voter  : GovVoter}
+  → Γ .txid ≢ proj₁ aid
+  → _⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS} {_⊢_⇀⦇_,GOV⦈_} (Γ , n) s vps s'
+  → recordedVote s' aid voter ≡ foldl (stepVote voter aid) (recordedVote s aid voter) vps
+lift-GOVS fresh (BS-base Id-nop) = refl
+lift-GOVS {aid = aid} {voter} fresh
+  (BS-ind {sigs = sigs} (GOV-Vote {aid = aid₁} {voter = voter₁} (m∈ , _)) rest)
+  with voter₁ ≟ voter | aid₁ ≟ aid
+... | yes refl | yes refl = trans  (lift-GOVS fresh rest)
+                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote m∈))
+... | no  v≢   | yes refl = trans  (lift-GOVS fresh rest)
+                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote-≢voter v≢))
+... | yes _    | no  a≢   = trans  (lift-GOVS fresh rest)
+                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote-≢gid a≢))
+... | no  _    | no  a≢   = trans  (lift-GOVS fresh rest)
+                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote-≢gid a≢))
+lift-GOVS {Γ = Γ} {n = n} {s = s} {aid = aid} {voter} fresh
+  (BS-ind {sigs = sigs} (GOV-Propose _) rest) =
+    trans  (lift-GOVS fresh rest)
+           (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addAction-≢ {s} λ eq → fresh (cong proj₁ eq)) )
+```
+
+Finally, both claims follow.  The lifted statement combines `lift-GOVS`{.AgdaFunction} with
+`foldl-stepVote-nothing`{.AgdaFunction} (the last vote in the block survives folding from any
+starting accumulator).
+
+```agda
+last-vote-applied : last-vote-applied-to-GA
+last-vote-applied {s = s} {vps = vps} {aid = aid} {voter} fresh govs lvo =
+  trans (lift-GOVS fresh govs)
+        (foldl-stepVote-nothing vps (recordedVote s aid voter) lvo)
+```
+
+[^1]: This is a potential TODO item: formally prove the claim, "`GovEnv.txid Γ ≢ proj₁ aid` holds for every state reachable in the ledger."

--- a/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
@@ -19,6 +19,7 @@ open import Ledger.Prelude
 open import Ledger.Conway.Specification.Gov.Actions gs hiding (yes; no)
 open import Ledger.Conway.Specification.Gov gs
 open GovActionState using (votes)
+open import Data.List.Relation.Unary.Any using (Any; here; there)
 open GovVotes
 ```
 -->
@@ -30,6 +31,8 @@ in the resulting `GovState`{.AgdaFunction}.  There is one subtlety: a voter (a
 `GovVoter`{.AgdaRecord}, i.e. a role together with a credential) may vote on the same
 action more than once within a single block, in which case only the *last* such vote is
 kept.  We therefore state the property in terms of the last vote a voter casts.
+
+
 
 *Formally*.
 
@@ -81,9 +84,20 @@ vote-applied-to-GA = ∀ {Γ k s s'} {gv : GovVote}
 Lifting to a whole block (the `GOVS`{.AgdaFunction} closure of `GOV`{.AgdaDatatype}),
 the last vote a voter casts on an action is the one recorded in the resulting state.
 
+This needs one precondition: the action `aid`{.AgdaBound} being voted on must not have been
+*created by the current transaction*, i.e. `GovEnv.txid Γ ≢ proj₁ aid`{.AgdaBound}.  Without
+it the claim is false — a `GOVPropose`{.AgdaInductiveConstructor} in the same block mints a
+fresh action with id `(txid , k)`{.AgdaBound}; if that collides with a pre-existing
+`aid`{.AgdaBound} it is inserted (by priority) ahead of the voted entry and shadows it, so
+`recordedVote`{.AgdaFunction} no longer sees the vote.  The condition holds for every state
+reachable in the ledger (actions already in `s`{.AgdaBound} carry the ids of *earlier*
+transactions), so it only rules out voting on an action proposed within the very same
+transaction.
+
 ```agda
 last-vote-applied-to-GA : Type
 last-vote-applied-to-GA = ∀ {Γ s s' vps} {aid : GovActionID} {voter : GovVoter} {v : Vote}
+  → GovEnv.txid Γ ≢ proj₁ aid    -- `aid` was not created by the current transaction
   → Γ ⊢ s ⇀⦇ vps ,GOVS⦈ s'
   → lastVoteOn voter aid vps ≡ just v
   → recordedVote s' aid voter ≡ just v
@@ -141,9 +155,88 @@ Since `Γ ⊢ s ⇀⦇ vps ,GOVS⦈ s'` unfolds to `… (Γ , 0) s vps s'`, inst
 `GOVS→run≡`{.AgdaFunction} at `k = 0` lets Step 2 replace the abstract result state
 `s'`{.AgdaBound} by `runGOVS Γ 0 s vps`{.AgdaFunction}.
 
+
 ### Step 2. <span class="AgdaFunction">recordedVote</span> is a <span class="AgdaFunction">foldl</span> of <span class="AgdaFunction">stepVote</span> over signal
 
-TODO
+**Remarks**.
+
+1.  A `recordedVote` correspondence, like,
+
+        recordedVote (runGOVS Γ k s vps) aid voter ≡ foldl (stepVote voter aid) (recordedVote s aid voter) vps
+
+    is *not* a pure consequence of `runGOVS`; we have to induct on the derivation.
+
+    It's **false** as a pure statement; counterexample:
+
+    > take `s = []`, `vps = [ inj₁ (vote aid voter v) ]`.
+    > Then `runGOVS … = addVote [] aid voter v = []` (no entry to modify), so
+    > `recordedVote` is `nothing`, yet `lastVoteOn = just v`.
+
+    To rule this out we assume the premise `(aid , ast) ∈ fromList s` of `GOV-Vote`
+    (the voted action must exist).  That premise only lives in the *derivation*, so
+    Step 2 must induct on the GOVS derivation, not on `runGOVS`.
+
+2.  `last-vote-applied-to-GA`, as stated over an arbitrary `GovState`, isn't true; it
+    needs a freshness guard.
+
+    **Counterexample**.  Let `Γ.txid = T`, and let `s` already contain an action with
+    id `(T, 5)` carrying voter's vote `v` (malformed but type-correct). Take
+
+        vps = [ vote (T,5) voter v , propose-something ]
+
+    where the proposal sits at trace position `5`, so it **re-mints** id `(T,5)` with
+    empty votes. `insertGovAction` can place that empty entry ahead of the original
+    (lower `govActionPriority`), so `lookupGAState` now finds the empty one →
+    `recordedVote s' = nothing`, while `lastVoteOn = just v`.
+
+    This is unreachable in practice (a real `s` never contains an action stamped with
+    the *current* tx's id), which is exactly why it needs to be stated as a precondition.
+    **The base case `vote-applied-to-GA` has no such issue — it's unconditionally true.**
+
+```agda
+lookupᵐ?-insert : ∀ {A B : Type} ⦃ _ : DecEq A ⦄ (m : A ⇀ B) (k : A) (v : B)
+  → lookupᵐ? (insert m k v) k ≡ just v
+lookupᵐ?-insert m k v =
+  ∈⇒lookup≡just (insert m k v) k (Properties.∈-∪⁺ (inj₁ (Equivalence.to ∈-singleton refl)))
+
+opaque
+  unfolding addVote
+  lookupGAState-addVote-≢ : ∀ s aid₀ {voter₀ v₀ aid} → aid₀ ≢ aid
+    → lookupGAState (addVote s aid₀ voter₀ v₀) aid ≡ lookupGAState s aid
+  lookupGAState-addVote-≢ []                 aid₀ ne = refl
+  lookupGAState-addVote-≢ ((aid'' , g'') ∷ s) aid₀ {voter₀} {v₀} {aid} ne with aid ≟ aid''
+  ... | no  _    = lookupGAState-addVote-≢ s aid₀ {voter₀} {v₀} {aid} ne
+  ... | yes refl with aid ≟ aid₀
+  ...   | yes refl = ⊥-elim (ne refl)
+  ...   | no  _    = refl
+
+  recordedVote-addVote-≢gid : ∀ s aid₀ {voter₀ v₀ aid voter} → aid₀ ≢ aid
+    → recordedVote (addVote s aid₀ voter₀ v₀) aid voter ≡ recordedVote s aid voter
+  recordedVote-addVote-≢gid s aid₀ {voter₀} {v₀} {aid} {voter} ne
+    rewrite lookupGAState-addVote-≢ s aid₀ {voter₀} {v₀} {aid} ne = refl
+
+
+  recordedVote-addVote : (s : GovState) (aid : GovActionID) (ast : GovActionState)
+    {voter : GovVoter} {v : Vote}
+    → (aid , ast) ∈ fromList s
+    → recordedVote (addVote s aid voter v) aid voter ≡ just v
+  recordedVote-addVote s aid ast {voter} {v} p = go voter s (Equivalence.from ∈-fromList p)
+    where
+    go : (w : GovVoter) (t : GovState) → (aid , ast) ∈ˡ t
+       → recordedVote (addVote t aid w v) aid w ≡ just v
+    go w ((aid' , g') ∷ t) mem with aid ≟ aid'
+    ... | no aid≢ = case mem of λ where
+      (here refl) → ⊥-elim (aid≢ refl)
+      (there m) → go w t m
+    ... | yes refl rewrite dec-yes (aid ≟ aid) refl .proj₂ with w
+    ...   | ⟦ CC   , c  ⟧ᵍᵛ = lookupᵐ?-insert (gvCC   (votes g')) c  v
+    ...   | ⟦ DRep , c  ⟧ᵍᵛ = lookupᵐ?-insert (gvDRep (votes g')) c  v
+    ...   | ⟦ SPO  , kh ⟧ᵍᵛ = lookupᵐ?-insert (gvSPO  (votes g')) kh v
+
+-- The base case (already proved).
+vote-applied : vote-applied-to-GA
+vote-applied {s = s} (GOV-Vote {aid} {ast} (aid∈s , _)) = recordedVote-addVote s aid ast aid∈s
+```
 
 ### Step 3. Discharge <span class="AgdaFunction">vote-applied-to-GA</span> and <span class="AgdaFunction">last-vote-applied-to-GA</span>
 

--- a/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
@@ -1,0 +1,92 @@
+---
+source_branch: master
+source_path: src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
+---
+
+## Claim: A voter's vote is applied to the governance action {#clm:LastVoteApplied}
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Conway.Specification.Gov.Base
+
+module Ledger.Conway.Specification.Gov.Properties.LastVoteApplied
+  (gs : GovStructure) (open GovStructure gs)
+  where
+
+open import Ledger.Prelude
+open import Ledger.Conway.Specification.Gov.Actions gs hiding (yes; no)
+open import Ledger.Conway.Specification.Gov gs
+open GovActionState using (votes)
+open GovVotes
+```
+-->
+
+*Informally*.
+
+When a voter casts a vote on a governance action, that vote is recorded on the action
+in the resulting `GovState`{.AgdaFunction}.  There is one subtlety: a voter (a
+`GovVoter`{.AgdaRecord}, i.e. a role together with a credential) may vote on the same
+action more than once within a single block, in which case only the *last* such vote is
+kept.  We therefore state the property in terms of the last vote a voter casts.
+
+*Formally*.
+
+We first define what it means to read back the vote a voter has recorded on an action,
+and the last vote a voter casts in a list of `GOV`{.AgdaDatatype} signals.
+
+```agda
+-- The vote (if any) that `voter` has recorded in a single GovActionState.
+votedOn : GovActionState → GovVoter → Maybe Vote
+votedOn gaSt ⟦ CC   , c  ⟧ᵍᵛ = lookupᵐ? (votes gaSt .gvCC) c
+votedOn gaSt ⟦ DRep , c  ⟧ᵍᵛ = lookupᵐ? (votes gaSt .gvDRep) c
+votedOn gaSt ⟦ SPO  , kh ⟧ᵍᵛ = lookupᵐ? (votes gaSt .gvSPO) kh
+
+-- Find the GovActionState associated with an action id in a GovState.
+lookupGAState : GovState → GovActionID → Maybe GovActionState
+lookupGAState []                  aid = nothing
+lookupGAState ((aid' , gaSt) ∷ s) aid = case aid ≟ aid' of λ where
+  (yes _) → just gaSt
+  (no  _) → lookupGAState s aid
+
+-- The vote (if any) recorded for `voter` on action `aid` in `s`.
+recordedVote : GovState → GovActionID → GovVoter → Maybe Vote
+recordedVote s aid voter = case lookupGAState s aid of λ where
+  nothing     → nothing
+  (just gaSt) → votedOn gaSt voter
+
+-- Fold step keeping the most recent vote `voter` cast on action `aid`.
+stepVote : GovVoter → GovActionID → Maybe Vote → GovVote ⊎ GovProposal → Maybe Vote
+stepVote voter aid acc (inj₂ _)  = acc
+stepVote voter aid acc (inj₁ gv) with GovVote.voter gv ≟ voter | GovVote.gid gv ≟ aid
+... | yes _ | yes _ = just (GovVote.vote gv)
+... | _     | _     = acc
+
+-- The last vote `voter` cast on action `aid` in a list of GOV signals.
+lastVoteOn : GovVoter → GovActionID → List (GovVote ⊎ GovProposal) → Maybe Vote
+lastVoteOn voter aid = foldl (stepVote voter aid) nothing
+```
+
+The base case is a single `GOV`{.AgdaDatatype} vote step: the cast vote is recorded on
+the targeted action.
+
+```agda
+vote-applied-to-GA : Type
+vote-applied-to-GA = ∀ {Γ k s s'} {gv : GovVote}
+  → (Γ , k) ⊢ s ⇀⦇ inj₁ gv ,GOV⦈ s'
+  → recordedVote s' (GovVote.gid gv) (GovVote.voter gv) ≡ just (GovVote.vote gv)
+```
+
+Lifting to a whole block (the `GOVS`{.AgdaFunction} closure of `GOV`{.AgdaDatatype}),
+the last vote a voter casts on an action is the one recorded in the resulting state.
+
+```agda
+last-vote-applied-to-GA : Type
+last-vote-applied-to-GA = ∀ {Γ s s' vps} {aid : GovActionID} {voter : GovVoter} {v : Vote}
+  → Γ ⊢ s ⇀⦇ vps ,GOVS⦈ s'
+  → lastVoteOn voter aid vps ≡ just v
+  → recordedVote s' aid voter ≡ just v
+```
+
+*Proof*. (coming soon)

--- a/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
@@ -3,7 +3,7 @@ source_branch: master
 source_path: src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
 ---
 
-## Claim: A voter's vote is applied to the governance action {#clm:LastVoteApplied}
+## Theorem: A voter's last vote is applied to the governance action {#clm:LastVoteApplied}
 
 <!--
 ```agda
@@ -30,11 +30,10 @@ open PParams using (govActionLifetime)
 
 *Informally*.
 
-When a voter casts a vote on a governance action, that vote is recorded on the action
-in the resulting `GovState`{.AgdaFunction}.  There is one subtlety: a voter (a
-`GovVoter`{.AgdaRecord}, i.e. a role together with a credential) may vote on the same
-action more than once within a single block, in which case only the *last* such vote is
-kept.  We therefore state the property in terms of the last vote a voter casts.
+**Theorem** (last-vote-applied).
+When a voter casts one or more votes on a governance action within a single block
+(the `GOVS`{.AgdaDatatype} closure of `GOV`{.AgdaDatatype} steps), the last vote they
+cast is the one recorded in the resulting `GovState`{.AgdaRecord}.
 
 *Formally*.
 
@@ -73,8 +72,6 @@ lastVoteOn : GovVoter → GovActionID → List (GovVote ⊎ GovProposal) → May
 lastVoteOn voter aid = foldl (stepVote voter aid) nothing
 ```
 
-**Theorem**.
-
 The following is the type that codifies the property we wish to prove.
 
 ```agda
@@ -94,25 +91,29 @@ last-vote-applied-to-GA =
 
 **Proof**.
 
-The proof (that `last-vote-applied-to-GA` is inhabited) has two ingredients.
+The proof (that `last-vote-applied-to-GA` is inhabited) has three main ingredients.
 
-1.  A handful of *per-step* facts describing how a single `GOV`{.AgdaDatatype} signal
-    changes the vote that `recordedVote`{.AgdaFunction} reads back: a vote on the targeted
-    action and voter records it; any other vote, or a proposal, leaves it untouched.
-2.  An induction on the `GOVS`{.AgdaDatatype} derivation that chains these per-step facts
-    into the `foldl`{.AgdaFunction} that `lastVoteOn`{.AgdaFunction} computes.
++  **Four per-step lemmas**. A handful of *per-step* facts describing how a
+   single `GOV`{.AgdaDatatype} signal changes the vote that `recordedVote`{.AgdaFunction}
+   reads back: a vote on the targeted action and voter records it; any other vote, or a
+   proposal, leaves it untouched.
 
-### 1. Fold and per-step lemmas
++  **A fold lemma** (foldl-stepVote-nothing).  Once a matching vote appears in the
+   signal list, `foldl` `stepVote` produces that vote regardless of the starting accumulator.
+   This lets us replace the `nothing` seed of `lastVoteOn` with `recordedVote s aid voter`
+   (the initial state's recorded vote).
 
-The base case is a single `GOV`{.AgdaDatatype} vote step: the cast vote is recorded on
-the targeted action.
++  **Induction on the `GOVS`{.AgdaDatatype} derivation** (lift-GOVS).  At each step, the
+   appropriate per-step lemma rewrites the accumulator.  The induction chains these per-step facts
+   into the `foldl`{.AgdaFunction} that `lastVoteOn`{.AgdaFunction} computes.  Crucially,
+   inducting on the derivation (not the bare list) provides the `GOV-Vote` membership proof
+   that `recordedVote-addVote` requires.
 
-```agda
-vote-applied-to-GA : Type
-vote-applied-to-GA = ∀ {Γ k s s'} {gv : GovVote}
-  → (Γ , k) ⊢ s ⇀⦇ inj₁ gv ,GOV⦈ s'
-  → recordedVote s' (gv .gid) (GovVoterOf gv) ≡ just (VoteOf gv)
-```
+### Four per-step lemmas
+
+Four per-step lemmas describe how a single GOV step changes the recorded vote.
+
+#### 1. <span class="AgdaFunction">recordedVote-addVote</span>
 
 Voting for `(aid , voter)` on an action that is present records exactly `v`.
 
@@ -121,11 +122,11 @@ opaque
   unfolding addVote
 
   recordedVote-addVote :
-    {s      : GovState}
-    {aid    : GovActionID}
-    {ast    : GovActionState}
-    {voter  : GovVoter}
-    {v      : Vote}
+    {s     : GovState}
+    {aid   : GovActionID}
+    {ast   : GovActionState}
+    {voter : GovVoter}
+    {v     : Vote}
     → (aid , ast) ∈ fromList s → recordedVote (addVote s aid voter v) aid voter ≡ just v
 
   recordedVote-addVote {s} {aid} {ast} {voter} {v} p = go voter s (Equivalence.from ∈-fromList p)
@@ -142,70 +143,61 @@ opaque
     ...   | there m   = go w t m
 ```
 
-The base case follows immediately: a `GOV-Vote`{.AgdaInductiveConstructor} step exists
-only when the voted action is present, which is the premise `recordedVote-addVote` needs.
+The next two per-step facts say a `GOV`{.AgdaDatatype} step that does *not* match
+`(aid , voter)` leaves its recorded vote unchanged.
 
-```agda
-vote-applied : vote-applied-to-GA
-vote-applied (GOV-Vote (aid∈s , _)) = recordedVote-addVote aid∈s
-```
+#### 2. <span class="AgdaFunction">recordedVote-addVote-≢gid</span>
 
-Once a matching vote appears, `foldl stepVote` produces that vote regardless of the
-starting accumulator (a later matching vote overrides, a non-match keeps the accumulator).
-In particular, starting from `nothing`{.AgdaInductiveConstructor} (as `lastVoteOn`{.AgdaFunction}
-does) can be replaced by starting from any accumulator.
-
-```agda
-foldl-stepVote-nothing : ∀ {voter aid} (vps : List (GovVote ⊎ GovProposal)) (acc : Maybe Vote) {v}
-  → foldl (stepVote voter aid) nothing vps ≡ just v
-  → foldl (stepVote voter aid) acc   vps ≡ just v
-foldl-stepVote-nothing [] acc ()
-foldl-stepVote-nothing (inj₂ p ∷ vps) acc h = foldl-stepVote-nothing vps acc h
-foldl-stepVote-nothing {voter} {aid} (inj₁ gv ∷ vps) acc h
-  with GovVote.voter gv ≟ voter | gv .gid ≟ aid
-... | yes _ | yes _ = h
-... | yes _ | no  _ = foldl-stepVote-nothing vps acc h
-... | no  _ | yes _ = foldl-stepVote-nothing vps acc h
-... | no  _ | no  _ = foldl-stepVote-nothing vps acc h
-```
-
-Two per-step facts say a `GOV`{.AgdaDatatype} step that does *not* match `(aid , voter)`
-leaves its recorded vote unchanged.  First, voting on a *different action*:
+Voting on a *different action* leaves the recorded vote unchanged.
 
 ```agda
 opaque
   unfolding addVote
 
-  lookupGAState-addVote-≢ : ∀ s aid₀ {voter₀ v₀ aid} → aid₀ ≢ aid
+  lookupGAState-addVote-≢ :
+    {s : GovState}
+    {aid₀ aid : GovActionID}
+    {voter₀ : GovVoter}
+    {v₀ : Vote}
+    → aid₀ ≢ aid
     → lookupGAState (addVote s aid₀ voter₀ v₀) aid ≡ lookupGAState s aid
-  lookupGAState-addVote-≢ [] aid₀ ne = refl
-  lookupGAState-addVote-≢ ((aid'' , g'') ∷ s) aid₀ {voter₀} {v₀} {aid} ne with aid ≟ aid''
-  ... | no  _    = lookupGAState-addVote-≢ s aid₀ {voter₀} {v₀} {aid} ne
+  lookupGAState-addVote-≢ {s = []} _ = refl
+  lookupGAState-addVote-≢ {s = ((aid'' , g'') ∷ s)} {aid₀} {aid} {voter₀} {v₀} ne
+    with aid ≟ aid''
+  ... | no  _    = lookupGAState-addVote-≢ {s} {voter₀ = voter₀} {v₀} ne
   ... | yes refl with aid ≟ aid₀
   ...   | yes refl = ⊥-elim (ne refl)
   ...   | no  _    = refl
 
   recordedVote-addVote-≢gid :
-    {s : GovState} {aid₀ : GovActionID} {voter₀ : GovVoter} {v₀ : Vote} {aid : GovActionID} {voter : GovVoter}
+    {s : GovState}
+    {aid₀ aid : GovActionID}
+    {voter₀ voter : GovVoter}
+    {v₀ : Vote}
     → aid₀ ≢ aid
     → recordedVote (addVote s aid₀ voter₀ v₀) aid voter ≡ recordedVote s aid voter
-  recordedVote-addVote-≢gid {s} {aid₀} {voter₀} {v₀} {aid} {voter} ne
-    rewrite lookupGAState-addVote-≢ s aid₀ {voter₀} {v₀} {aid} ne = refl
+  recordedVote-addVote-≢gid {s} {voter₀ = voter₀} {v₀ = v₀} ne
+    rewrite lookupGAState-addVote-≢ {s = s} {voter₀ = voter₀} {v₀} ne = refl
 ```
 
-Second, a vote on the *same action* by a *different voter*.  Once the voted entry is
-located, the recorded vote for `voter`{.AgdaBound} reads role `voter`{.AgdaBound}'s
+#### 3. <span class="AgdaFunction">recordedVote-addVote-≢voter</span>
+
+A vote on the *same action* by a *different voter*, leaves the recorded vote unchanged.
+
+Once the voted entry is located, the recorded vote for `voter`{.AgdaBound} reads the
 credential map.  A vote by `voter₀ ≢ voter`{.AgdaBound} either touches a different role's
-map (the read map is untouched — `refl`{.AgdaInductiveConstructor}) or the same role at a
-different credential (`lookupᵐ?-insert-≢`{.AgdaFunction}, the credentials differing because
-the voters do).
+map or the same role at a different credential (`lookupᵐ?-insert-≢`{.AgdaFunction},
+the credentials differing because the voters differ).
 
 ```agda
   recordedVote-addVote-≢voter :
-    {s : GovState} {aid : GovActionID} {voter₀ : GovVoter} {v₀ : Vote} {voter : GovVoter}
+    {s : GovState}
+    {aid : GovActionID}
+    {voter₀ voter : GovVoter}
+    {v₀ : Vote}
     → voter₀ ≢ voter
     → recordedVote (addVote s aid voter₀ v₀) aid voter ≡ recordedVote s aid voter
-  recordedVote-addVote-≢voter {s} {aid} {voter₀} {v₀} {voter} ne = go voter₀ voter s ne
+  recordedVote-addVote-≢voter {s} {aid} {voter₀} {voter} {v₀} ne = go voter₀ voter s ne
     where
     go : (w₀ w : GovVoter) (t : GovState) → w₀ ≢ w
        → recordedVote (addVote t aid w₀ v₀) aid w ≡ recordedVote t aid w
@@ -227,16 +219,20 @@ the voters do).
       lookupᵐ?-insert-≢ (gvSPO (votes g')) λ kh₀≡kh → ne′ (cong ⟦ SPO  ,_⟧ᵍᵛ kh₀≡kh)
 ```
 
-The third per-step fact concerns a `GOV-Propose`{.AgdaInductiveConstructor} step.  Proposing
-adds a fresh action via `insertGovAction`{.AgdaFunction}, a priority-ordered insert.  Looking
-up *any other* id is unaffected, since the new entry carries the fresh id and
-`insertGovAction`{.AgdaFunction} preserves the relative order of the existing entries.  This
-is where the freshness hypothesis is consumed: the proposed id `(txid , k)`{.AgdaBound}
-differs from `aid`{.AgdaBound}.
+#### 4. <span class="AgdaFunction">recordedVote-addAction-≢</span>
+
+Proposing a new action with a different id leaves the recorded vote unchanged.
+
+This concerns a `GOV-Propose`{.AgdaInductiveConstructor} step.  Proposing adds a
+fresh action via `insertGovAction`{.AgdaFunction}, a priority-ordered insert.
+Looking up *any other* id is unaffected, since the new entry carries the fresh id and
+`insertGovAction`{.AgdaFunction} preserves the relative order of the existing entries.
+This is where the freshness hypothesis is consumed: the proposed id `(txid , k)`
+differs from `aid`.
 
 ```agda
-lookupGAState-insertGovAction-≢ : ∀ s (p : GovActionID × GovActionState) {aid} → proj₁ p ≢ aid
-  → lookupGAState (insertGovAction s p) aid ≡ lookupGAState s aid
+lookupGAState-insertGovAction-≢ : ∀ s (p : GovActionID × GovActionState) {aid}
+  → proj₁ p ≢ aid → lookupGAState (insertGovAction s p) aid ≡ lookupGAState s aid
 lookupGAState-insertGovAction-≢ []                 (aid₀ , ast₀) {aid} ne with aid ≟ aid₀
 ... | yes refl = ⊥-elim (ne refl)
 ... | no  _    = refl
@@ -254,31 +250,69 @@ lookupGAState-insertGovAction-≢ ((gaID , astH) ∷ s) (aid₀ , ast₀) {aid} 
 recordedVote-addAction-≢ :
   {s : GovState }
   {e : Epoch }
-  {aid₀ : GovActionID }
+  {aid₀ aid : GovActionID }
   {addr : RewardAddress }
   {a : GovAction }
   {prev : NeedsHash (gaType a) }
-  {aid : GovActionID }
   {voter : GovVoter}
   → aid₀ ≢ aid
   → recordedVote (addAction s e aid₀ addr a prev) aid voter ≡ recordedVote s aid voter
-recordedVote-addAction-≢ {s} {e} {aid₀} {addr} {a} {prev} {aid} ne
+recordedVote-addAction-≢ {s} {e} {aid₀} {aid} {addr} {a} {prev} ne
   rewrite lookupGAState-insertGovAction-≢ s (mkGovStatePair e aid₀ addr a prev) {aid} ne = refl
-
--- recordedVote-addAction-≢ : ∀ s e aid₀ addr a prev {aid voter} → aid₀ ≢ aid
---   → recordedVote (addAction s e aid₀ addr a prev) aid voter ≡ recordedVote s aid voter
--- recordedVote-addAction-≢ s e aid₀ addr a prev {aid} ne
---   rewrite lookupGAState-insertGovAction-≢ s (mkGovStatePair e aid₀ addr a prev) {aid} ne = refl
 ```
 
-### 2. Lifting to a block: induction on the <span class="AgdaDatatype">GOVS</span> derivation
+### The fold lemma
+
+Once a matching vote appears, `foldl stepVote` produces that vote regardless of the
+starting accumulator (a later matching vote overrides, a non-match keeps the accumulator).
+In particular, starting from `nothing`{.AgdaInductiveConstructor} (as
+`lastVoteOn`{.AgdaFunction} does) can be replaced by starting from any accumulator.
+
+```agda
+foldl-stepVote-nothing :
+  {aid : GovActionID}
+  {voter : GovVoter}
+  (vps : List (GovVote ⊎ GovProposal))
+  (acc : Maybe Vote)
+  {v : Vote}
+  → foldl (stepVote voter aid) nothing  vps ≡ just v
+  → foldl (stepVote voter aid) acc      vps ≡ just v
+foldl-stepVote-nothing [] acc ()
+foldl-stepVote-nothing (inj₂ p ∷ vps) acc h = foldl-stepVote-nothing vps acc h
+foldl-stepVote-nothing {aid} {voter} (inj₁ gv ∷ vps) acc h
+  with GovVote.voter gv ≟ voter | gv .gid ≟ aid
+... | yes _ | yes _ = h
+... | yes _ | no  _ = foldl-stepVote-nothing vps acc h
+... | no  _ | yes _ = foldl-stepVote-nothing vps acc h
+... | no  _ | no  _ = foldl-stepVote-nothing vps acc h
+```
+
+### Induction on the <span class="AgdaDatatype">GOVS</span> derivation
+
+The base case is a single `GOV`{.AgdaDatatype} vote step: the cast vote is recorded on
+the targeted action.
+
+```agda
+vote-applied-to-GA : Type
+vote-applied-to-GA = ∀ {Γ k s s'} {gv : GovVote}
+  → (Γ , k) ⊢ s ⇀⦇ inj₁ gv ,GOV⦈ s'
+  → recordedVote s' (gv .gid) (GovVoterOf gv) ≡ just (VoteOf gv)
+```
+
+The base case follows immediately: a `GOV-Vote`{.AgdaInductiveConstructor} step exists
+only when the voted action is present, which is the premise `recordedVote-addVote` needs.
+
+```agda
+vote-applied : vote-applied-to-GA
+vote-applied (GOV-Vote (aid∈s , _)) = recordedVote-addVote aid∈s
+```
 
 Lifting to a whole block (the `GOVS`{.AgdaDatatype} closure of `GOV`{.AgdaDatatype}),
 the last vote a voter casts on an action is the one recorded in the resulting state.
 
 This needs one precondition: the action `aid`{.AgdaBound} being voted on must not have been
 *created by the current transaction*, i.e. `Γ .txid ≢ proj₁ aid`.  Without
-it the claim is false.  Indeed, suppose a `GOVPropose`{.AgdaInductiveConstructor} in
+it the claim is false.  Indeed, suppose a `GOV-Propose`{.AgdaInductiveConstructor} in
 the same block yields a fresh action with id `(txid , k)`; if that collides with a
 pre-existing `aid`{.AgdaBound} it is inserted (by priority) ahead of the voted entry
 and shadows it, so `recordedVote`{.AgdaFunction} no longer sees the vote.
@@ -314,22 +348,36 @@ lift-GOVS :
   → Γ .txid ≢ proj₁ aid
   → _⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS} {_⊢_⇀⦇_,GOV⦈_} (Γ , n) s vps s'
   → recordedVote s' aid voter ≡ foldl (stepVote voter aid) (recordedVote s aid voter) vps
-lift-GOVS fresh (BS-base Id-nop) = refl
+lift-GOVS _ (BS-base Id-nop) = refl
 lift-GOVS {aid = aid} {voter} fresh
   (BS-ind {sigs = sigs} (GOV-Vote {aid = aid₁} {voter = voter₁} (m∈ , _)) rest)
   with voter₁ ≟ voter | aid₁ ≟ aid
-... | yes refl | yes refl = trans  (lift-GOVS fresh rest)
-                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote m∈))
-... | no  v≢   | yes refl = trans  (lift-GOVS fresh rest)
-                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote-≢voter v≢))
-... | yes _    | no  a≢   = trans  (lift-GOVS fresh rest)
-                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote-≢gid a≢))
-... | no  _    | no  a≢   = trans  (lift-GOVS fresh rest)
-                                   (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addVote-≢gid a≢))
-lift-GOVS {Γ = Γ} {n = n} {s = s} {aid = aid} {voter} fresh
+
+... | yes refl | yes refl =
+  trans  (lift-GOVS fresh rest)
+         (cong  (λ acc → foldl (stepVote voter aid) acc sigs)
+                (recordedVote-addVote m∈))
+
+... | no  v≢   | yes refl =
+  trans  (lift-GOVS fresh rest)
+         (cong  (λ acc → foldl (stepVote voter aid) acc sigs)
+                (recordedVote-addVote-≢voter v≢))
+
+... | yes _    | no  a≢   =
+  trans  (lift-GOVS fresh rest)
+         (cong  (λ acc → foldl (stepVote voter aid) acc sigs)
+                (recordedVote-addVote-≢gid a≢))
+
+... | no  _    | no  a≢   =
+  trans  (lift-GOVS fresh rest)
+         (cong  (λ acc → foldl (stepVote voter aid) acc sigs)
+                (recordedVote-addVote-≢gid a≢))
+
+lift-GOVS {s = s} {aid = aid} {voter} fresh
   (BS-ind {sigs = sigs} (GOV-Propose _) rest) =
     trans  (lift-GOVS fresh rest)
-           (cong (λ acc → foldl (stepVote voter aid) acc sigs) (recordedVote-addAction-≢ {s} λ eq → fresh (cong proj₁ eq)) )
+           (cong  (λ acc → foldl (stepVote voter aid) acc sigs)
+                  (recordedVote-addAction-≢ {s} λ eq → fresh (cong proj₁ eq)) )
 ```
 
 Finally, both claims follow.  The lifted statement combines `lift-GOVS`{.AgdaFunction} with
@@ -338,9 +386,8 @@ starting accumulator).
 
 ```agda
 last-vote-applied : last-vote-applied-to-GA
-last-vote-applied {s = s} {vps = vps} {aid = aid} {voter} fresh govs lvo =
-  trans (lift-GOVS fresh govs)
-        (foldl-stepVote-nothing vps (recordedVote s aid voter) lvo)
+last-vote-applied {s = s} {vps = vps} {aid} {voter} fresh govs lvo =
+  trans (lift-GOVS fresh govs) (foldl-stepVote-nothing vps (recordedVote s aid voter) lvo)
 ```
 
 [^1]: This is a potential TODO item: formally prove the claim, "`GovEnv.txid Γ ≢ proj₁ aid` holds for every state reachable in the ledger."

--- a/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov/Properties/LastVoteApplied.lagda.md
@@ -89,4 +89,62 @@ last-vote-applied-to-GA = ∀ {Γ s s' vps} {aid : GovActionID} {voter : GovVote
   → recordedVote s' aid voter ≡ just v
 ```
 
-*Proof*. (coming soon)
+*Proof*.
+
+We build the proof in three steps.
+
+1.  **Step 1**.  Replace a `GOVS`{.AgdaDatatype} derivation by the pure function it
+    computes, so the rest is reasoning about ordinary folds rather than the
+    transition system.
+2.  **Step 2** (to come).  Show `recordedVote`{.AgdaFunction} of the resulting state
+    is a `foldl`{.AgdaFunction} of `stepVote`{.AgdaFunction} over the signals.
+3.  **Step 3** (to come).  Discharge `vote-applied-to-GA`{.AgdaFunction} and
+    `last-vote-applied-to-GA`{.AgdaFunction} from Step 2.
+
+### Step 1.  The `GOVS` closure computes a pure fold {#sec:lva-proof-step1}
+
+A `GOVS`{.AgdaDatatype} derivation is the indexed reflexive-transitive closure of
+`GOV`{.AgdaDatatype}.  We first replace such a derivation by the
+`GovState`{.AgdaFunction} function it computes.  (This mirrors `STS→updateGovSt≡` in
+`Ledger.Conway.Specification.Ledger.Properties.Base`.)
+
+```agda
+-- The GovState update performed by one GOV signal at trace position `k`:
+-- a vote overrides the entry via `addVote`; a proposal appends a fresh action via
+-- `addAction`.  These are, by construction, the outputs of the GOV-Vote and
+-- GOV-Propose rules respectively.
+applyVP : GovEnv → ℕ → GovState → GovVote ⊎ GovProposal → GovState
+applyVP Γ k s (inj₁ gv) = addVote s (GovVote.gid gv) (GovVote.voter gv) (GovVote.vote gv)
+applyVP Γ k s (inj₂ gp) =
+  addAction s (PParams.govActionLifetime (PParamsOf Γ) +ᵉ GovEnv.epoch Γ)
+              (GovEnv.txid Γ , k)
+              (GovProposal.returnAddr gp) (GovProposal.action gp) (GovProposal.prevAction gp)
+
+-- Fold the per-signal update across a whole block, threading the position index.
+runGOVS : GovEnv → ℕ → GovState → List (GovVote ⊎ GovProposal) → GovState
+runGOVS Γ k s [] = s
+runGOVS Γ k s (vp ∷ vps) = runGOVS Γ (suc k) (applyVP Γ k s vp) vps
+
+-- A GOVS derivation computes exactly `runGOVS`.  Induct on the closure; each
+-- inductive step is definitionally the recursive call, because the GOV rule's
+-- output state is `applyVP` applied to that signal.
+GOVS→run≡ : (vps : List (GovVote ⊎ GovProposal)) (k : ℕ)
+  {Γ : GovEnv} {s s' : GovState}
+  → _⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS} {_⊢_⇀⦇_,GOV⦈_} (Γ , k) s vps s'
+  → s' ≡ runGOVS Γ k s vps
+GOVS→run≡ []               k (BS-base Id-nop)            = refl
+GOVS→run≡ (inj₁ gv ∷ vps)  k (BS-ind (GOV-Vote    _) h)  = GOVS→run≡ vps (suc k) h
+GOVS→run≡ (inj₂ gp ∷ vps)  k (BS-ind (GOV-Propose _) h)  = GOVS→run≡ vps (suc k) h
+```
+
+Since `Γ ⊢ s ⇀⦇ vps ,GOVS⦈ s'` unfolds to `… (Γ , 0) s vps s'`, instantiating
+`GOVS→run≡`{.AgdaFunction} at `k = 0` lets Step 2 replace the abstract result state
+`s'`{.AgdaBound} by `runGOVS Γ 0 s vps`{.AgdaFunction}.
+
+### Step 2. <span class="AgdaFunction">recordedVote</span> is a <span class="AgdaFunction">foldl</span> of <span class="AgdaFunction">stepVote</span> over signal
+
+TODO
+
+### Step 3. Discharge <span class="AgdaFunction">vote-applied-to-GA</span> and <span class="AgdaFunction">last-vote-applied-to-GA</span>
+
+TODO

--- a/src/Ledger/Conway/Specification/Ledger/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Ledger/Properties.lagda.md
@@ -11,5 +11,6 @@ module Ledger.Conway.Specification.Ledger.Properties where
 open import Ledger.Conway.Specification.Ledger.Properties.Base
 open import Ledger.Conway.Specification.Ledger.Properties.Computational
 open import Ledger.Conway.Specification.Ledger.Properties.GovDepsMatch
+open import Ledger.Conway.Specification.Ledger.Properties.LastVoteApplied
 open import Ledger.Conway.Specification.Ledger.Properties.PoV
 ```

--- a/src/Ledger/Conway/Specification/Ledger/Properties/LastVoteApplied.lagda.md
+++ b/src/Ledger/Conway/Specification/Ledger/Properties/LastVoteApplied.lagda.md
@@ -1,0 +1,144 @@
+---
+source_branch: master
+source_path: src/Ledger/Conway/Specification/Ledger/Properties/LastVoteApplied.lagda.md
+---
+
+## Theorem: The last vote is applied at the LEDGER level {#thm:LEDGER-LastVoteApplied}
+
+<!--
+```agda
+{-# OPTIONS --safe #-}
+
+open import Ledger.Conway.Specification.Transaction
+open import Ledger.Conway.Specification.Abstract
+
+module Ledger.Conway.Specification.Ledger.Properties.LastVoteApplied
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs) (open AbstractFunctions abs)
+  where
+
+open import Ledger.Prelude
+open import Ledger.Conway.Specification.Gov govStructure
+open import Ledger.Conway.Specification.Gov.Actions govStructure
+  using () renaming (Vote to Vote')
+open import Ledger.Conway.Specification.Gov.Properties.LastVoteApplied govStructure
+open import Ledger.Conway.Specification.Ledger txs abs
+open import Data.List.Properties using (foldl-++)
+
+private
+  GOVS' = _⊢_⇀⟦_⟧ᵢ*'_ {_⊢_⇀⟦_⟧ᵇ_ = IdSTS} {_⊢_⇀⦇_,GOV⦈_}
+```
+-->
+
+This module lifts the `GOVS`{.AgdaDatatype}-level `last-vote-applied`{.AgdaFunction}
+property to the `LEDGER`{.AgdaDatatype} rule, **without** the freshness premise
+`TxIdOf tx ≢ proj₁ aid`{.AgdaBound}.
+
+The key insight is that `txgov`{.AgdaFunction} places all proposals before all votes:
+
+    txgov txb = map inj₂ txGovProposals ++ map inj₁ txGovVotes
+
+During the proposals phase, `lastVoteOn`{.AgdaFunction} is unaffected (proposals are
+no-ops for `stepVote`{.AgdaFunction}).  During the votes phase, no proposals occur, so
+`recordedVote-addAction-≢`{.AgdaFunction} — the only lemma that consumes the freshness
+assumption — is never invoked.
+
+### Helper lemmas
+
+Proposals don't change the `foldl`{.AgdaFunction} `stepVote`{.AgdaFunction} accumulator.
+
+```agda
+stepVote-proposals : ∀ {voter aid} acc (props : List GovProposal)
+  → foldl (stepVote voter aid) acc (map inj₂ props) ≡ acc
+stepVote-proposals acc [] = refl
+stepVote-proposals acc (p ∷ props) = stepVote-proposals acc props
+```
+
+Split an indexed-closure derivation at a list concatenation.
+
+```agda
+split-GOVS :
+  (xs   : List (GovVote ⊎ GovProposal))
+  {ys   : List (GovVote ⊎ GovProposal)}
+  {Γ    : GovEnv}
+  {n    : ℕ}
+  {s s' : GovState}
+  → GOVS' (Γ , n) s (xs ++ ys) s'
+  → ∃[ s₁ ] ∃[ n' ] (GOVS' (Γ , n) s xs s₁ × GOVS' (Γ , n') s₁ ys s')
+split-GOVS [] d = _ , _ , BS-base Id-nop , d
+split-GOVS (x ∷ xs) (BS-ind step rest) =
+  let s₁ , n' , first , second = split-GOVS xs rest
+  in  s₁ , n' , BS-ind step first , second
+```
+
+Votes-only variant of `lift-GOVS`{.AgdaFunction}: when the signal list consists only
+of votes, the `GOV-Propose`{.AgdaInductiveConstructor} case never fires, so no freshness
+assumption is needed.
+
+```agda
+lift-GOVS-votes :
+  {Γ     : GovEnv}
+  {n     : ℕ}
+  {s s'  : GovState}
+  {aid   : GovActionID}
+  {voter : GovVoter}
+  (vs : List GovVote)
+  → GOVS' (Γ , n) s (map inj₁ vs) s'
+  → recordedVote s' aid voter
+    ≡ foldl (stepVote voter aid) (recordedVote s aid voter) (map inj₁ vs)
+lift-GOVS-votes [] (BS-base Id-nop) = refl
+lift-GOVS-votes {aid = aid} {voter} (v ∷ vs)
+  (BS-ind (GOV-Vote {aid = aid₁} {voter = voter₁} (m∈ , _)) rest)
+  with voter₁ ≟ voter | aid₁ ≟ aid
+... | yes refl | yes refl =
+  trans (lift-GOVS-votes vs rest)
+    (cong (λ a → foldl (stepVote voter aid) a (map inj₁ vs)) (recordedVote-addVote m∈))
+... | no  v≢ | yes refl =
+  trans (lift-GOVS-votes vs rest)
+    (cong (λ a → foldl (stepVote voter aid) a (map inj₁ vs)) (recordedVote-addVote-≢voter v≢))
+... | yes _ | no a≢ =
+  trans (lift-GOVS-votes vs rest)
+    (cong (λ a → foldl (stepVote voter aid) a (map inj₁ vs)) (recordedVote-addVote-≢gid a≢))
+... | no _ | no a≢ =
+  trans (lift-GOVS-votes vs rest)
+    (cong (λ a → foldl (stepVote voter aid) a (map inj₁ vs)) (recordedVote-addVote-≢gid a≢))
+```
+
+### Main theorem
+
+At the `LEDGER`{.AgdaDatatype} level, the last vote a voter casts on an action is
+recorded.
+
+```agda
+LEDGER-last-vote-applied :
+  {Γ     : LEnv}
+  {s s'  : LState}
+  {tx    : Tx}
+  {aid   : GovActionID}
+  {voter : GovVoter}
+  {v     : Vote'}
+  → Tx.isValid tx ≡ true
+  → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s'
+  → lastVoteOn voter aid (txgov (Tx.body tx)) ≡ just v
+  → recordedVote (GovStateOf s') aid voter ≡ just v
+LEDGER-last-vote-applied {tx = tx} {aid} {voter} {v} refl (LEDGER-V⋯ _ _ _ govs) lvo
+  with split-GOVS (map inj₂ (GovProposalsOf tx)) govs
+... | s₁ , _ , _ , votes-d = trans  (lift-GOVS-votes votes votes-d)
+                                    (foldl-stepVote-nothing (map inj₁ votes) _ lvo')
+  where
+  props : List GovProposal
+  props = GovProposalsOf tx
+
+  votes : List GovVote
+  votes = GovVotesOf tx
+
+  -- Proposals don't affect lastVoteOn, so the vote comes from the votes phase
+  lvo' : foldl (stepVote voter aid) nothing (map inj₁ votes) ≡ just v
+  lvo' = subst  (_≡ just v)
+                (trans (foldl-++ (stepVote voter aid) nothing (map inj₂ props) (map inj₁ votes))
+                       (cong (λ a → foldl (stepVote voter aid) a (map inj₁ votes))
+                             (stepVote-proposals nothing props)))
+                lvo
+
+LEDGER-last-vote-applied refl (LEDGER-I⋯ () _) _
+```

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -118,7 +118,8 @@ proposals in `tx`{.AgdaBound}.
    set `updateGroups`{.AgdaField} `pu`{.AgdaBound} is nonempty.
 
 
-+  **Claim** [Gov-LastVoteApplied][].  A voter's vote is applied to the governance action.
++  **Theorem** [Gov-LastVoteApplied][] and [Ledger-LastVoteApplied][].
+   A voter's last vote is applied to the governance action.
 
    When a voter casts a vote on a governance action via the `GOV`{.AgdaDatatype} rule, that
    vote is recorded on the action in the resulting `GovState`{.AgdaFunction}.  Lifting to a

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -118,7 +118,7 @@ proposals in `tx`{.AgdaBound}.
    set `updateGroups`{.AgdaField} `pu`{.AgdaBound} is nonempty.
 
 
-+  **Claim** [Gov-LastVoteApplied]][]`.  A voter's vote is applied to the governance action.
++  **Claim** [Gov-LastVoteApplied][].  A voter's vote is applied to the governance action.
 
    When a voter casts a vote on a governance action via the `GOV`{.AgdaDatatype} rule, that
    vote is recorded on the action in the resulting `GovState`{.AgdaFunction}.  Lifting to a

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -118,6 +118,13 @@ proposals in `tx`{.AgdaBound}.
    set `updateGroups`{.AgdaField} `pu`{.AgdaBound} is nonempty.
 
 
++  **Claim** [Gov-LastVoteApplied]][]`.  A voter's vote is applied to the governance action.
+
+   When a voter casts a vote on a governance action via the `GOV`{.AgdaDatatype} rule, that
+   vote is recorded on the action in the resulting `GovState`{.AgdaFunction}.  Lifting to a
+   block (the `GOVS`{.AgdaFunction} closure), the *last* vote a voter casts on a given action
+   is the one recorded in the resulting state.
+
 +  **Claim** [CHAIN-EpochStep][].  A new enact state occurs only in a new epoch.
 
    Let `cs`{.AgdaBound} and `cs'`{.AgdaBound} be `ChainStates`{.AgdaRecord} and

--- a/src/Ledger/Conway/Specification/Transaction.lagda.md
+++ b/src/Ledger/Conway/Specification/Transaction.lagda.md
@@ -190,6 +190,10 @@ record TransactionStructure : Type₁ where
     field GovProposalsOf  : A → List GovProposal
   open HasGovProposals ⦃...⦄ public
 
+  record HasGovVotes {a} (A : Type a) : Type a where
+    field GovVotesOf  : A → List GovVote
+  open HasGovVotes ⦃...⦄ public
+
   record HasTxId {a} (A : Type a) : Type a where
     field TxIdOf    : A → TxId
   open HasTxId ⦃...⦄ public
@@ -235,6 +239,9 @@ record TransactionStructure : Type₁ where
 
     HasGovProposals-Tx : HasGovProposals Tx
     HasGovProposals-Tx .GovProposalsOf = TxBody.txGovProposals ∘ TxBodyOf
+
+    HasGovVotes-Tx : HasGovVotes Tx
+    HasGovVotes-Tx .GovVotesOf = TxBody.txGovVotes ∘ TxBodyOf
 
     HasWithdrawals-TxBody : HasWithdrawals TxBody
     HasWithdrawals-TxBody .WithdrawalsOf = TxBody.txWithdrawals


### PR DESCRIPTION
# Description

## A voter's last vote is applied to the governance action

Closes #417

#417 asks only for the **statement** of this property; this PR also **proves it**.

### GOVS-level result (`Gov/Properties/LastVoteApplied`)

- `last-vote-applied-to-GA`: across a block (the `GOVS` closure of `GOV`), the *last* vote a voter casts on an action is the one recorded in the resulting `GovState`, provided that action was not created by the current transaction (`Γ.txid ≢ proj₁ aid`).
- `vote-applied-to-GA`: the single-step companion.

The precondition is needed at this level because the signal list is an arbitrary `List (GovVote ⊎ GovProposal)` — proposals and votes can be interleaved, and a proposal after a vote can shadow it via priority insertion.

The proof is by induction on the `GOVS` derivation, chaining four per-step `recordedVote-*` facts into the fold that `lastVoteOn` computes.

### LEDGER-level result (`Ledger/Properties/LastVoteApplied`)

- `LEDGER-last-vote-applied` — the same property lifted to the `LEDGER` rule, **without** the freshness premise `Γ.txid ≢ proj₁ aid`.

The key insight is that `txgov` places all proposals before all votes (`map inj₂ txGovProposals ++ map inj₁ txGovVotes`). During the proposals phase, `lastVoteOn` is unaffected (proposals are no-ops for `stepVote`). During the votes phase, no proposals occur, so `recordedVote-addAction-≢` — the only lemma that consumes the freshness assumption — is never invoked.

Three helper lemmas support this:
- `stepVote-proposals`: proposals don't change the vote-fold accumulator
- `split-GOVS`: decompose a `GOVS` derivation at a `++` boundary
- `lift-GOVS-votes`: votes-only lift needs no freshness (`GOV-Propose` is ruled out by pattern matching on `inj₁`)

**Also.** Four general lookup-after-insert lemmas were added to `Axiom.Set.Map.Extras` (candidates for upstreaming to agda-sets).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
