### PR TITLE
[Dijkstra] Move normal/legacy mode decision to LEDGER

### DIFF
--- a/src/Ledger/Dijkstra/Foreign/Utxo.agda
+++ b/src/Ledger/Dijkstra/Foreign/Utxo.agda
@@ -46,7 +46,7 @@ instance
 unquoteDecl = do
   hsTypeAlias UTxO
   
-utxo-step : HsType (UTxOEnv × Bool → UTxOState → Tx TxLevelTop → ComputationResult String UTxOState)
+utxo-step : HsType (UTxOEnv → UTxOState → Tx TxLevelTop → ComputationResult String UTxOState)
 utxo-step = to (compute Computational-UTXO)
 
 {-# COMPILE GHC utxo-step as utxoStep #-}

--- a/src/Ledger/Dijkstra/Specification/Entities.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Entities.lagda.md
@@ -106,6 +106,10 @@ transactions to assert predicates about account balances.
 The `ENTITIES`{.AgdaDatatype} rule applies withdrawals, via
 `applyWithdrawals`{.AgdaFunction} before certificate evaluation.  In
 the Dijkstra era, withdrawals can be partial, unless in legacy mode.
+Whether legacy mode applies is decided in the `LEDGER`{.AgdaDatatype}
+rule (via `isLegacyMode`{.AgdaFunction}, defined in the
+`Utxow`{.AgdaModule} module) and provided here through the
+`legacyMode`{.AgdaField} field of `EntitiesEnv`{.AgdaRecord}.
 
 ## Direct Deposits
 

--- a/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger.lagda.md
@@ -227,6 +227,13 @@ top-level in the `LEDGER`{.AgdaDatatype} rule. This is threaded through
     scripts referenced/witnessed by every subtransaction (computed by
     `getAllScripts`).
 
+  -  legacyMode : Bool records whether the top-level transaction must be
+    processed in *legacy mode*, i.e., whether some phase-2 script it needs
+    uses a Plutus language older than V4 (computed by `isLegacyMode`).  The
+    decision is made once, here, and threaded to
+    `UTXOW`{.AgdaDatatype}/`UTXO`{.AgdaDatatype} via `UTxOEnv`{.AgdaRecord}
+    and to `ENTITIES`{.AgdaDatatype} via `EntitiesEnv`{.AgdaRecord}.
+
 ### Design Rationale for Ledger Rule Premises
 
 +  **Batch-scoped phase-2 context**.
@@ -305,12 +312,15 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LedgerEnv → LedgerState → TopLevelTx → Ledg
 
          allScripts : ℙ Script
          allScripts = getAllScripts tx utxo₀
+
+         legacyMode : Bool
+         legacyMode = isLegacyMode utxo₀ allScripts tx
     in
       ∙ IsValidFlagOf tx ≡ true
       ∙ ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , rewards₀ , allScripts , IsValidFlagOf tx ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoState₁ , govState₁ , certState₁ ⟧
-      ∙ ⟦ epoch slot , pp , allColdCreds govState₁ enactState , true , rewards₀ ⟧ ⊢ certState₁ ⇀⦇ tx ,ENTITIES⦈ certState₂
+      ∙ ⟦ epoch slot , pp , allColdCreds govState₁ enactState , legacyMode , rewards₀ ⟧ ⊢ certState₁ ⇀⦇ tx ,ENTITIES⦈ certState₂
       ∙ ⟦ TxIdOf tx , epoch slot , pp , ppolicy , enactState , certState₂ , dom (RewardsOf certState₂) ⟧ ⊢ govState₁ ⇀⦇ GovProposals+Votes tx ,GOVS⦈ govState₂
-      ∙ ⟦ slot , pp , treasury , utxo₀ , PoolsOf certState₀ , allScripts ⟧ ⊢ utxoState₁ ⇀⦇ tx ,UTXOW⦈ utxoState₂
+      ∙ ⟦ slot , pp , treasury , utxo₀ , PoolsOf certState₀ , allScripts , legacyMode ⟧ ⊢ utxoState₁ ⇀⦇ tx ,UTXOW⦈ utxoState₂
         ────────────────────────────────
         ⟦ slot , ppolicy , pp , enactState , treasury ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ tx ,LEDGER⦈ ⟦ utxoState₂ , rmOrphanDRepVotes certState₂ govState₂ , certState₂ ⟧
 
@@ -323,10 +333,13 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LedgerEnv → LedgerState → TopLevelTx → Ledg
 
          allScripts : ℙ Script
          allScripts = getAllScripts tx utxo₀
+
+         legacyMode : Bool
+         legacyMode = isLegacyMode utxo₀ allScripts tx
     in
       ∙ IsValidFlagOf tx ≡ false
       ∙ ⟦ slot , ppolicy , pp , enactState , treasury , utxo₀ , rewards₀ , allScripts , IsValidFlagOf tx ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ SubTransactionsOf tx ,SUBLEDGERS⦈ ⟦ utxoState₀ , govState₀ , certState₀ ⟧
-      ∙ ⟦ slot , pp , treasury , utxo₀ , PoolsOf certState₀ , allScripts ⟧ ⊢ utxoState₀ ⇀⦇ tx ,UTXOW⦈ utxoState₁
+      ∙ ⟦ slot , pp , treasury , utxo₀ , PoolsOf certState₀ , allScripts , legacyMode ⟧ ⊢ utxoState₀ ⇀⦇ tx ,UTXOW⦈ utxoState₁
         ────────────────────────────────
         ⟦ slot , ppolicy , pp , enactState , treasury ⟧ ⊢ ⟦ utxoState₀ , govState₀ , certState₀ ⟧ ⇀⦇ tx ,LEDGER⦈ ⟦ utxoState₁ , govState₀ , certState₀ ⟧
 

--- a/src/Ledger/Dijkstra/Specification/Ledger/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ledger/Properties/Computational.lagda.md
@@ -219,17 +219,20 @@ instance
       allScripts : ℙ Script
       allScripts = getAllScripts txTop utxo₀
 
+      legacyMode : Bool
+      legacyMode = isLegacyMode utxo₀ allScripts txTop
+
       subΓ : SubLedgerEnv
       subΓ = ⟦ slot , ppolicy , pparams , enactState , treasury , utxo₀ , RewardsOf (CertStateOf s) , allScripts , IsValidFlagOf txTop ⟧
 
       entitiesΓ : GovState → CertState → EntitiesEnv
-      entitiesΓ govSt certSt = ⟦ epoch slot , pparams , allColdCreds govSt enactState , true , RewardsOf certSt ⟧
+      entitiesΓ govSt certSt = ⟦ epoch slot , pparams , allColdCreds govSt enactState , legacyMode , RewardsOf certSt ⟧
 
       govΓ : CertState → GovEnv
       govΓ certSt = ⟦ TxIdOf txTop , epoch slot , pparams , ppolicy , enactState , certSt , dom (RewardsOf certSt) ⟧
 
       utxoΓ : UTxOEnv
-      utxoΓ = ⟦ slot , pparams , treasury , utxo₀ , PoolsOf (CertStateOf s) , allScripts ⟧
+      utxoΓ = ⟦ slot , pparams , treasury , utxo₀ , PoolsOf (CertStateOf s) , allScripts , legacyMode ⟧
 ```
 -->
 

--- a/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo.lagda.md
@@ -79,6 +79,7 @@ record UTxOEnv : Type where
     utxo₀             : UTxO
     pools₀            : Pools
     allScripts        : ℙ Script
+    legacyMode        : Bool
 
 record SubUTxOEnv : Type where
   field
@@ -96,6 +97,10 @@ The `UTxOEnv`{.AgdaRecord} carries
 +  `allScripts`{.AgdaField}: *batch-wide script pool* containing all scripts available
    to the batch (witness scripts plus reference scripts resolved from allowed
    reference inputs and batch outputs);
++  `legacyMode`{.AgdaField}: whether the top-level transaction is processed in
+   *legacy mode*.  This is decided once, in the `LEDGER`{.AgdaDatatype} rule
+   (via `isLegacyMode`{.AgdaFunction}, defined in the `Utxow`{.AgdaModule}
+   module), and threaded through the rules via this environment field;
 
 The pre-batch UTxO snapshot `utxo₀`{.AgdaField} is used to resolve all
 *spend-side* lookups (inputs, collateral, and datum lookup for spent outputs).
@@ -132,6 +137,10 @@ record HasIsTopLevelValidFlag {a} (A : Type a) : Type a where
   field IsTopLevelValidFlagOf : A → Bool
 open HasIsTopLevelValidFlag ⦃...⦄ public
 
+record HasLegacyMode {a} (A : Type a) : Type a where
+  field LegacyModeOf : A → Bool
+open HasLegacyMode ⦃...⦄ public
+
 record HasScriptPool {a} (A : Type a) : Type a where
   field ScriptPoolOf : A → ℙ Script
 open HasScriptPool ⦃...⦄ public
@@ -159,6 +168,9 @@ instance
 
   HasScriptPool-UTxOEnv : HasScriptPool UTxOEnv
   HasScriptPool-UTxOEnv .ScriptPoolOf = UTxOEnv.allScripts
+
+  HasLegacyMode-UTxOEnv : HasLegacyMode UTxOEnv
+  HasLegacyMode-UTxOEnv .LegacyModeOf = UTxOEnv.legacyMode
 
   HasSlot-SubUTxOEnv : HasSlot SubUTxOEnv
   HasSlot-SubUTxOEnv .SlotOf = SubUTxOEnv.slot
@@ -202,7 +214,6 @@ private
     ℓ          : TxLevel
     A          : Type
     Γ          : A
-    legacyMode : Bool
     s₀         : UTxOState
     txTop      : TopLevelTx
     txSub      : SubLevelTx
@@ -474,7 +485,7 @@ unquoteDecl SUBUTXO-premises = genPremises SUBUTXO-premises (quote SUBUTXO)
 4. In Legacy Mode: The top-level transaction must be self-balancing.
 
 ```agda
-data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UTxOState → Type where
+data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv → UTxOState → TopLevelTx → UTxOState → Type where
 
   UTXO :
     let
@@ -489,7 +500,7 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
     ∙ minfee (PParamsOf Γ) txTop (UTxOOf Γ) ≤ TxFeesOf txTop
     ∙ coin (MintedValueOf txTop) ≡ 0
     ∙ consumedBatch (PParamsOf Γ) txTop (UTxOOf Γ) ≡ producedBatch (PParamsOf Γ) (PoolsOf Γ) txTop
-    ∙ (legacyMode ≡ true → consumed (PParamsOf Γ) txTop (UTxOOf Γ) ≡ produced (PParamsOf Γ) (PoolsOf Γ) txTop)  -- (4)
+    ∙ (LegacyModeOf Γ ≡ true → consumed (PParamsOf Γ) txTop (UTxOOf Γ) ≡ produced (PParamsOf Γ) (PoolsOf Γ) txTop)  -- (4)
     ∙ SizeOf txTop ≤ maxTxSize (PParamsOf Γ)
     ∙ ∑ˡ[ x ← setToList (allReferenceScripts txTop (UTxOOf Γ)) ] scriptSize x ≤ (PParamsOf Γ) .maxRefScriptSizePerTx
     ∙ ((RedeemersOf txTop ˢ ≢ ∅) ⊎ (List.Any (λ txSub → RedeemersOf txSub ˢ ≢ ∅) (SubTransactionsOf txTop))
@@ -507,7 +518,7 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv × Bool → UTxOState → TopLevelTx → UT
        s₁ = if IsValidFlagOf txTop
             then ⟦ (UTxOOf s₀ ∣ SpendInputsOf txTop ᶜ) ∪ˡ outs txTop , FeesOf s₀ + TxFeesOf txTop , DonationsOf s₀ + DonationsOf txTop ⟧ else ⟦ UTxOOf s₀ ∣ (CollateralInputsOf txTop) ᶜ , FeesOf s₀ + cbalance (UTxOOf s₀ ∣ CollateralInputsOf txTop) , DonationsOf s₀ ⟧
     in
-      (Γ , legacyMode)  ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁
+      Γ ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁
 
 ```
 <!--

--- a/src/Ledger/Dijkstra/Specification/Utxo/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxo/Properties/Computational.lagda.md
@@ -101,29 +101,29 @@ instance
 <!--
 ```agda
   Computational-UTXO = record {go} where
-    module go (Γ,legacyMode : UTxOEnv × Bool) (s₀ : UTxOState) (txTop : TopLevelTx)
-      (let H , ⁇ H? = UTXO-premises {txTop = txTop} {Γ = proj₁ Γ,legacyMode} {s₀ = s₀} {legacyMode = proj₂ Γ,legacyMode})
+    module go (Γ : UTxOEnv) (s₀ : UTxOState) (txTop : TopLevelTx)
+      (let H , ⁇ H? = UTXO-premises {txTop = txTop} {Γ = Γ} {s₀ = s₀})
       where
 
       module UTXOS = Computational Computational-UTXOS
 
       computeProof-aux
         : Dec H
-        → ComputationResult String (∃[ s₁ ] (Γ,legacyMode .proj₁) ⊢ tt ⇀⦇ txTop ,UTXOS⦈ s₁)
-        → ComputationResult String (∃[ s₁ ] Γ,legacyMode ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁)
+        → ComputationResult String (∃[ s₁ ] Γ ⊢ tt ⇀⦇ txTop ,UTXOS⦈ s₁)
+        → ComputationResult String (∃[ s₁ ] Γ ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁)
       computeProof-aux d (failure x) = failure "UTXO" 
       computeProof-aux (no ¬p) (success x) = failure "UTXO"
       computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ )) (success h)
         = success (-, UTXO (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ , proj₂ h))
 
