### PR TITLE
[Dijkstra] Explicit deposits in certificate deregistration

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -63,7 +63,7 @@ StakeDelegs = Credential ⇀ KeyHash
 
 data DCert : Type where
   delegate    : Credential → Maybe VDeleg → Maybe KeyHash → Coin → DCert
-  dereg       : Credential → Maybe Coin → DCert
+  dereg       : Credential → Coin → DCert
   regpool     : KeyHash → StakePoolParams → DCert
   retirepool  : KeyHash → Epoch → DCert
   regdrep     : Credential → Coin → Anchor → DCert
@@ -401,9 +401,8 @@ data _⊢_⇀⦇_,DELEG⦈_ : DelegEnv → DState → DCert → DState → Type 
   DELEG-dereg :
     ∙ (c , 0) ∈ rwds
     ∙ (c , d) ∈ deposits
-    ∙ md ≡ nothing ⊎ md ≡ just d
       ────────────────────────────────
-      ⟦ pp , pools , delegatees ⟧ ⊢ ⟦ vDelegs , sDelegs , rwds , deposits ⟧ ⇀⦇ dereg c md ,DELEG⦈ ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ , deposits ∣ ❴ c ❵ ᶜ ⟧
+      ⟦ pp , pools , delegatees ⟧ ⊢ ⟦ vDelegs , sDelegs , rwds , deposits ⟧ ⇀⦇ dereg c d ,DELEG⦈ ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ , deposits ∣ ❴ c ❵ ᶜ ⟧
 
 
 isPoolRegistered : Pools -> KeyHash -> Maybe StakePoolParams

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -303,70 +303,32 @@ rewardsBalance ds = ∑[ x ← RewardsOf ds ] x
 
 Functions in this section compute the effect that a `DCert`{.AgdaRecord} list has on
 the three deposit fields (`DState.deposits`{.AgdaField}, `PState.deposits`{.AgdaField},
-`GState.deposits`{.AgdaField}) carried by a `CertState`{.AgdaRecord}.  They describe
-the deposit evolution for a single `DCert` and mirror that of the corresponding
-`CERT` sub-rule.
+`GState.deposits`{.AgdaField}) carried by a `CertState`{.AgdaRecord}.
 
