### PR TITLE
Add Agda typecheck skill + SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -64,14 +64,18 @@ NIX_CONF="$HOME/.config/nix/nix.conf"
 # `experimental-features = nix-command` must not cause us to skip enabling flakes.
 grep -qE 'experimental-features.*flakes' "$NIX_CONF" 2>/dev/null || \
   echo 'extra-experimental-features = nix-command flakes' >> "$NIX_CONF"
+# Use extra-* so we add the caches/keys without clobbering any substituters or
+# trusted-public-keys the environment already configured (plain `substituters =`
+# is last-one-wins). The `cache.iog.io` guard keeps this idempotent.
 grep -q 'cache.iog.io' "$NIX_CONF" 2>/dev/null || cat >> "$NIX_CONF" <<'CONF'
-substituters = https://cache.iog.io https://cache.nixos.org/
-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+extra-substituters = https://cache.iog.io https://cache.nixos.org
+extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 CONF
 
 # 3. Persist nix on PATH for the rest of the session.
 if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
-  echo ". \"$HOME/.nix-profile/etc/profile.d/nix.sh\"" >> "$CLAUDE_ENV_FILE"
+  grep -qF 'nix-profile/etc/profile.d/nix.sh' "$CLAUDE_ENV_FILE" 2>/dev/null || \
+    echo ". \"$HOME/.nix-profile/etc/profile.d/nix.sh\"" >> "$CLAUDE_ENV_FILE"
 fi
 
 # 4. Pre-warm the dev shell so `nix develop --command agda <file>` is fast.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# SessionStart hook: provision the Nix toolchain so Agda typechecking works in