-      computeProof : ComputationResult String (∃[ s₁ ] Γ,legacyMode ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁)
-      computeProof = computeProof-aux H? (UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop)
+      computeProof : ComputationResult String (∃[ s₁ ] Γ ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁)
+      computeProof = computeProof-aux H? (UTXOS.computeProof Γ tt txTop)
 
-      completeness : ∀ s₁ → Γ,legacyMode ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁ → map proj₁ computeProof ≡ success s₁
+      completeness : ∀ s₁ → Γ ⊢ s₀ ⇀⦇ txTop ,UTXO⦈ s₁ → map proj₁ computeProof ≡ success s₁
       completeness s₁ (UTXO-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ p₁₆ p₁₇ h)
         with H?
       ... | no ¬p = ⊥-elim (¬p ((p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , p₁₆ , p₁₇ )))
       ... | yes _
-        with UTXOS.computeProof (Γ,legacyMode .proj₁) tt txTop | UTXOS.completeness _ _ _ _ h
+        with UTXOS.computeProof Γ tt txTop | UTXOS.completeness _ _ _ _ h
       ... | success h | refl = refl
 ```

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -371,7 +371,7 @@ attempting both.
     in
 
     ∙ LegacyModeOf Γ ≡ false
-    ∙ ∀[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV4 ∷ []) -- (1)
+    ∙ isLegacyMode utxo₀ scriptsProvided txTop ≡ false -- (1)
     ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (2)
     ∙ ∀[ (vk , σ) ∈ TxWitnesses.vKeySigs (Tx.txWitnesses txTop) ] isSigned vk (txidBytes (TxIdOf txTop)) σ
     ∙ ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided (GuardsOf txTop) txVldt s
@@ -464,7 +464,7 @@ attempting both.
     in
 
     ∙ LegacyModeOf Γ ≡ true
-    ∙ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) -- (1)
+    ∙ isLegacyMode utxo₀ scriptsProvided txTop ≡ true -- (1)
     ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (2)
     ∙ ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes (TxIdOf txTop)) σ
     ∙ ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided (GuardsOf txTop) txVldt s

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -126,6 +126,35 @@ allowedLanguages tx utxo =
     fromList (PlutusV4 ∷ [])
 ```
 