-### Helper Functions
-
-The three deposit fields carried by a `CertState`{.AgdaRecord} have types
-`Credential ⇀ Coin`, `KeyHash ⇀ Coin`, and `Credential ⇀ Coin`, respectively,
-and we package them up as a triple of values which are computed via
-`coinFromDepositTriple`{.AgdaFunction}.  By definition,
-
-    coinFromDeposits cs ≡ coinFromDepositTriple (depositTripleOf cs).
+In Dijkstra, both registration and deregistration certificates carry
+the explicit deposit. Hence, it is sufficient to use the list of
+certificates in a transaction to compute the amount from new and
+refunded deposits.
 
 ```agda
-DepositTriple : Type
-DepositTriple = (Credential ⇀ Coin) × (KeyHash ⇀ Coin) × (Credential ⇀ Coin)
-
-depositTripleOf : CertState → DepositTriple
-depositTripleOf cs = DepositsOf (DStateOf cs) , DepositsOf (PStateOf cs) , DepositsOf (GStateOf cs)
-
-coinFromDepositTriple : DepositTriple → Coin
-coinFromDepositTriple (dd , dp , dg) = getCoin dd + getCoin dp + getCoin dg
-
 module _ (pp : PParams) where
 
-  updateCertDeposit : DCert → DepositTriple → DepositTriple
-  updateCertDeposit cert (dd , dp , dg) = case cert of λ where
-    (delegate c _ _ d)  → (dd ∪⁺ ❴ c , d ❵  , dp                              , dg)
-    (dereg c _)         → (dd ∣ ❴ c ❵ ᶜ     , dp                              , dg)
-    (regpool kh _)      → (dd               , dp ∪ˡ ❴ kh , pp .poolDeposit ❵  , dg)
-    (regdrep c d _)     → (dd               , dp                              , dg ∪⁺ ❴ c , d ❵)
-    (deregdrep c _)     → (dd               , dp                              , dg ∣ ❴ c ❵ ᶜ)
-    _                   → (dd               , dp                              , dg)
-
-  updateCertDepositsStep : CertState → DCert → CertState
-  updateCertDepositsStep cs c =
-    let (dd , dp , dg) = updateCertDeposit c (depositTripleOf cs) in
-    ⟦ record dState { deposits = dd } , record pState { deposits = dp } , record gState { deposits = dg } ⟧
-    where open CertState cs
-```
-
-Note that any drift between the `updateCertDepositsStep`{.AgdaFunction} and the
-`CERT` sub-rule semantics is a soundness problem: it would allow the UTXO
-batch-balance equation to accept transactions whose actual `CertState` evolution
-doesn't balance.
-
-```agda
-coinFromDeposits : CertState → Coin
-coinFromDeposits cs = coinFromDepositTriple (depositTripleOf cs)
-
-module _ (pp : PParams) (certState : CertState) where
-
-  updateCertDeposits : List DCert → CertState
-  updateCertDeposits = foldl (updateCertDepositsStep pp) certState
-
-  depositsChange : List DCert → ℤ
-  depositsChange certs =
-    coinFromDeposits (updateCertDeposits certs) - coinFromDeposits certState
-
   newCertDeposits : List DCert → Coin
-  newCertDeposits certs = posPart (depositsChange certs)
+  newCertDeposits = foldl addNewCertDeposit 0
+    where
+      addNewCertDeposit : DCert → Coin → Coin
+      addNewCertDeposit (delegate _ _ _ d) acc = acc + d
+      addNewCertDeposit (regpool _ _)      acc = acc + pp .poolDeposit
+      addNewCertDeposit (regdrep _ d _)    acc = acc + d
+      addNewCertDeposit _                  acc = acc
 
   refundCertDeposits : List DCert → Coin
-  refundCertDeposits certs = negPart (depositsChange certs)
+  refundCertDeposits = foldl addRefundCertDeposit 0
+    where
+      addRefundCertDeposit : DCert → Coin → Coin
+      addRefundCertDeposit (dereg _ d)     acc = acc + d
+      addRefundCertDeposit (deregdrep _ d) acc = acc + d
+      addRefundCertDeposit _               acc = acc
 ```
 
 <!--

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -79,6 +79,9 @@ cwitness (regdrep c _ _)     = just c
 cwitness (deregdrep c _)     = just c
 cwitness (ccreghot c _)      = just c
 
+IsPoolRegistered : Pools -> KeyHash -> Type
+IsPoolRegistered ps kh = Is-just (lookupᵐ? ps kh)
+
 -- Certification Types
 record CertEnv : Type where
   field
@@ -274,7 +277,6 @@ private variable
   an          : Anchor
   Γ           : CertEnv
   d           : Coin
-  md          : Maybe Coin
   c           : Credential
   mc          : Maybe Credential
   delegatees  : ℙ Credential
@@ -313,13 +315,16 @@ refunded deposits.
 ```agda
 module _ (pp : PParams) where
 
-  newCertDeposits : List DCert → Coin
-  newCertDeposits = foldl addNewCertDeposit 0
+  newCertDeposits : ℙ KeyHash → List DCert → Coin
+  newCertDeposits pools = proj₁ ∘ foldl addNewCertDeposit (0 , pools)
     where
-      addNewCertDeposit : DCert → Coin → Coin
-      addNewCertDeposit (delegate _ _ _ d) acc = acc + d
-      addNewCertDeposit (regpool _ _)      acc = acc + pp .poolDeposit
-      addNewCertDeposit (regdrep _ d _)    acc = acc + d
+      addNewCertDeposit : DCert → Coin × ℙ KeyHash → Coin × ℙ KeyHash
+      addNewCertDeposit (delegate _ _ _ d) (dep , pools) = dep + d , pools
+      addNewCertDeposit (regpool kh _)     (dep , pools) =
+        if kh ∈ pools
+          then (dep , pools)
+          else (dep + pp .poolDeposit , pools ∪ ❴ kh ❵)
+      addNewCertDeposit (regdrep _ d _)    (dep , pools) = dep + d , pools
       addNewCertDeposit _                  acc = acc
 
   refundCertDeposits : List DCert → Coin
@@ -365,10 +370,6 @@ data _⊢_⇀⦇_,DELEG⦈_ : DelegEnv → DState → DCert → DState → Type 
     ∙ (c , d) ∈ deposits
       ────────────────────────────────
       ⟦ pp , pools , delegatees ⟧ ⊢ ⟦ vDelegs , sDelegs , rwds , deposits ⟧ ⇀⦇ dereg c d ,DELEG⦈ ⟦ vDelegs ∣ ❴ c ❵ ᶜ , sDelegs ∣ ❴ c ❵ ᶜ , rwds ∣ ❴ c ❵ ᶜ , deposits ∣ ❴ c ❵ ᶜ ⟧
-
-
-isPoolRegistered : Pools -> KeyHash -> Maybe StakePoolParams
-isPoolRegistered ps kh = lookupᵐ? ps kh
 ```
 
 ## `POOL`{.AgdaDatatype} Transition System