+# Claude Code on the web sessions.
+#
+# The project typechecks only through its Nix flake (flake.nix pins Agda and the
+# Agda libraries via github:input-output-hk/agda.nix); there is no system `agda`.
+# This hook installs nix (if absent), enables flakes, points at the binary caches
+# the flake needs, and pre-warms `nix develop` so the dev shell is cached for the
+# rest of this session (and, since container state is cached after the hook
+# completes, for future sessions too).
+#
+# NETWORK REQUIREMENT: needs the policy to allow `nixos.org` (installer),
+# `cache.nixos.org` and `cache.iog.io` (substituters), and `github.com` (flake
+# inputs). As of 2026-06-16 the default policy returns 403 for nixos.org and
+# cache.iog.io, so this hook logs the problem and exits 0 (non-fatal) rather than
+# blocking session startup. Once the policy permits those hosts it works as-is.
+set -uo pipefail
+
+log() { printf '[session-start] %s\n' "$*"; }
+
+# Only run in the remote (web) environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  log "not a remote session; skipping nix provisioning."
+  exit 0
+fi
+
+# 1. Install nix (single-user, daemonless) if not already present.
+if ! command -v nix >/dev/null 2>&1; then
+  # Make any already-installed profile visible first.
+  if [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+  fi
+fi
+
+if ! command -v nix >/dev/null 2>&1; then
+  log "installing nix (single-user)..."
+  if curl -fsSL -m 30 -o /tmp/nix-install https://nixos.org/nix/install; then
+    sh /tmp/nix-install --no-daemon --yes 2>&1 | sed 's/^/[nix-install] /' || \
+      log "nix installer exited non-zero (continuing)."
+    if [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+      # shellcheck disable=SC1091
+      . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+    fi
+  else
+    log "ERROR: cannot fetch https://nixos.org/nix/install (network policy likely blocks nixos.org)."
+    log "       Allow nixos.org + cache.nixos.org + cache.iog.io + github.com in the environment's"
+    log "       network policy, then this hook will install and warm the toolchain. Skipping for now."
+    exit 0
+  fi
+fi
+
+if ! command -v nix >/dev/null 2>&1; then
+  log "ERROR: nix still not on PATH after install attempt; skipping."
+  exit 0
+fi
+log "nix present: $(nix --version 2>/dev/null || echo unknown)"
+
+# 2. Enable flakes and configure the binary caches the flake expects (from ci.yml).
+mkdir -p "$HOME/.config/nix"
+NIX_CONF="$HOME/.config/nix/nix.conf"
+grep -q 'experimental-features' "$NIX_CONF" 2>/dev/null || \
+  echo 'experimental-features = nix-command flakes' >> "$NIX_CONF"
+grep -q 'cache.iog.io' "$NIX_CONF" 2>/dev/null || cat >> "$NIX_CONF" <<'CONF'
+substituters = https://cache.iog.io https://cache.nixos.org/
+trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+CONF
+
+# 3. Persist nix on PATH for the rest of the session.
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  echo ". \"$HOME/.nix-profile/etc/profile.d/nix.sh\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+# 4. Pre-warm the dev shell so `nix develop --command agda <file>` is fast.
+#    Best-effort: a failure here (e.g. blocked cache.iog.io) must not block startup.
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+log "pre-warming 'nix develop' (this can take a while on a cold cache)..."
+if nix develop --command agda --version 2>&1 | sed 's/^/[nix-develop] /'; then
+  log "toolchain ready: 'nix develop --command agda <file>' works."
+else
+  log "WARNING: 'nix develop' did not complete (often a blocked cache.iog.io). Typechecking"
+  log "         may be unavailable until the network policy allows the IOG cache. Non-fatal."
+fi
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -59,8 +59,11 @@ log "nix present: $(nix --version 2>/dev/null || echo unknown)"
 # 2. Enable flakes and configure the binary caches the flake expects (from ci.yml).
 mkdir -p "$HOME/.config/nix"
 NIX_CONF="$HOME/.config/nix/nix.conf"
-grep -q 'experimental-features' "$NIX_CONF" 2>/dev/null || \
-  echo 'experimental-features = nix-command flakes' >> "$NIX_CONF"
+# Append via extra-experimental-features so we don't clobber an existing
+# experimental-features line, and key the check on `flakes` specifically: a bare
+# `experimental-features = nix-command` must not cause us to skip enabling flakes.
+grep -qE 'experimental-features.*flakes' "$NIX_CONF" 2>/dev/null || \
+  echo 'extra-experimental-features = nix-command flakes' >> "$NIX_CONF"
 grep -q 'cache.iog.io' "$NIX_CONF" 2>/dev/null || cat >> "$NIX_CONF" <<'CONF'
 substituters = https://cache.iog.io https://cache.nixos.org/
 trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/agda-typecheck/SKILL.md
+++ b/.claude/skills/agda-typecheck/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: agda-typecheck
+description: Typecheck Agda modules (.lagda.md / .agda) in the formal-ledger-specifications repo via the project's Nix flake. Use after editing any Agda module to verify it compiles, and before declaring Agda work done. Covers the `nix develop` invocation, reading common Agda errors, and the project's Agda quality gate.
+---
+
+# Typechecking Agda in formal-ledger-specifications
+
+The project typechecks only through its Nix flake (it pins the correct Agda
+version and Agda libraries). There is no system-wide `agda` on `PATH`.
+
+> Prerequisite: this requires `nix` to be available and the network policy to
+> permit the flake's substituters (`cache.nixos.org` and `cache.iog.io`) and
+> flake inputs (`github.com`). On Claude Code on the web, provision this with a
+> SessionStart hook (see `.claude/hooks/`) and a network policy that allows those
+> hosts; otherwise these commands will fail and Agda cannot be checked here.
+
+## Procedure
+
+1. Enter the toolchain. All Agda commands run inside the flake shell:
+   `nix develop --command <cmd>`. (The flake pins the correct Agda version and
+   the supporting Agda libraries we use.)
+2. Check edited module(s) only — fast, and it localizes errors:
+   `nix develop --command agda src/Path/To/Module.lagda.md`.
+3. Do not stage generated artifacts (`*.agdai`, `Everything*.agda`, `/.agda/`);
+   they are gitignored.
+
+## Reading common Agda errors
+
++ Unsolved metas / yellow highlighting: a term's type is under-determined; add an
+  explicit type signature or annotate the ambiguous argument.
++ `x != y of type T`: a definitional-equality mismatch; check whether the
+  development expects setoid equality rather than propositional `_≡_`.
++ `No instance of ...`: a missing import, or an instance argument not in scope.
+
+## Quality gate (verify before declaring done)
+
++ Every new public definition has an explicit type signature.
++ New lemmas are named, not inlined into opaque `rewrite` chains.
++ No `let` bindings are used if a `where` block *below* the proof could be used
+  instead.
++ Helper functions and pattern matching are used instead of the `with`
+  construction, unless the `with` substantially simplifies the presentation.
++ No new synonym was introduced for an existing concept.
++ Inline Agda names in prose use kramdown spans, e.g. `` `S`{.AgdaFunction} ``.


### PR DESCRIPTION
Adds Claude Code (web) configuration so cloud sessions can typecheck Agda through the project's Nix flake. **Tooling only — no changes to the specification, the build, or CI.** Only `.claude/` files are added.

## What this adds

- **`.claude/skills/agda-typecheck/SKILL.md`** — a skill documenting the `nix develop --command agda <file>` workflow, common Agda error triage, and the project's Agda quality gate (explicit type signatures, named lemmas, `where` over `let`, helper functions over `with`, kramdown `{.AgdaFunction}` spans in prose, no generated artifacts staged, etc.).
- **`.claude/hooks/session-start.sh`** + **`.claude/settings.json`** — a `SessionStart` hook that, in a remote (web) session, installs nix, enables flakes, configures the `cache.nixos.org` / `cache.iog.io` substituters (public keys taken from `.github/workflows/ci.yml`), and pre-warms `nix develop` so `nix develop --command agda <file>` is ready. It is guarded by `CLAUDE_CODE_REMOTE`, idempotent, and **non-fatal**: if it can't proceed it logs a clear message and exits 0 without blocking session startup.

## Why

Cloud sessions start from a fresh clone with no system `agda` (the project pins Agda and its libraries via the flake). Without this, Claude Code on the web can't machine-check `.lagda.md` edits. With it, edited modules can be typechecked in-session before pushing.

## Network prerequisite

The hook needs the environment's **Network access** to allow `nixos.org` and `cache.iog.io`. Everything else it uses (`*.nixos.org`, GitHub) is already in the **Trusted** default allowlist. Configure this per environment (Custom network access + those two domains, keeping the default package-manager list). Until then the hook logs the missing hosts and skips — harmless.

## Notes for reviewers

- This same commit is also bundled into the LEDGER-pov branch (#1203) so the tooling is usable while this PR awaits review; this PR is the canonical place to land it on `master`.
- The hook runs **synchronously** (guarantees the toolchain is ready before the session starts, at the cost of slower startup on a cold cache). It can be switched to async (faster startup, with a startup race-condition caveat) if the team prefers.

## Checklist
- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md` *(n/a — no spec changes)*
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md) *(n/a — shell + markdown config only)*
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0174ZBS1RKAGSbBXDsESUwoA

---
_Generated by [Claude Code](https://claude.ai/code/session_0174ZBS1RKAGSbBXDsESUwoA)_