+## Deciding the Operation Mode {#sec:deciding-the-operation-mode}
+
+The phase-2 scripts a transaction *needs* are the scripts in the (batch-wide)
+script pool whose hashes appear among the credentials the transaction needs.
+
+```agda
+neededP2Scripts : UTxO → ℙ Script → Tx ℓ → ℙ P2Script
+neededP2Scripts utxo scriptPool tx = mapPartial toP2Script scriptsNeeded
+  where
+    scriptHashesNeeded : ℙ ScriptHash
+    scriptHashesNeeded = mapPartial isScriptObj (mapˢ proj₂ (credsNeeded utxo tx))
+
+    scriptsNeeded : ℙ Script
+    scriptsNeeded = filterˢ (λ s → hash s ∈ scriptHashesNeeded) scriptPool
+```
+
+A top-level transaction is processed in *legacy mode* exactly when some
+phase-2 script it needs uses a Plutus language older than V4.  This decision
+is made once, in the `LEDGER`{.AgdaDatatype} rule, and the result is threaded
+through the rules via the `legacyMode`{.AgdaField} field of
+`UTxOEnv`{.AgdaRecord} and of `EntitiesEnv`{.AgdaRecord}.
+
+```agda
+isLegacyMode : UTxO → ℙ Script → TopLevelTx → Bool
+isLegacyMode utxo scriptPool txTop =
+  ¿ ∃[ s ∈ neededP2Scripts utxo scriptPool txTop ]
+      language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ¿ᵇ
+```
+
 ## Checking the script integrity hash
 
 The script integrity hash helps determining that the cost model for execution