@@ -377,7 +378,7 @@ isPoolRegistered ps kh = lookupᵐ? ps kh
 data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type where
 
   POOL-reg :
-    ∙ Is-nothing (isPoolRegistered pools kh)
+    ∙ ¬ (IsPoolRegistered pools kh)
     ────────────────────────────────
     pp ⊢ ⟦ pools
          , fPools
@@ -391,7 +392,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
          ⟧
 
   POOL-rereg :
-    ∙ Is-just (isPoolRegistered pools kh)
+    ∙ IsPoolRegistered pools kh
     ────────────────────────────────
     pp ⊢ ⟦ pools
          , fPools

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -79,8 +79,8 @@ cwitness (regdrep c _ _)     = just c
 cwitness (deregdrep c _)     = just c
 cwitness (ccreghot c _)      = just c
 
-IsPoolRegistered : Pools -> KeyHash -> Type
-IsPoolRegistered ps kh = Is-just (lookupᵐ? ps kh)
+IsPoolRegistered : Pools → KeyHash → Type
+IsPoolRegistered ps kh = kh ∈ dom ps
 
 -- Certification Types
 record CertEnv : Type where
@@ -307,10 +307,7 @@ Functions in this section compute the effect that a `DCert`{.AgdaRecord} list ha
 the three deposit fields (`DState.deposits`{.AgdaField}, `PState.deposits`{.AgdaField},
 `GState.deposits`{.AgdaField}) carried by a `CertState`{.AgdaRecord}.
 
-In Dijkstra, both registration and deregistration certificates carry
-the explicit deposit. Hence, it is sufficient to use the list of
-certificates in a transaction to compute the amount from new and
-refunded deposits.
+In Dijkstra, delegation and `DRep` (de)registration certificates carry their deposit explicitly, so new and refunded deposits can be computed from the certificate list alone.  The exception is pool registration: `regpool`{.AgdaInductiveConstructor} carries no deposit, and whether it charges `poolDeposit`{.AgdaField} depends on whether the pool is already registered. `newCertDeposits` therefore additionally takes the set of registered pool keys (`pools : ℙ KeyHash`), and threads it through the certificate list, charging each newly registered pool exactly once.
 
 ```agda
 module _ (pp : PParams) where

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -315,22 +315,22 @@ module _ (pp : PParams) where
   newCertDeposits : ℙ KeyHash → List DCert → Coin
   newCertDeposits pools = proj₁ ∘ foldl addNewCertDeposit (0 , pools)
     where
-      addNewCertDeposit : DCert → Coin × ℙ KeyHash → Coin × ℙ KeyHash
-      addNewCertDeposit (delegate _ _ _ d) (dep , pools) = dep + d , pools
-      addNewCertDeposit (regpool kh _)     (dep , pools) =
+      addNewCertDeposit : Coin × ℙ KeyHash → DCert → Coin × ℙ KeyHash
+      addNewCertDeposit (dep , pools) (delegate _ _ _ d) = dep + d , pools
+      addNewCertDeposit (dep , pools) (regpool kh _)     =
         if kh ∈ pools
           then (dep , pools)
           else (dep + pp .poolDeposit , pools ∪ ❴ kh ❵)
-      addNewCertDeposit (regdrep _ d _)    (dep , pools) = dep + d , pools
-      addNewCertDeposit _                  acc = acc
+      addNewCertDeposit (dep , pools) (regdrep _ d _) = dep + d , pools
+      addNewCertDeposit acc           _               = acc
 
   refundCertDeposits : List DCert → Coin
   refundCertDeposits = foldl addRefundCertDeposit 0
     where
-      addRefundCertDeposit : DCert → Coin → Coin
-      addRefundCertDeposit (dereg _ d)     acc = acc + d
-      addRefundCertDeposit (deregdrep _ d) acc = acc + d
-      addRefundCertDeposit _               acc = acc
+      addRefundCertDeposit : Coin → DCert → Coin
+      addRefundCertDeposit acc (dereg _ d)     = acc + d
+      addRefundCertDeposit acc (deregdrep _ d) = acc + d
+      addRefundCertDeposit acc _               = acc
 ```
 
 <!--

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -45,16 +45,13 @@ instance
                                 × mc ∈ mapˢ just (dom (DelegEnv.pools de)) ∪ ❴ nothing ❵ ¿ of λ where
       (yes p) → success (-, DELEG-delegate p)
       (no ¬p) → failure (genErrors ¬p)
