### PR TITLE
[Dijkstra] Add missing script checks to UTXOW

### DIFF
--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -139,6 +139,17 @@ record GovCertEnv : Type where
 
 <!--
 ```agda
+IsConwayCert? : IsConwayCert ⁇¹
+IsConwayCert? {x} .dec with x
+... | regdrep _ _ _ = yes tt
+... | deregdrep _ _ = yes tt
+... | ccreghot _ _  = yes tt
+... | delegate _ (just _) _ _ = yes tt
+... | delegate _ nothing  _ _ = no (λ ())
+... | dereg _ _ = no (λ ())
+... | regpool _ _ = no (λ ())
+... | retirepool _ _ = no (λ ())
+
 record HasDeposits (A : Type) {K : Type} : Type where
   field DepositsOf : A → K ⇀ Coin
 open HasDeposits ⦃...⦄ public

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -79,6 +79,13 @@ cwitness (ccreghot c _)      = just c
 IsPoolRegistered : Pools → KeyHash → Type
 IsPoolRegistered ps kh = kh ∈ dom ps
 
+IsConwayCert : DCert → Type
+IsConwayCert (regdrep _ _ _)           = ⊤
+IsConwayCert (deregdrep _ _)           = ⊤
+IsConwayCert (ccreghot _ _)            = ⊤
+IsConwayCert (delegate _ (just _) _ _) = ⊤
+IsConwayCert _                         = ⊥
+
 record CertEnv : Type where
   field
     epoch           : Epoch

--- a/src/Ledger/Dijkstra/Specification/Script/Validation.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Script/Validation.lagda.md
@@ -139,6 +139,9 @@ credentialToP1Script c scripts =
   do sh ← isScriptObj c
      s  ← lookupHash sh scripts
      toP1Script s
+
+txOutToP2Script : ℙ Script → TxOut → Maybe P2Script
+txOutToP2Script scripts txOut = credentialToP2Script (payCred (proj₁ txOut)) scripts
 ```
 
 ```agda

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -18,6 +18,7 @@ module Ledger.Dijkstra.Specification.Utxow
   (abs : AbstractFunctions txs) (open AbstractFunctions abs)
   where
 
+open import Ledger.Dijkstra.Specification.Certs govStructure
 open import Ledger.Dijkstra.Specification.Utxo txs abs
 open import Ledger.Dijkstra.Specification.Script.Validation txs abs
 import Data.List.Relation.Unary.Any as L
@@ -52,10 +53,11 @@ module _ (tx : TopLevelTx) where
     UsesV2Features = ∃[ o ∈ (range (TxOutsOf tx)) ∪ range (utxo ∣ (SpendInputsOf tx ∪ ReferenceInputsOf tx)) ] HasInlineDatum o
 
   data UsesV3Features : Set where
-    hasVotes     : ¬ (Is-[] (ListOfGovVotesOf tx))      → UsesV3Features
-    hasProposals : ¬ (Is-[] (ListOfGovProposalsOf tx))  → UsesV3Features
-    hasDonation  : NonZero (DonationsOf tx)             → UsesV3Features
-    hasTreasure  : Is-just (CurrentTreasuryOf tx)       → UsesV3Features
+    hasVotes       : ¬ (Is-[] (ListOfGovVotesOf tx))      → UsesV3Features
+    hasProposals   : ¬ (Is-[] (ListOfGovProposalsOf tx))  → UsesV3Features
+    hasDonation    : NonZero (DonationsOf tx)             → UsesV3Features
+    hasTreasure    : Is-just (CurrentTreasuryOf tx)       → UsesV3Features
+    hasConwayCerts : L.Any IsConwayCert (DCertsOf tx)     → UsesV3Features
 
   data UsesV4Features : Set where
     hasScriptGuards      : ¬ (∀[ g ∈ GuardsOf tx ] IsKeyHashObj g) → UsesV4Features
@@ -65,18 +67,36 @@ module _ (tx : TopLevelTx) where
 
 <!--
 ```agda
+private
+  IsConwayCert? : IsConwayCert ⁇¹
+  IsConwayCert? {x} .dec with x
+  ... | regdrep _ _ _ = yes tt
+  ... | deregdrep _ _ = yes tt
+  ... | ccreghot _ _  = yes tt
+  ... | delegate _ (just _) _ _ = yes tt
+  ... | delegate _ nothing  _ _ = no (λ ())
+  ... | dereg _ _ = no (λ ())
+  ... | regpool _ _ = no (λ ())
+  ... | retirepool _ _ = no (λ ())
+
 module _ {tx : TopLevelTx} where
   instance
     Dec-UsesV3Features : UsesV3Features tx ⁇
     Dec-UsesV3Features .dec
       with ¿ ¬ Is-[] (ListOfGovVotesOf tx) ¿ | ¿ ¬ Is-[] (ListOfGovProposalsOf tx) ¿
          | ¿ NonZero (DonationsOf tx)   ¿ | ¿ Is-just (CurrentTreasuryOf tx)  ¿