@@ -261,9 +290,12 @@ different operating modes, **normal mode** and **legacy mode**. These correspond
 the rules `UTXOW-normal`{.AgdaInductiveConstructor} and
 `UTXOW-legacy`{.AgdaInductiveConstructor}.
 
-The mode is denoted by a Boolean in the second component of the environment,
-(`Γ`{.AgdaBound} , `legacyMode`{.AgdaBound}), so a computation can select one
-mode up front rather than deciding both.
+The mode itself is not decided here: it is decided once, in the
+`LEDGER`{.AgdaDatatype} rule, by `isLegacyMode`{.AgdaFunction} (see
+[above](#sec:deciding-the-operation-mode)), and communicated through the
+`legacyMode`{.AgdaField} field of the environment.  Each rule selects on that
+field, so a computation can pick the applicable mode up front rather than
+attempting both.
 
 ### Normal Mode
 
@@ -338,6 +370,7 @@ mode up front rather than deciding both.
                                       (credsNeeded utxo₀ txTop)
     in
 
+    ∙ LegacyModeOf Γ ≡ false
     ∙ ∀[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV4 ∷ []) -- (1)
     ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (2)
     ∙ ∀[ (vk , σ) ∈ TxWitnesses.vKeySigs (Tx.txWitnesses txTop) ] isSigned vk (txidBytes (TxIdOf txTop)) σ
@@ -351,7 +384,7 @@ mode up front rather than deciding both.
     ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguages txTop utxo₀
     ∙ txADhash ≡ map hash txAuxData
     ∙ scriptIntegrityHash ≡ hashScriptIntegrity (PParamsOf Γ) (languages p2ScriptsNeeded) txRedeemers txData
-    ∙ (Γ , false) ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
+    ∙ Γ ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
       ────────────────────────────────
       Γ ⊢ s ⇀⦇ txTop ,UTXOW⦈ s'
 ```
@@ -430,6 +463,7 @@ mode up front rather than deciding both.
                                       (credsNeeded utxo₀ txTop)
     in
 
+    ∙ LegacyModeOf Γ ≡ true
     ∙ ∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) -- (1)
     ∙ concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -- (2)
     ∙ ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes (TxIdOf txTop)) σ
@@ -443,7 +477,7 @@ mode up front rather than deciding both.
     ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguagesLegacy txTop utxo₀
     ∙ txADhash ≡ map hash txAuxData
     ∙ scriptIntegrityHash ≡ hashScriptIntegrity (PParamsOf Γ) (languages p2ScriptsNeeded) txRedeemers txData
-    ∙ (Γ , true) ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
+    ∙ Γ ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
       ────────────────────────────────
       Γ ⊢ s ⇀⦇ txTop ,UTXOW⦈ s'
 ```
@@ -453,8 +487,8 @@ mode up front rather than deciding both.
 unquoteDecl UTXOW-normal-premises = genPremises UTXOW-normal-premises (quote UTXOW-normal)
 unquoteDecl UTXOW-legacy-premises = genPremises UTXOW-legacy-premises (quote UTXOW-legacy)
 unquoteDecl SUBUTXOW-premises = genPremises SUBUTXOW-premises (quote SUBUTXOW)
-pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , h)
-pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , h)
+pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)
+pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)
 pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -19,7 +19,6 @@ module Ledger.Dijkstra.Specification.Utxow.Properties.Computational
   (abs : AbstractFunctions txs) (open AbstractFunctions abs)
   where
 
