### PR TITLE
Restrict isRegistered to actual CC members

### DIFF
--- a/src/Ledger/Conway/Specification/Gov.lagda.md
+++ b/src/Ledger/Conway/Specification/Gov.lagda.md
@@ -44,6 +44,7 @@ open import Function.Related.Propositional using (↔⇒)
 
 open GovActionState
 open GovStructure govStructure
+open EnactState using (cc)
 ```
 -->
 
@@ -249,7 +250,7 @@ opaque
   isRegistered : GovEnv → GovVoter → Type
   isRegistered Γ v = case v of
     λ where
-      ⟦ CC   , c  ⟧ᵍᵛ → just c ∈ range (CCHotKeysOf (CertStateOf Γ))
+      ⟦ CC   , c  ⟧ᵍᵛ → just c ∈ range (CCHotKeysOf (CertStateOf Γ) ∣ (ccCreds (cc (EnactStateOf Γ))))
       ⟦ DRep , c  ⟧ᵍᵛ → c ∈ dom (DRepsOf (CertStateOf Γ))
       ⟦ SPO  , kh ⟧ᵍᵛ → kh ∈ dom (PoolsOf (CertStateOf Γ))
 

--- a/src/Ledger/Dijkstra/Specification/Gov.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Gov.lagda.md
@@ -36,6 +36,7 @@ open import Relation.Nullary.Decidable using () renaming (map to map-Dec)
 open import Function.Properties.Equivalence using () renaming (sym to sym-Equiv)
 open import Function.Related.Propositional using (↔⇒)
 
+open EnactState using (cc)
 open GovStructure govStructure
 ```
 -->
@@ -228,7 +229,7 @@ opaque
   isRegistered : GovEnv → GovVoter → Type
   isRegistered Γ v = case v of
     λ where
-      ⟦ CC   , c  ⟧ᵍᵛ → just c ∈ range (CCHotKeysOf (CertStateOf Γ))
+      ⟦ CC   , c  ⟧ᵍᵛ → just c ∈ range (CCHotKeysOf (CertStateOf Γ) ∣ (ccCreds (cc (EnactStateOf Γ))))
       ⟦ DRep , c  ⟧ᵍᵛ → c ∈ dom (DRepsOf (CertStateOf Γ))
       ⟦ SPO  , kh ⟧ᵍᵛ → kh ∈ dom (PoolsOf (CertStateOf Γ))
 


### PR DESCRIPTION
# Description

This change makes the specification match the behaviour of the implementation for conformance testing.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