-    ... | yes p | _ | _ | _ = yes (hasVotes p)
-    ... | _ | yes p | _ | _ = yes (hasProposals p)
-    ... | _ | _ | yes p | _ = yes (hasDonation p)
-    ... | _ | _ | _ | yes p = yes (hasTreasure p)
-    ... | no p₁ | no p₂ | no p₃ | no p₄
-      = no λ { (hasVotes x) → p₁ x ; (hasProposals x) → p₂ x ; (hasDonation x) → p₃ x ; (hasTreasure x) → p₄ x}
+         | ¿ L.Any IsConwayCert (DCertsOf tx)  ¿ ⦃ Dec-Any ⦃ IsConwayCert? ⦄ ⦄
+    ... | yes p | _ | _ | _ | _ = yes (hasVotes p)
+    ... | _ | yes p | _ | _ | _ = yes (hasProposals p)
+    ... | _ | _ | yes p | _ | _ = yes (hasDonation p)
+    ... | _ | _ | _ | yes p | _ = yes (hasTreasure p)
+    ... | _ | _ | _ | _ | yes p = yes (hasConwayCerts p)
+    ... | no p₁ | no p₂ | no p₃ | no p₄ | no p₅
+      = no λ { (hasVotes x) → p₁ x
+             ; (hasProposals x) → p₂ x
+             ; (hasDonation x) → p₃ x
+             ; (hasTreasure x) → p₄ x
+             ; (hasConwayCerts x) → p₅ x }
 
 module _ {tx : TopLevelTx} where
   open Tx tx

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -71,18 +71,6 @@ module _ (tx : TopLevelTx) where
 
 <!--
 ```agda
-private
-  IsConwayCert? : IsConwayCert ⁇¹
-  IsConwayCert? {x} .dec with x
-  ... | regdrep _ _ _ = yes tt
-  ... | deregdrep _ _ = yes tt
-  ... | ccreghot _ _  = yes tt
-  ... | delegate _ (just _) _ _ = yes tt
-  ... | delegate _ nothing  _ _ = no (λ ())
-  ... | dereg _ _ = no (λ ())
-  ... | regpool _ _ = no (λ ())
-  ... | retirepool _ _ = no (λ ())
-
 module _ {tx : TopLevelTx} where
   instance
     Dec-UsesV3Features : UsesV3Features tx ⁇
@@ -142,19 +130,21 @@ allowedLanguagesLegacy tx utxo =
   else
     fromList (PlutusV4 ∷ PlutusV3 ∷ PlutusV2 ∷ PlutusV1 ∷ [])
 
-TxOutSpendable-PlutusV1-V2 : ℙ Script → TxOut → Type
-TxOutSpendable-PlutusV1-V2 scripts txOut
-  = Maybe.All (λ s → language s ≡ PlutusV1 → HasDataHash txOut) (txOutToP2Script scripts txOut)
-    ×
-    Maybe.All (λ s → language s ≡ PlutusV2 → HasDataHash txOut ⊎ HasInlineDatum txOut)
-              (txOutToP2Script scripts txOut)
-
 allowedLanguages : Tx ℓ → UTxO → ℙ Language
 allowedLanguages tx utxo =
   if UsesBootstrapAddress utxo tx
     then ∅
   else
     fromList (PlutusV4 ∷ [])
+```
+
+```agda
+TxOutSpendable-PlutusV1-V2 : ℙ Script → TxOut → Type
+TxOutSpendable-PlutusV1-V2 scripts txOut
+  = Maybe.All (λ s → language s ≡ PlutusV1 → HasDataHash txOut) (txOutToP2Script scripts txOut)
+    ×
+    Maybe.All (λ s → language s ≡ PlutusV2 → HasDataHash txOut ⊎ HasInlineDatum txOut)
+              (txOutToP2Script scripts txOut)
 ```
 
 ## Deciding the Operation Mode {#sec:deciding-the-operation-mode}

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -23,6 +23,7 @@ open import Ledger.Dijkstra.Specification.Utxo txs abs
 open import Ledger.Dijkstra.Specification.Script.Validation txs abs
 import Data.List.Relation.Unary.Any as L
 import Data.List.Relation.Unary.All as L
+import Data.Maybe.Relation.Unary.All as Maybe
 
 private variable
   ℓ     : TxLevel
@@ -44,11 +45,14 @@ UsesBootstrapAddress utxo tx
   where
     open Tx tx; open TxBody txBody
 
+HasInlineDatum : TxOut → Type
+HasInlineDatum txout = Is-just (txOutToDatum txout)
+
+HasDataHash : TxOut → Type
+HasDataHash txout = Is-just (txOutToDataHash txout)
+
 module _ (tx : TopLevelTx) where
   module _ (utxo : UTxO) where