-    (dereg c md) → case lookupᵐ?? (DepositsOf ds) c of λ where
-      (yes ((_ , d) , _ , _)) →
+    (dereg c d) →
         case
           ¿ (c , 0) ∈ (RewardsOf ds)
           × (c , d) ∈ (DepositsOf ds)
-          × (md ≡ nothing ⊎ md ≡ just d)
           ¿ of λ where
             (yes q) → success (-, DELEG-dereg q)
             (no ¬q) → failure (genErrors ¬q)
-      (no ¬p) → failure (genErrors ¬p)
     _ → failure "Unexpected certificate in DELEG"
 
   Computational-DELEG .completeness de ds (delegate c mv mc d)
@@ -63,23 +60,10 @@ instance
                                            × mv ∈ mapˢ (just ∘ vDelegCredential) (DelegEnv.delegatees de) ∪
                                                fromList ( nothing ∷ just vDelegAbstain ∷ just vDelegNoConfidence ∷ [] )
                                            × mc ∈ mapˢ just (dom (DelegEnv.pools de)) ∪ ❴ nothing ❵ ¿) p .proj₂ = refl
-  Computational-DELEG .completeness _ ds (dereg c nothing) _ (DELEG-dereg {d = d} h@(p , q , r))
-    with lookupᵐ?? (DepositsOf ds) c
-  ... | (yes ((_ , d') , s₂ , refl)) rewrite dec-yes
-          (¿ (c , 0) ∈ (RewardsOf ds)
-           × (c , d') ∈ (DepositsOf ds)
-           × (nothing ≡ nothing {A = ℕ} ⊎ nothing ≡ just d')
-           ¿) (p , s₂ , inj₁ refl) .proj₂ = refl
-  Computational-DELEG .completeness _ ds (dereg c nothing) _ (DELEG-dereg h@(p , q , r))
-      | (no ¬s) = ⊥-elim (¬s (_ , q , refl))
-  Computational-DELEG .completeness _ ds (dereg c (just d)) _ (DELEG-dereg h@(p , q , inj₂ refl))
-    with lookupᵐ?? (DepositsOf ds) c
-  ... | (yes ((_ , d') , q' , refl)) rewrite dec-yes
-          (¿ (c , 0) ∈ (RewardsOf ds)
-           × (c , d') ∈ (DepositsOf ds)
-           × (just d ≡ nothing {A = ℕ} ⊎ just d ≡ just d')
-           ¿) (p , q' , inj₂ (cong just (proj₂ (DepositsOf ds) q q'))) .proj₂ = refl
-  ... | (no ¬s) = ⊥-elim (¬s (_ , q , refl))
+  Computational-DELEG .completeness _ ds (dereg c d) _ (DELEG-dereg h@(p , q))
+    with ¿ (c , 0) ∈ (RewardsOf ds) × (c , d) ∈ (DepositsOf ds) ¿
+  ... | yes p = refl
+  ... | no ¬p = ⊥-elim (¬p (p , q))
 
   Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
   Computational-POOL .computeProof _ stᵖ (regpool c _)

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -60,7 +60,7 @@ instance
                                            × mv ∈ mapˢ (just ∘ vDelegCredential) (DelegEnv.delegatees de) ∪
                                                fromList ( nothing ∷ just vDelegAbstain ∷ just vDelegNoConfidence ∷ [] )
                                            × mc ∈ mapˢ just (dom (DelegEnv.pools de)) ∪ ❴ nothing ❵ ¿) p .proj₂ = refl
-  Computational-DELEG .completeness _ ds (dereg c d) _ (DELEG-dereg h@(p , q))
+  Computational-DELEG .completeness _ ds (dereg c d) _ (DELEG-dereg (p , q))
     with ¿ (c , 0) ∈ (RewardsOf ds) × (c , d) ∈ (DepositsOf ds) ¿
   ... | yes p = refl
   ... | no ¬p = ⊥-elim (¬p (p , q))

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -63,17 +63,17 @@ instance
 
   Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
   Computational-POOL .computeProof _ stᵖ (regpool c _)
-    with ¿ Is-just (lookupᵐ? (PoolsOf stᵖ) c) ¿
+    with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | yes p = success (-, (POOL-rereg p))
   ... | no ¬p = success (-, (POOL-reg ¬p))
   Computational-POOL .computeProof _ stᵖ (retirepool c e) = success (-, POOL-retirepool)
   Computational-POOL .computeProof _ stᵖ _ = failure "Unexpected certificate in POOL"
   Computational-POOL .completeness _ stᵖ (regpool c _) _ (POOL-reg p)
-    with ¿ Is-just (lookupᵐ? (PoolsOf stᵖ) c) ¿
+    with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | yes p' = ⊥-elim (p p')
   ... | no _ = refl
   Computational-POOL .completeness _ stᵖ (regpool c _) _ (POOL-rereg p)
-    with ¿ Is-just (lookupᵐ? (PoolsOf stᵖ) c) ¿
+    with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | yes _ = refl
   ... | no ¬p = ⊥-elim (¬p p)
   Computational-POOL .completeness _ _ (retirepool _ _) _ POOL-retirepool = refl

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -23,13 +23,6 @@ open RewardAddress
 
 open Computational ⦃...⦄
 
-private
-  lookupᵐ?? :
-    {K V : Type} →
-    ⦃ _ : DecEq K ⦄ →
-    (m : K ⇀ V) (k : K) →
-    Dec (Any (λ (k' , _) → k ≡ k') (m ˢ))
-
 instance
   Computational-DELEG : Computational _⊢_⇀⦇_,DELEG⦈_ String
   Computational-DELEG .computeProof de ds =

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -15,14 +15,11 @@ open import Ledger.Prelude
 open import Ledger.Dijkstra.Specification.Gov.Actions govStructure hiding (yes; no)
 open import Ledger.Dijkstra.Specification.Certs govStructure
 
-open import stdlib.Data.Maybe
 open import stdlib-meta.Tactic.GenError using (genErrors)
 import Data.Maybe.Relation.Unary.Any as M
-import Data.Maybe.Relation.Unary.All as M
 
 open GovStructure govStructure
 open RewardAddress
-open Inverse
 
 open Computational ⦃...⦄
 
@@ -32,7 +29,6 @@ private
     ⦃ _ : DecEq K ⦄ →
     (m : K ⇀ V) (k : K) →
     Dec (Any (λ (k' , _) → k ≡ k') (m ˢ))
-  lookupᵐ?? m k = any? (λ { _ → ¿ _ ¿ }) (m ˢ)
 
 instance
   Computational-DELEG : Computational _⊢_⇀⦇_,DELEG⦈_ String

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -69,12 +69,12 @@ instance
   Computational-POOL .computeProof _ stᵖ (regpool c _)
     with ¿ Is-just (lookupᵐ? (PoolsOf stᵖ) c) ¿
   ... | yes p = success (-, (POOL-rereg p))
-  ... | no ¬p = success (-, (POOL-reg (¬Is-just↔Is-nothing _ .to ¬p)))
+  ... | no ¬p = success (-, (POOL-reg ¬p))
   Computational-POOL .computeProof _ stᵖ (retirepool c e) = success (-, POOL-retirepool)
   Computational-POOL .computeProof _ stᵖ _ = failure "Unexpected certificate in POOL"
   Computational-POOL .completeness _ stᵖ (regpool c _) _ (POOL-reg p)
     with ¿ Is-just (lookupᵐ? (PoolsOf stᵖ) c) ¿
-  ... | yes p' = ⊥-elim (¬Is-just↔Is-nothing _ .from p p')
+  ... | yes p' = ⊥-elim (p p')
   ... | no _ = refl
   Computational-POOL .completeness _ stᵖ (regpool c _) _ (POOL-rereg p)
     with ¿ Is-just (lookupᵐ? (PoolsOf stᵖ) c) ¿

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -176,7 +176,7 @@ allColdCreds govSt es =
 
 1. UTxO state (UTxO balance plus fees plus donations)
 2. the rewards balance in `DState.rewards`{.AgdaField};
-3. The three `CertState`{.AgdaRecord} deposit fields, via coinFromDeposits:
+3. The three `CertState`{.AgdaRecord} deposit fields, via `getCoin`{.AgdaFunction}:
 
    + `DState.deposits`{.AgdaField} (stake-key deposits, `Credential ⇀ Coin`)
    + `PState.deposits`{.AgdaField} (pool deposits, `KeyHash ⇀ Coin`)

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -188,7 +188,7 @@ instance
   HasCoin-LedgerState : HasCoin LedgerState
   HasCoin-LedgerState .getCoin s =  getCoin (UTxOStateOf s)
                                     + rewardsBalance (DStateOf (CertStateOf s))
-                                    + coinFromDeposits (CertStateOf s)
+                                    + getCoin (DepositsOf (DStateOf s)) + getCoin (DepositsOf (PStateOf s)) + getCoin (DepositsOf (GStateOf s))
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -304,7 +304,7 @@ module _ (pp : PParams) where
 
 ```agda
 
-module _ (pp : PParams) (certState : CertState) where
+module _ (pp : PParams) where
 
   consumedTx : Tx ℓ → UTxO → Value
   consumedTx tx utxo = balance (utxo ∣ SpendInputsOf tx)
@@ -313,7 +313,7 @@ module _ (pp : PParams) (certState : CertState) where
 
   consumed : TopLevelTx → UTxO → Value
   consumed txTop utxo = consumedTx txTop utxo
-                       + inject (refundCertDeposits pp certState (allDCerts txTop))
+                       + inject (refundCertDeposits pp (allDCerts txTop))
 
   consumedBatch : TopLevelTx → UTxO → Value
   consumedBatch txTop utxo = consumed txTop utxo
@@ -335,7 +335,7 @@ the transaction and that amount is deposited into accounts.
   produced : TopLevelTx → Value
   produced txTop = producedTx txTop
                    + inject (TxFeesOf txTop)
-                   + inject (newCertDeposits pp certState (allDCerts txTop))
+                   + inject (newCertDeposits pp (allDCerts txTop))
 
   producedBatch : TopLevelTx → Value
   producedBatch txTop = produced txTop
@@ -544,8 +544,8 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
     ∙ inInterval (SlotOf Γ) (ValidIntervalOf txTop)
     ∙ minfee (PParamsOf Γ) txTop (UTxOOf Γ) ≤ TxFeesOf txTop
     ∙ coin (MintedValueOf txTop) ≡ 0
-    ∙ consumedBatch (PParamsOf Γ) (CertStateOf Γ) txTop (UTxOOf Γ) ≡ producedBatch (PParamsOf Γ) (CertStateOf Γ) txTop
-    ∙ (legacyMode ≡ true → consumed (PParamsOf Γ) (CertStateOf Γ) txTop (UTxOOf Γ) ≡ produced (PParamsOf Γ) (CertStateOf Γ) txTop)  -- (4)
+    ∙ consumedBatch (PParamsOf Γ) txTop (UTxOOf Γ) ≡ producedBatch (PParamsOf Γ) txTop
+    ∙ (legacyMode ≡ true → consumed (PParamsOf Γ) txTop (UTxOOf Γ) ≡ produced (PParamsOf Γ) txTop)  -- (4)
     ∙ SizeOf txTop ≤ maxTxSize (PParamsOf Γ)
     ∙ ∑ˡ[ x ← setToList (allReferenceScripts txTop (UTxOOf Γ)) ] scriptSize x ≤ (PParamsOf Γ) .maxRefScriptSizePerTx
     ∙ ((RedeemersOf txTop ˢ ≢ ∅) ⊎ (List.Any (λ txSub → RedeemersOf txSub ˢ ≢ ∅) (SubTransactionsOf txTop))

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -197,6 +197,9 @@ instance
   HasDonations-UTxOState : HasDonations UTxOState
   HasDonations-UTxOState .DonationsOf = UTxOState.donations
 
+  HasPools-UTxOEnv : HasPools UTxOEnv
+  HasPools-UTxOEnv .PoolsOf = PoolsOf ∘ UTxOEnv.certState
+
   unquoteDecl HasCast-UTxOEnv
               HasCast-SubUTxOEnv
               HasCast-UTxOState = derive-HasCast
@@ -332,14 +335,14 @@ the transaction and that amount is deposited into accounts.
                   + inject (getCoin (DirectDepositsOf tx))
                   + inject (govProposalsDeposits pp (ListOfGovProposalsOf tx))
 
-  produced : TopLevelTx → Value
-  produced txTop = producedTx txTop
+  produced : Pools → TopLevelTx → Value
+  produced pools txTop = producedTx txTop
                    + inject (TxFeesOf txTop)
-                   + inject (newCertDeposits pp (allDCerts txTop))
+                   + inject (newCertDeposits pp (dom pools) (allDCerts txTop))
 
-  producedBatch : TopLevelTx → Value
-  producedBatch txTop = produced txTop
-                        + ∑ˡ[ stx ← SubTransactionsOf txTop ] (producedTx stx)
+  producedBatch : Pools → TopLevelTx → Value
+  producedBatch pools txTop = produced pools txTop
+                            + ∑ˡ[ stx ← SubTransactionsOf txTop ] (producedTx stx)
 ```
 
 ## CIP-159 Notes
@@ -544,8 +547,8 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
     ∙ inInterval (SlotOf Γ) (ValidIntervalOf txTop)
     ∙ minfee (PParamsOf Γ) txTop (UTxOOf Γ) ≤ TxFeesOf txTop
     ∙ coin (MintedValueOf txTop) ≡ 0
-    ∙ consumedBatch (PParamsOf Γ) txTop (UTxOOf Γ) ≡ producedBatch (PParamsOf Γ) txTop
-    ∙ (legacyMode ≡ true → consumed (PParamsOf Γ) txTop (UTxOOf Γ) ≡ produced (PParamsOf Γ) txTop)  -- (4)
+    ∙ consumedBatch (PParamsOf Γ) txTop (UTxOOf Γ) ≡ producedBatch (PParamsOf Γ) (PoolsOf Γ) txTop
+    ∙ (legacyMode ≡ true → consumed (PParamsOf Γ) txTop (UTxOOf Γ) ≡ produced (PParamsOf Γ) (PoolsOf Γ) txTop)  -- (4)
     ∙ SizeOf txTop ≤ maxTxSize (PParamsOf Γ)
     ∙ ∑ˡ[ x ← setToList (allReferenceScripts txTop (UTxOOf Γ)) ] scriptSize x ≤ (PParamsOf Γ) .maxRefScriptSizePerTx
     ∙ ((RedeemersOf txTop ˢ ≢ ∅) ⊎ (List.Any (λ txSub → RedeemersOf txSub ˢ ≢ ∅) (SubTransactionsOf txTop))


### PR DESCRIPTION
# Description

This PR makes the optional field in the deregistration certificate mandatory.

In addition, it changes the calculation of new and refunded deposits from certificates.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