-import Data.List.Relation.Unary.Any as L
 open import Ledger.Dijkstra.Specification.Script.Validation txs abs
 open import Ledger.Dijkstra.Specification.Utxow txs abs
 open import Ledger.Dijkstra.Specification.Utxo txs abs
@@ -63,66 +62,41 @@ instance
   Computational-UTXOW = record {go} where
     module go (Γ : UTxOEnv) (s₀ : UTxOState) (txTop : TopLevelTx)
       (let H-normal , ⁇ H?-normal = UTXOW-normal-premises {txTop = txTop} {Γ = Γ}
-           H-legacy , ⁇ H?-legacy = UTXOW-legacy-premises {txTop = txTop} {Γ = Γ}
-
-           scriptsProvided = ScriptPoolOf Γ
-           credentialsNeeded = mapˢ proj₂ (credsNeeded (UTxOOf Γ) txTop)
-           scriptHashesNeeded = mapPartial isScriptObj credentialsNeeded
-           scriptsNeeded = filterˢ (λ s → hash s ∈ scriptHashesNeeded) scriptsProvided
-           p2ScriptsNeeded = mapPartial toP2Script scriptsNeeded)
+           H-legacy , ⁇ H?-legacy = UTXOW-legacy-premises {txTop = txTop} {Γ = Γ})
       where
