### PR TITLE
CONTRIBUTING: document single-module Agda type-checking via the Nix dev shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,6 +373,35 @@ code block with the standard HTML comment delimiters.  For example,
 
 See also: [the Agda documentation section on literate markdown][Agda literate markdown].
 
+### Type-checking while you work
+
+The specification is type-checked through the Nix flake, which pins the Agda version
+and all required libraries — there is no separate global Agda install to maintain. For
+day-to-day work, enter the development shell once and run Agda from there, so the
+toolchain is on your `PATH` for your editor and any other tooling:
+
+```bash
+nix develop                                              # Agda + libraries on PATH
+agda src/Ledger/Dijkstra/Specification/Ledger.lagda.md   # type-check one module
+```
+
+Type-checking a single module is much faster than `nix build` (which checks the whole
+specification) and is the quickest way to iterate on a proof. To check one module
+without staying in the shell:
+
+```bash
+nix develop --command agda src/Path/To/Module.lagda.md
+```
+
+If you use [direnv](https://direnv.net), add `use flake` to a `.envrc` and run `direnv
+allow`; the toolchain is then placed on your `PATH` automatically whenever you enter the
+project directory. Launching your editor — and any agent tooling, such as Claude Code —
+from that shell makes Agda available to all of it, which is cheaper than re-entering
+`nix develop` for each invocation.
+
+Generated artifacts (`*.agdai`, `Everything*.agda`, `_build/`, `/.agda/`) are
+git-ignored; don't commit them.
+
 ### Checking how your code looks on the site
 
 An important step in contributing any code to the repository is to check how it will

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -386,7 +386,7 @@ agda src/Ledger/Dijkstra/Specification/Ledger.lagda.md   # type-check one module
 ```
 
 Type-checking a single module is much faster than `nix build` (which checks the whole
-specification) and, apart from type-checking directly inside Emacs, it is the quickest 
+specification) and, apart from type-checking directly inside Emacs, it is the quickest
 way to iterate on a proof.
 
 Launching your editor — and any agent tooling, such as Claude Code —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,9 +376,9 @@ See also: [the Agda documentation section on literate markdown][Agda literate ma
 ### Type-checking while you work
 
 The specification is type-checked through the Nix flake, which pins the Agda version
-and all required libraries. For
-day-to-day work, enter the development shell once and run Agda from there, so the
-toolchain is on your `PATH` for your editor and any other tooling:
+and all required libraries. For day-to-day work, enter the Nix development shell once and
+run Agda from there, so the toolchain is on your `PATH` for your editor and any other
+tooling.
 
 ```bash
 nix develop                                              # Agda + libraries on PATH
@@ -386,19 +386,17 @@ agda src/Ledger/Dijkstra/Specification/Ledger.lagda.md   # type-check one module
 ```
 
 Type-checking a single module is much faster than `nix build` (which checks the whole
-specification) and is the quickest way to iterate on a proof. To check one module
-without staying in the shell:
+specification) and, apart from type-checking directly inside Emacs, it is the quickest 
+way to iterate on a proof.
+
+Launching your editor — and any agent tooling, such as Claude Code —
+from inside the Nix shell makes Agda available to all of it, which is cheaper than
+re-entering `nix develop` for each invocation.  However, it is possible to type-check
+a module without staying in the shell with the command
 
 ```bash
 nix develop --command agda src/Path/To/Module.lagda.md
 ```
-
-Launching your editor — and any agent tooling, such as Claude Code —
-from that shell makes Agda available to all of it, which is cheaper than re-entering
-`nix develop` for each invocation.
-
-Generated artifacts (`*.agdai`, `Everything*.agda`, `_build/`, `/.agda/`) are
-git-ignored; don't commit them.
 
 ### Checking how your code looks on the site
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,7 +376,7 @@ See also: [the Agda documentation section on literate markdown][Agda literate ma
 ### Type-checking while you work
 
 The specification is type-checked through the Nix flake, which pins the Agda version
-and all required libraries — there is no separate global Agda install to maintain. For
+and all required libraries. For
 day-to-day work, enter the development shell once and run Agda from there, so the
 toolchain is on your `PATH` for your editor and any other tooling:
 
@@ -393,9 +393,7 @@ without staying in the shell:
 nix develop --command agda src/Path/To/Module.lagda.md
 ```
 
-If you use [direnv](https://direnv.net), add `use flake` to a `.envrc` and run `direnv
-allow`; the toolchain is then placed on your `PATH` automatically whenever you enter the
-project directory. Launching your editor — and any agent tooling, such as Claude Code —
+Launching your editor — and any agent tooling, such as Claude Code —
 from that shell makes Agda available to all of it, which is cheaper than re-entering
 `nix develop` for each invocation.
 


### PR DESCRIPTION
Adds a short **"Type-checking while you work"** subsection to `CONTRIBUTING.md` (under *Working on the Agda source code*):

- enter the Nix dev shell once and type-check a **single module** with `agda <file>` (or `nix develop --command agda <file>`) — much faster than `nix build`, which checks the whole specification — for quick iteration on a proof;
- ~~a `direnv` (`use flake`) tip so the toolchain is on `PATH` automatically, and a note to launch your editor / agent tooling (e.g. Claude Code) **from that shell** rather than re-entering `nix develop` per invocation;~~
- ~~a reminder that generated artifacts are git-ignored.~~

This is the lightweight, no-repo-machinery alternative to a SessionStart hook (see #1220, which I'm closing) — it documents the existing `nix develop` workflow the team already uses, per Carlos's feedback. Docs-only; no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0174ZBS1RKAGSbBXDsESUwoA