-    HasInlineDatum : TxOut → Type
-    HasInlineDatum txout = Is-just (txOutToDatum txout)
-
     UsesV2Features : Type
     UsesV2Features = ∃[ o ∈ (range (TxOutsOf tx)) ∪ range (utxo ∣ (SpendInputsOf tx ∪ ReferenceInputsOf tx)) ] HasInlineDatum o
 
@@ -137,6 +141,13 @@ allowedLanguagesLegacy tx utxo =
     then fromList (PlutusV4 ∷ PlutusV3 ∷ PlutusV2 ∷ [])
   else
     fromList (PlutusV4 ∷ PlutusV3 ∷ PlutusV2 ∷ PlutusV1 ∷ [])
+
+TxOutSpendable-PlutusV1-V2 : ℙ Script → TxOut → Type
+TxOutSpendable-PlutusV1-V2 scripts txOut
+  = Maybe.All (λ s → language s ≡ PlutusV1 → HasDataHash txOut) (txOutToP2Script scripts txOut)
+    ×
+    Maybe.All (λ s → language s ≡ PlutusV2 → HasDataHash txOut ⊎ HasInlineDatum txOut)
+              (txOutToP2Script scripts txOut)
 
 allowedLanguages : Tx ℓ → UTxO → ℙ Language
 allowedLanguages tx utxo =
@@ -502,6 +513,7 @@ attempting both.
     ∙ dataHashesProvided ⊆ dataHashesNeededSpendInputs ∪ dataHashesOutputs ∪ dataHashesReferenceInputs
     ∙ dom txRedeemers ≡ᵉ scriptRedeemerPtrs
     ∙ languages p2ScriptsNeeded ⊆ dom (PParams.costmdls (PParamsOf Γ)) ∩ allowedLanguagesLegacy txTop utxo₀
+    ∙ ∀[ txOut ∈ range (utxo₀ ∣ SpendInputsOf txTop) ] TxOutSpendable-PlutusV1-V2 scriptsProvided txOut
     ∙ txADhash ≡ map hash txAuxData
     ∙ scriptIntegrityHash ≡ hashScriptIntegrity (PParamsOf Γ) (languages p2ScriptsNeeded) txRedeemers txData
     ∙ Γ ⊢ s ⇀⦇ txTop ,UTXO⦈ s'
@@ -515,7 +527,7 @@ unquoteDecl UTXOW-normal-premises = genPremises UTXOW-normal-premises (quote UTX
 unquoteDecl UTXOW-legacy-premises = genPremises UTXOW-legacy-premises (quote UTXOW-legacy)
 unquoteDecl SUBUTXOW-premises = genPremises SUBUTXOW-premises (quote SUBUTXOW)
 pattern UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ h = UTXOW-normal (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , h)
-pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , h)
+pattern UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ h = UTXOW-legacy (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , h)
 pattern SUBUTXOW-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ h = SUBUTXOW (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , h)
 ```
 -->

--- a/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow/Properties/Computational.lagda.md
@@ -71,8 +71,8 @@ instance
 
       computeProof-aux : Dec H-legacy → Dec H-normal
                        → ComputationResult String (∃[ s₁ ] (Γ ⊢ s₀ ⇀⦇ txTop ,UTXOW⦈ s₁))
-      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄)) _ =
-        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , h)))
+      computeProof-aux (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅)) _ =
+        map (map₂′ (λ h → UTXOW-legacy {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅ , h)))
             (UTXO.computeProof Γ s₀ txTop)
       computeProof-aux (no _) (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄)) =
         map (map₂′ (λ h → UTXOW-normal {txTop = txTop} {Γ = Γ} (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , h)))
@@ -90,11 +90,11 @@ instance
                        → map proj₁ (computeProof-aux dLeg dNorm) ≡ success s₁
       completeness-aux (yes (q₀ , _)) _ _ (UTXOW-normal-⋯ p₀ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
         case trans (sym q₀) p₀ of λ ()
-      completeness-aux (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
+      completeness-aux (yes _) _ _ (UTXOW-legacy-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)
         with UTXO.computeProof Γ s₀ txTop | UTXO.completeness _ _ _ _ h
       ... | success _ | refl = refl
-      completeness-aux (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ _) =
-        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄))
+      completeness-aux (no ¬p) _ _ (UTXOW-legacy-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ p₁₅ _) =
+        ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ , p₁₅))
       completeness-aux (no _) (no ¬p) _ (UTXOW-normal-⋯ p₀ p₁ p₂ p₃ p₄ p₅ p₆ p₇ p₈ p₉ p₁₀ p₁₁ p₁₂ p₁₃ p₁₄ _) =
         ⊥-elim (¬p (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆ , p₇ , p₈ , p₉ , p₁₀ , p₁₁ , p₁₂ , p₁₃ , p₁₄ ))
       completeness-aux (no _) (yes _) _ (UTXOW-normal-⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h)


### PR DESCRIPTION
# Description

- Check that txOuts locked by Plutus V1-V2 scripts have datahashes/inline datums
- Add check for Conway-era certificates to `UsesV3Features`

_Blocked by #1263_

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