-
-      private
-        V1,V2,V3∩V4⊆∅ : fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []) ∩ fromList (PlutusV4 ∷ []) ⊆ ∅
-        V1,V2,V3∩V4⊆∅ x with ∈-filter .Equivalence.from x
-        ... | (a , b) with ∈-fromList .Equivalence.from a | ∈-fromList .Equivalence.from b
-        V1,V2,V3∩V4⊆∅ x | (a , b) | L.here refl | L.there (L.here p)
-          with fromPlutusLanguage .Injection.injective p
-        ... | ()
-        V1,V2,V3∩V4⊆∅ x | a , b | L.here refl | L.there (L.there (L.here p))
-          with fromPlutusLanguage .Injection.injective p
-        ... | ()
-        V1,V2,V3∩V4⊆∅ x | a , b | L.here refl | L.here p
-          with fromPlutusLanguage .Injection.injective p
-        ... | ()
 
       module UTXO = Computational Computational-UTXO
 
-      DecV3 = Dec (∃[ s ∈ p2ScriptsNeeded ] language s ∈ fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ []))
-
-      computeProof-aux : DecV3 → Dec H-legacy → Dec H-normal
+      computeProof-aux : Dec H-legacy → Dec H-normal
                        → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
-      computeProof-aux (yes _) (no _) _ = failure "UTXOW"
-      computeProof-aux (yes _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂)) _ =
-        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , h)))
-            (UTXO.computeProof (Γ , true) s₀ txTop)
-      computeProof-aux (no _) _ (no _) = failure "UTXOW"
-      computeProof-aux (no _) _ (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂)) =
-        map (map₂′ (λ h → UTXOW-normal {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , h)))
-            (UTXO.computeProof (Γ , false) s₀ txTop)
+      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃)) _ =
+        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)))
+            (UTXO.computeProof Γ s₀ txTop)
+      computeProof-aux (no _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃)) =
+        map (map₂′ (λ h → UTXOW-normal {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , h)))
+            (UTXO.computeProof Γ s₀ txTop)
+      computeProof-aux (no _) (no _) = failure "UTXOW"
 
       computeProof : ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
-      computeProof = computeProof-aux ¿ _ ¿ H?-legacy H?-normal
+      computeProof = computeProof-aux H?-legacy H?-normal
 
-      completeness-aux : (dV3 : DecV3) (dLeg : Dec H-legacy) (dNorm : Dec H-normal)
+      completeness-aux : (dLeg : Dec H-legacy) (dNorm : Dec H-normal)
                          (s₁ : UTxOState)
                        → Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁
-                       → map proj₁ (computeProof-aux dV3 dLeg dNorm) ≡ success s₁
-      completeness-aux (yes (s , p , q)) _ _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _) =
-        ⊥-elim (Properties.∉-∅ (V1,V2,V3∩V4⊆∅ (∈-∩ .Equivalence.to (q , (p₀ p)))))
-      completeness-aux (no ¬p) _ _ _ (UTXOW-legacy-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _) =
-        ⊥-elim (¬p p₀)
-      completeness-aux (yes _) (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ _) =
-        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂))
-      completeness-aux (yes _) (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
-        with UTXO.computeProof (Γ , true) s₀ txTop | UTXO.completeness _ _ _ _ h
+                       → map proj₁ (computeProof-aux dLeg dNorm) ≡ success s₁
+      completeness-aux (yes (q₀ , _)) _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
+        case trans (sym q₀) p₀ of λ ()
+      completeness-aux (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
+        with UTXO.computeProof Γ s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
-      completeness-aux (no _) _ (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ _) =
-        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂))
-      completeness-aux (no _) _ (yes _) _ (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
-        with UTXO.computeProof (Γ , false) s₀ txTop | UTXO.completeness _ _ _ _ h
+      completeness-aux (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃))
+      completeness-aux (no _) (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃))
+      completeness-aux (no _) (yes _) _ (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
+        with UTXO.computeProof Γ s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
 
       completeness : ∀ s₁ → Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁ → map proj₁ computeProof ≡ success s₁
-      completeness = completeness-aux ¿ _ ¿ H?-legacy H?-normal
+      completeness = completeness-aux H?-legacy H?-normal
 ```


### PR DESCRIPTION
## Description

Closes #1258.

Previously the normal-vs-legacy decision lived in two places that could disagree: `UTXOW` chose a mode nondeterministically via its two rules (feeding `false`/`true` into `UTXO`'s self-balance premise), while `LEDGER-V` passed a hardcoded `true` to `ENTITIES` — making the `legacyMode ≡ false` branch of `ENTITIES` (partial top-level withdrawals) unreachable and letting an all-V4 transaction get normal-mode UTxO accounting but legacy-mode withdrawal treatment.

This PR makes the decision once, in `LEDGER`, and threads the result through the rules' environments.

### Changes

+  **`Utxow`**: new `neededP2Scripts` and `isLegacyMode : UTxO → ℙ Script → TopLevelTx → Bool` — legacy exactly when some needed phase-2 script uses a pre-V4 Plutus language (the same criterion `Computational-UTXOW` already used to dispatch).  `UTXOW-normal`/`UTXOW-legacy` gain a first premise `LegacyModeOf Γ ≡ false`/`≡ true` and pass `Γ` to `UTXO` unchanged.  Their language premises remain as checks, so the environment flag is validated rather than trusted, and each rule keeps its standalone meaning.

+  **`Utxo`**: `UTxOEnv` gains a named `legacyMode : Bool` field (mirroring how `isTopLevelValid` is threaded via `SubUTxOEnv`), with a `HasLegacyMode`/`LegacyModeOf` accessor. `UTXO`'s environment is plain `UTxOEnv` again instead of `UTxOEnv × Bool`.

+  **`Ledger`**: `LEDGER-V`/`LEDGER-I` compute `legacyMode = isLegacyMode utxo₀ allScripts tx` and thread it to `UTXOW`/`UTXO` via `UTxOEnv` and to `ENTITIES` via `EntitiesEnv`, replacing the hardcoded `true`. All three rules now see one consistent flag.

+  **Computational**: `Computational-UTXOW` dispatches on the flag premises, which removes the `DecV3` decision and the `V1,V2,V3∩V4⊆∅` disjointness lemma; `Computational-UTXO` loses the product-env plumbing; `Computational-LEDGER` mirrors the new rule environments.

+  **`Foreign/Utxo`**: `utxo-step` is now `UTxOEnv → UTxOState → Tx TxLevelTop → …` (the flag moved into the auto-derived `MkUTxOEnv`; no Haskell consumers exist yet).

### Verification

The full `Ledger.Dijkstra` aggregate typechecks (Agda 2.8.0 via the Nix flake), as does `Specification/Computational.lagda.md`, which sits outside the aggregate's import graph. No modules outside `src/Ledger/Dijkstra` import the changed ones.

### Out of scope

The legacy-mode withdrawal gap is *not* fixed here: the `ENTITIES` legacy branch still requires the top-level withdrawal to equal the current (post-`SUBLEDGERS`) balance with no `rewards₀` bound, and `UsesV4Features` only inspects top-level fields, so a legacy batch can still carry sub-transactions with direct deposits and drain them. This is now tracked in Issue #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Checked/revised by @williamdemeo**

## Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
