### PR TITLE
[Conway/Dijkstra] Move txIns ∩ refInputs ≡ ∅ to allowedLanguages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## Conway spec
 
+- Move `txIns ∩ refInputs ≡ ∅` precondition to `allowedLanguages` to allow non-disjoint tx and ref. inputs for Plutus V1-V2
 - Require collateral inputs to be present in the UTxO set in the UTXO rule
 - State and prove the claim that a voter's (last) vote in a block is applied to the governance action (see #417)
 - Change `RwdAddr` to `RewardAddress`

--- a/src/Ledger/Conway/Conformance/Equivalence.lagda.md
+++ b/src/Ledger/Conway/Conformance/Equivalence.lagda.md
@@ -50,7 +50,7 @@ lemInvalidDepositsL : ∀ {Γ utxoSt utxoSt' tx}
                     → Γ L.⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
                     → L.UTxOState.deposits utxoSt ≡ L.UTxOState.deposits utxoSt'
 lemInvalidDepositsL refl (L.UTXOW⇒UTXO
-                          (L.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+                          (L.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                             (L.Scripts-No _))) = refl
 
 lemInvalidDepositsC : ∀ {Γ utxoSt utxoSt' tx}
@@ -58,7 +58,7 @@ lemInvalidDepositsC : ∀ {Γ utxoSt utxoSt' tx}
                     → (h : Γ C.⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt')
                     → utxowDeposits h ≡ L.UTxOState.deposits utxoSt'
 lemInvalidDepositsC refl (C.UTXOW⇒UTXO
-                          (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+                          (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                             (C.Scripts-No _))) = refl
 
 -- The UTXOW rule doesn't change the deposits in Conformance
@@ -66,10 +66,10 @@ lemDepositsC : ∀ {Γ utxoSt utxoSt' tx}
              → (h : Γ C.⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt')
              → L.UTxOState.deposits utxoSt ≡ L.UTxOState.deposits utxoSt'
 lemDepositsC (C.UTXOW⇒UTXO
-               (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+               (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                  (C.Scripts-Yes _))) = refl
 lemDepositsC (C.UTXOW⇒UTXO
-               (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+               (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                  (C.Scripts-No _))) = refl
 
 lemUpdateDeposits : ∀ {Γ s tx s'} (open L.UTxOEnv Γ)
@@ -78,7 +78,7 @@ lemUpdateDeposits : ∀ {Γ s tx s'} (open L.UTxOEnv Γ)
                   → L.updateDeposits pparams (body tx) (L.UTxOState.deposits s) ≡ L.UTxOState.deposits s'
 lemUpdateDeposits refl
   (L.UTXOW⇒UTXO
-    (L.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (L.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
       (L.Scripts-Yes _))) = refl
 
 getValidCertDeposits : ∀ {Γ s tx s'}
@@ -90,7 +90,7 @@ getValidCertDeposits : ∀ {Γ s tx s'}
                      → L.ValidCertDeposits pparams deposits txCerts
 getValidCertDeposits refl
   (L.UTXOW⇒UTXO
-    (L.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (L.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
       (L.Scripts-Yes (v , _)))) = v
 
 makeCertDeps* : ∀ {Γ s tx s'}
@@ -231,7 +231,7 @@ lemUtxowDeposits : ∀ {Γ s s' tx}
                   → (r : Γ C.⊢ s ⇀⦇ tx ,UTXOW⦈ s')
                   → utxowDeposits r ≡ L.updateDeposits pparams (body tx) (C.UTxOState.deposits s')
 lemUtxowDeposits refl (C.UTXOW⇒UTXO
-                        (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+                        (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                           (C.Scripts-Yes _))) = refl
 
 instance

--- a/src/Ledger/Conway/Conformance/Equivalence/Utxo.lagda.md
+++ b/src/Ledger/Conway/Conformance/Equivalence/Utxo.lagda.md
@@ -57,7 +57,7 @@ module _ {Γ s tx s'} where
   utxoSDeposits (C.Scripts-No  _) = deposits
 
   utxoDeposits : Γ C.⊢ s ⇀⦇ tx ,UTXO⦈ s' → L.Deposits
-  utxoDeposits (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h) = utxoSDeposits h
+  utxoDeposits (C.UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h) = utxoSDeposits h
 
   utxowDeposits : Γ C.⊢ s ⇀⦇ tx ,UTXOW⦈ s' → L.Deposits
   utxowDeposits (C.UTXOW-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ h) = utxoDeposits h
@@ -84,8 +84,8 @@ instance
   -- deposits don't change! Why are they even part of the UTxOState?
   -- In conformance the update happens in GOVCERT (under CERT).
   UTXOToConf : ∀ {Γ s tx s'} → Γ L.⊢ s ⇀⦇ tx ,UTXO⦈ s' ⭆ Γ C.⊢ s ⇀⦇ tx ,UTXO⦈ (withDepositsFrom s s')
-  UTXOToConf {s = s} {tx = tx} .convⁱ _ (L.UTXO-inductive (a , b , c , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , utxo)) =
-    C.UTXO-inductive (a , b , c , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , conv utxo)
+  UTXOToConf {s = s} {tx = tx} .convⁱ _ (L.UTXO-inductive (a , b , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , utxo)) =
+    C.UTXO-inductive (a , b , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , conv utxo)
 
   UTXOFromConf : ∀ {Γ s tx s'}
                    (let open L.UTxOEnv Γ using () renaming (pparams to pp)
@@ -95,8 +95,8 @@ instance
                → (isValid tx ≡ false ⊎ L.ValidCertDeposits pp deposits txCerts)
                  ⊢ Γ C.⊢ s ⇀⦇ tx ,UTXO⦈ s' ⭆ⁱ λ _ h →
                    Γ L.⊢ s ⇀⦇ tx ,UTXO⦈ (setDeposits (utxoDeposits h) s')
-  UTXOFromConf {s = s} {tx = tx} .convⁱ validCerts (C.UTXO-inductive (a , b , c , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , utxo)) =
-    L.UTXO-inductive (a , b , c , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , (validCerts ⊢conv utxo))
+  UTXOFromConf {s = s} {tx = tx} .convⁱ validCerts (C.UTXO-inductive (a , b , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , utxo)) =
+    L.UTXO-inductive (a , b , d , e , f , g , r , h , i , j , k , l , m , n , o , p , q , (validCerts ⊢conv utxo))
 
   UTXOWToConf : ∀ {Γ s tx s'} → Γ L.⊢ s ⇀⦇ tx ,UTXOW⦈ s' ⭆ Γ C.⊢ s ⇀⦇ tx ,UTXOW⦈ (withDepositsFrom s s')
   UTXOWToConf .convⁱ _ (L.UTXOW-inductive⋯ a b c d e f g h i j k l utxo) =

--- a/src/Ledger/Conway/Conformance/Utxo.lagda.md
+++ b/src/Ledger/Conway/Conformance/Utxo.lagda.md
@@ -92,10 +92,13 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv → UTxOState → Tx → UTxOState → Type
         txOutsʰ = (mapValues txOutHash txOuts)
         overhead = 160
     in
-    ∙ txIns ≢ ∅                              ∙ txIns ∪ refInputs ∪ collateralInputs ⊆ dom utxo
-    ∙ txIns ∩ refInputs ≡ ∅                  ∙ L.inInterval slot txVldt
-    ∙ L.minfee pp utxo tx ≤ txFee            ∙ (txrdmrs ˢ ≢ ∅ → L.collateralCheck pp tx utxo)
-    ∙ consumed pp s txb ≡ produced pp s txb  ∙ coin mint ≡ 0
+    ∙ txIns ≢ ∅
+    ∙ txIns ∪ refInputs ∪ collateralInputs ⊆ dom utxo
+    ∙ L.inInterval slot txVldt
+    ∙ L.minfee pp utxo tx ≤ txFee
+    ∙ (txrdmrs ˢ ≢ ∅ → L.collateralCheck pp tx utxo)
+    ∙ consumed pp s txb ≡ produced pp s txb
+    ∙ coin mint ≡ 0
     ∙ (∅ᵐ ≢ᵐ txrdmrs × nothing ≢ proj₂ txVldt →
          map epochInfoSlotToUTCTime (proj₂ txVldt) ≢ nothing
       )
@@ -116,7 +119,7 @@ data _⊢_⇀⦇_,UTXO⦈_ : UTxOEnv → UTxOState → Tx → UTxOState → Type
       ────────────────────────────────
       Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s'
 
-pattern UTXO-inductive⋯ tx Γ s x y z w k l m c d v j n o p q r t u h
-      = UTXO-inductive {tx}{Γ}{s} (x , y , z , w , k , l , m , c , d , v , j , n , o , p , q , r , t , u , h)
+pattern UTXO-inductive⋯ tx Γ s x y w k l m c d v j n o p q r t u h
+      = UTXO-inductive {tx}{Γ}{s} (x , y , w , k , l , m , c , d , v , j , n , o , p , q , r , t , u , h)
 unquoteDecl UTXO-premises = genPremises UTXO-premises (quote UTXO-inductive)
 ```

--- a/src/Ledger/Conway/Conformance/Utxo/Properties.lagda.md
+++ b/src/Ledger/Conway/Conformance/Utxo/Properties.lagda.md
@@ -71,16 +71,16 @@ instance
           renaming (computeProof to computeProof'; completeness to completeness')
 
         computeProofH : Dec H → ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s')
-        computeProofH (yes (x , y , z , e , k , l , m , c , d , v , j , n , o , p , q , r , t , u)) =
-            map₂′ (UTXO-inductive⋯ _ _ _ x y z e k l m c d v j n o p q r t u) <$> computeProof' Γ s tx
+        computeProofH (yes (x , y , e , k , l , m , c , d , v , j , n , o , p , q , r , t , u)) =
+            map₂′ (UTXO-inductive⋯ _ _ _ x y e k l m c d v j n o p q r t u) <$> computeProof' Γ s tx
         computeProofH (no ¬p) = failure $ genErrors ¬p
 
         computeProof : ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s')
         computeProof = computeProofH H?
 
         completeness : ∀ s' → Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s' → map proj₁ computeProof ≡ success s'
-        completeness s' (UTXO-inductive⋯ _ _ _ x y z e k l m c d v j n o p q r t u h) with H?
-        ... | no ¬p = ⊥-elim $ ¬p (x , y , z , e , k , l , m , c , d , v , j , n , o , p , q , r , t , u )
+        completeness s' (UTXO-inductive⋯ _ _ _ x y e k l m c d v j n o p q r t u h) with H?
+        ... | no ¬p = ⊥-elim $ ¬p (x , y , e , k , l , m , c , d , v , j , n , o , p , q , r , t , u )
         ... | yes _ with computeProof' Γ s tx | completeness' _ _ _ _ h
         ... | success _ | refl = refl
 

--- a/src/Ledger/Conway/Specification/Ledger/Properties/Base.lagda.md
+++ b/src/Ledger/Conway/Specification/Ledger/Properties/Base.lagda.md
@@ -71,7 +71,7 @@ In the remainder of this section, we show some utility lemmas without proofs.
 <!--
 ```agda
 module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {DepositPurpose})
-pattern UTXOW-UTXOS x = UTXOW⇒UTXO (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ x)
+pattern UTXOW-UTXOS x = UTXOW⇒UTXO (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ x)
 
 open Equivalence
 ```

--- a/src/Ledger/Conway/Specification/Ledger/Properties/PoV.lagda.md
+++ b/src/Ledger/Conway/Specification/Ledger/Properties/PoV.lagda.md
@@ -43,7 +43,7 @@ module _
                    → InjectiveOn (dom s) f → getCoin (mapˢ (map₁ f) s) ≡ getCoin s )
   where
 
-  pattern UTXO-induction r = UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ r _ _ _
+  pattern UTXO-induction r = UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ r _ _ _
 ```
 -->
 

--- a/src/Ledger/Conway/Specification/Utxo.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo.lagda.md
@@ -541,10 +541,13 @@ data _⊢_⇀⦇_,UTXO⦈_ where
         txOutsʰ   = mapValues txOutHash txOuts
         overhead  = 160
     in
-    ∙ txIns ≢ ∅                              ∙ txIns ∪ refInputs ∪ collateralInputs ⊆ dom utxo
-    ∙ txIns ∩ refInputs ≡ ∅                  ∙ inInterval slot txVldt
-    ∙ minfee pp utxo tx ≤ txFee              ∙ (txrdmrs ˢ ≢ ∅ → collateralCheck pp tx utxo)
-    ∙ consumed pp s txb ≡ produced pp s txb  ∙ coin mint ≡ 0
+    ∙ txIns ≢ ∅
+    ∙ txIns ∪ refInputs ∪ collateralInputs ⊆ dom utxo
+    ∙ inInterval slot txVldt
+    ∙ minfee pp utxo tx ≤ txFee
+    ∙ (txrdmrs ˢ ≢ ∅ → collateralCheck pp tx utxo)
+    ∙ consumed pp s txb ≡ produced pp s txb
+    ∙ coin mint ≡ 0
     ∙ (∅ᵐ ≢ᵐ txrdmrs × nothing ≢ proj₂ txVldt →
          map epochInfoSlotToUTCTime (proj₂ txVldt) ≢ nothing
       )
@@ -567,8 +570,8 @@ data _⊢_⇀⦇_,UTXO⦈_ where
 
 <!--
 ```agda
-pattern UTXO-inductive⋯ tx Γ s x y z w k l m c d v j n o p q r t u h
-  = UTXO-inductive {Γ = Γ} {s = s} {tx = tx} (x , y , z , w , k , l , m , c , d , v , j , n , o , p , q , r , t , u , h)
+pattern UTXO-inductive⋯ tx Γ s x y w k l m c d v j n o p q r t u h
+  = UTXO-inductive {Γ = Γ} {s = s} {tx = tx} (x , y , w , k , l , m , c , d , v , j , n , o , p , q , r , t , u , h)
 unquoteDecl UTXO-premises = genPremises UTXO-premises (quote UTXO-inductive)
 ```
 -->

--- a/src/Ledger/Conway/Specification/Utxo/Properties/Base.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo/Properties/Base.lagda.md
@@ -186,7 +186,7 @@ module _
     stepS : Γ ⊢ ⟦ utxo  , fees  , deposits  , donations  ⟧ ⇀⦇ tx ,UTXOS⦈
                 ⟦ utxo' , fees' , deposits' , donations' ⟧
     stepS = case step of λ where
-      (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h) → h
+      (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h) → h
 
     pp : PParams
     pp = UTxOEnv.pparams Γ
@@ -208,13 +208,13 @@ module _
     newBal' : Γ ⊢ ⟦ utxo  , fees  , deposits  , donations  ⟧ ⇀⦇ tx ,UTXO⦈
                   ⟦ utxo' , fees' , deposits' , donations' ⟧
             → consumed pp utxoSt txb ≡ produced pp utxoSt txb
-    newBal' (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ x _ _ _ _ _ _ _ _ _ _ _ _) = x
+    newBal' (UTXO-inductive⋯ _ _ _ _ _ _ _ _ x _ _ _ _ _ _ _ _ _ _ _ _) = x
     newBal : consumed pp utxoSt txb ≡ produced pp utxoSt txb
     newBal = newBal' step
     noMintAda' : Γ ⊢ ⟦ utxo  , fees  , deposits  , donations  ⟧ ⇀⦇ tx ,UTXO⦈
                      ⟦ utxo' , fees' , deposits' , donations' ⟧
                → coin (mint) ≡ 0
-    noMintAda' (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ x _ _ _ _ _ _ _ _ _ _ _) = x
+    noMintAda' (UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ x _ _ _ _ _ _ _ _ _ _ _) = x
     noMintAda : coin mint ≡ 0
     noMintAda = noMintAda' step
     remDepTot : Coin

--- a/src/Ledger/Conway/Specification/Utxo/Properties/Computational.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo/Properties/Computational.lagda.md
@@ -117,16 +117,16 @@ instance
                                       (inj₂ _) → "something else broke"
 
         computeProofH : Dec H → ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s')
-        computeProofH (yes (x , y , z , e , k , l , m , c , d , v , j , n , o , p , q , r , t , u)) =
-            map₂′ (UTXO-inductive⋯ _ _ _ x y z e k l m c d v j n o p q r t u) <$> computeProof' Γ s tx
+        computeProofH (yes (x , y , e , k , l , m , c , d , v , j , n , o , p , q , r , t , u)) =
+            map₂′ (UTXO-inductive⋯ _ _ _ x y e k l m c d v j n o p q r t u) <$> computeProof' Γ s tx
         computeProofH (no ¬p) = failure $ genErr ¬p
 
         computeProof : ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s')
         computeProof = computeProofH H?
 
         completeness : ∀ s' → Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s' → map proj₁ computeProof ≡ success s'
-        completeness s' (UTXO-inductive⋯ _ _ _ x y z w k l m c d v j n o p q r t u h) with H?
-        ... | no ¬p = ⊥-elim $ ¬p (x , y , z , w , k , l , m , c , d , v , j , n , o , p , q , r , t , u)
+        completeness s' (UTXO-inductive⋯ _ _ _ x y w k l m c d v j n o p q r t u h) with H?
+        ... | no ¬p = ⊥-elim $ ¬p (x , y , w , k , l , m , c , d , v , j , n , o , p , q , r , t , u)
         ... | yes _ with computeProof' Γ s tx | completeness' _ _ _ _ h
         ... | success _ | refl = refl
 

--- a/src/Ledger/Conway/Specification/Utxo/Properties/Computational.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo/Properties/Computational.lagda.md
@@ -27,6 +27,7 @@ open import Ledger.Prelude hiding (≤-trans; ≤-antisym; All); open Properties
 open import Tactic.Cong                 using (cong!)
 open import Tactic.EquationalReasoning  using (module ≡-Reasoning)
 open import stdlib-meta.Tactic.MonoidSolver.NonNormalising using (solve-macro)
+open import stdlib-meta.Tactic.GenError
 
 open import Ledger.Conway.Specification.Utxo txs abs
 open import Ledger.Conway.Specification.Script.Validation txs abs
@@ -73,53 +74,10 @@ instance
         open Computational Computational-UTXOS
           renaming (computeProof to computeProof'; completeness to completeness')
 
-        genErr : ¬ H → String
-        genErr  ¬p = case dec-de-morgan ¬p of λ where
-          (inj₁ a) → "¬ TxBody.txIns (Tx.body tx) ≢ ∅"
-          (inj₂ b) → case dec-de-morgan b of λ where
-            (inj₁ a₁) → "¬ txIns ∪ refInputs ∪ collateralInputs ⊆ dom (UTxOOf s)"
-            (inj₂ b₁) → case dec-de-morgan b₁ of λ where
-                (inj₁ a₁') → "¬ txIns ∩ refInputs ≡ ∅"
-                (inj₂ b₂') → case dec-de-morgan b₂' of λ where
-                  (inj₁ a₂) → "¬ inInterval (UTxOEnv.slot Γ) (txvldt (Tx.body tx))"
-                  (inj₂ b₂) → case dec-de-morgan b₂ of λ where
-                    (inj₁ a₃) → "¬ minfee pp utxo tx ≤ txFee"
-                    (inj₂ b₃) → case dec-de-morgan b₃ of λ where
-                        (inj₁ a₄) → "¬ (txrdmrs ˢ ≢ ∅ → collateralCheck pp tx utxo)"
-                        (inj₂ b₄) → case dec-de-morgan b₄ of λ where
-                          (inj₁ a₅) →
-                            let
-                              pp = PParamsOf Γ
-                              txb = TxBodyOf tx
-                              con = consumed pp s txb
-                              prod = produced pp s txb
-                              showValue = show ∘ coin
-                            in
-                              ( "¬consumed (UTxOEnv.pparams Γ) s (Tx.body tx) ≡ produced (PParamsOf Γ) s (Tx.body tx)"
-                              +ˢ "\n  consumed =\t\t" +ˢ showValue con
-                              +ˢ "\n    ins  =\t\t" +ˢ showValue (balance (UTxOOf s ∣ txb .TxBody.txIns))
-                              +ˢ "\n    mint =\t\t" +ˢ showValue (TxBody.mint txb)
-                              +ˢ "\n    depositRefunds =\t" +ˢ showValue (inject (depositRefunds pp s txb))
-                              +ˢ "\n  produced =\t\t" +ˢ showValue prod
-                              +ˢ "\n    outs =\t\t" +ˢ showValue (balance $ outs txb)
-                              +ˢ "\n    fee  =\t\t" +ˢ show (FeesOf tx)
-                              +ˢ "\n    newDeposits  =\t" +ˢ show (newDeposits pp s txb)
-                              +ˢ "\n    donation  =\t\t" +ˢ show (DonationsOf txb)
-                              )
-                          (inj₂ b₅) → case dec-de-morgan b₅ of λ where
-                              (inj₁ a₆) → "¬ coin (TxBody.mint (Tx.body tx)) ≡ 0"
-                              (inj₂ b₆) → case dec-de-morgan b₆ of λ where
-                                (inj₁ a₇) → "¬ (∅ᵐ ≢ᵐ txrdmrs × nothing ≢ proj₂ txVldt → map epochInfoSlotToUTCTime (proj₂ txVldt) ≢ nothing)"
-                                (inj₂ b₇) → case dec-de-morgan b₇ of λ where
-                                    (inj₁ a₈) → "¬ ((Tx.txsize tx) Data.Nat.Base.≤ maxTxSize (UTxOEnv.pparams Γ))"
-                                    (inj₂ b₈) → case dec-de-morgan b₈ of λ where
-                                      (inj₁ a₉) → "¬ refScriptsSize utxo tx ≤ maxRefScriptSizePerTx pp"
-                                      (inj₂ _) → "something else broke"
-
         computeProofH : Dec H → ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s')
         computeProofH (yes (x , y , e , k , l , m , c , d , v , j , n , o , p , q , r , t , u)) =
             map₂′ (UTXO-inductive⋯ _ _ _ x y e k l m c d v j n o p q r t u) <$> computeProof' Γ s tx
-        computeProofH (no ¬p) = failure $ genErr ¬p
+        computeProofH (no ¬p) = failure $ genErrors ¬p
 
         computeProof : ComputationResult String (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,UTXO⦈ s')
         computeProof = computeProofH H?

--- a/src/Ledger/Conway/Specification/Utxo/Properties/GenMinSpend.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo/Properties/GenMinSpend.lagda.md
@@ -180,7 +180,7 @@ module _ -- ASSUMPTION --
        -------------------------------------------------------------------
     →  coin (consumed pp utxoState txb) ≥ length txGovProposals * govActionDeposit
 
-  gmsc step@(UTXO-inductive⋯ tx Γ utxoState _ _ _ _ _ _ c≡p cmint≡0 _ _ _ _ _ _ _ _ _ _ _) nrf =
+  gmsc step@(UTXO-inductive⋯ tx Γ utxoState _ _ _ _ _ c≡p cmint≡0 _ _ _ _ _ _ _ _ _ _ _) nrf =
     begin
     length txGovProposals * govActionDeposit
       ≡˘⟨ updatePropDeps≡ txGovProposals ⟩

--- a/src/Ledger/Conway/Specification/Utxo/Properties/MinSpend.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo/Properties/MinSpend.lagda.md
@@ -69,7 +69,7 @@ module _
 *Proof*.
 
 ```agda
-    utxoMinSpend step@(UTXO-inductive⋯ tx Γ utxoSt _ _ _ _ _ _ c≡p cmint≡0 _ _ _ _ _ _ _ _ _ _ _) nrf =
+    utxoMinSpend step@(UTXO-inductive⋯ tx Γ utxoSt _ _ _ _ _ c≡p cmint≡0 _ _ _ _ _ _ _ _ _ _ _) nrf =
       begin
       length txGovProposals * govActionDeps
         ≡˘⟨ updatePropDeps≡ gc-hom txGovProposals ⟩

--- a/src/Ledger/Conway/Specification/Utxo/Properties/PoV.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxo/Properties/PoV.lagda.md
@@ -60,9 +60,9 @@ UTXOpov : {Γ : UTxOEnv} {tx : Tx} {s s' : UTxOState}
 *Proof*.
 
 ```agda
-UTXOpov h' step@(UTXO-inductive⋯ _ Γ _ _ _ _ _ _ _ newBal noMintAda _ _ _ _ _ _ _ _ _ _ (Scripts-Yes (_ , _ , valid)))
+UTXOpov h' step@(UTXO-inductive⋯ _ Γ _ _ _ _ _ _ newBal noMintAda _ _ _ _ _ _ _ _ _ _ (Scripts-Yes (_ , _ , valid)))
   = pov-scripts step h' refl valid
 
-UTXOpov h' step@(UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ (Scripts-No (_ , invalid)))
+UTXOpov h' step@(UTXO-inductive⋯ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ (Scripts-No (_ , invalid)))
   = pov-no-scripts step h' invalid
 ```

--- a/src/Ledger/Conway/Specification/Utxow.lagda.md
+++ b/src/Ledger/Conway/Specification/Utxow.lagda.md
@@ -67,18 +67,17 @@ IsConwayCert (delegate _ (just _) _ _) = ⊤
 IsConwayCert _               = ⊥
 
 private
-  instance
-    IsConwayCert? : IsConwayCert ⁇¹
-    IsConwayCert? {x} .dec with x
-    ... | regdrep _ _ _ = yes tt
-    ... | deregdrep _ _ = yes tt
-    ... | ccreghot _ _  = yes tt
-    ... | delegate _ (just _) _ _ = yes tt
-    ... | delegate _ nothing  _ _ = no (λ ())
-    ... | dereg _ _ = no (λ ())
-    ... | regpool _ _ = no (λ ())
-    ... | retirepool _ _ = no (λ ())
-    ... | reg _ _ = no (λ ())
+  IsConwayCert? : IsConwayCert ⁇¹
+  IsConwayCert? {x} .dec with x
+  ... | regdrep _ _ _ = yes tt
+  ... | deregdrep _ _ = yes tt
+  ... | ccreghot _ _  = yes tt
+  ... | delegate _ (just _) _ _ = yes tt
+  ... | delegate _ nothing  _ _ = no (λ ())
+  ... | dereg _ _ = no (λ ())
+  ... | regpool _ _ = no (λ ())
+  ... | retirepool _ _ = no (λ ())
+  ... | reg _ _ = no (λ ())
 
 module _ (txb : TxBody) (let open TxBody txb) where
 
@@ -92,7 +91,7 @@ module _ (txb : TxBody) (let open TxBody txb) where
 instance
   Dec-UsesV3Features : ∀ {txb} → UsesV3Features txb ⁇
   Dec-UsesV3Features {record { txCerts = txCerts; txGovVotes = [] ; txGovProposals = [] ; txDonation = zero ; currentTreasury = nothing }}
-    with ¿ L.Any IsConwayCert txCerts ¿
+    with ¿ L.Any IsConwayCert txCerts ¿ ⦃ Dec-Any ⦃ IsConwayCert? ⦄ ⦄
   ... | yes p = ⁇ yes (HasConwayCerts p)
   ... | no ¬p
     = ⁇ no λ where (HasVotes x)    → x refl
@@ -133,17 +132,32 @@ Only inline datums are now disallowed from appearing together with a Plutus V1 s
 ```agda
 allowedLanguages : Tx → UTxO → ℙ Language
 allowedLanguages tx utxo =
-  if (∃[ o ∈ os ] IsBootstrapAddr (proj₁ o))
-    then ∅
-  else if UsesV3Features txb
-    then fromList (PlutusV3 ∷ [])
-  else if ∃[ o ∈ os ] HasInlineDatum o
-    then fromList (PlutusV2 ∷ PlutusV3 ∷ [])
-  else
-    fromList (PlutusV1 ∷ PlutusV2 ∷ PlutusV3 ∷ [])
+  (
+    if ¬ usesBootstrapAddr × txIns ∩ refInputs ≡ ∅
+      then ❴ PlutusV3 ❵
+      else ∅
+  )
+  ∪
+  (
+    if ¬ usesBootstrapAddr × ¬ usesV3Features
+      then ❴ PlutusV2 ❵
+      else ∅
+  )
+  ∪
+  (
+    if ¬ usesBootstrapAddr × ¬ usesV3Features × ¬ usesV2Features
+      then ❴ PlutusV1 ❵
+      else ∅
+  )
   where
     txb = tx .Tx.body; open TxBody txb
     os = range (outs txb) ∪ range (utxo ∣ (txIns ∪ refInputs))
+
+    usesBootstrapAddr = ∃[ (a , _) ∈ os ] IsBootstrapAddr a
+
+    usesV3Features = UsesV3Features txb
+
+    usesV2Features = ∃[ o ∈ os ] HasInlineDatum o
 ```
 
 ## Checking the script integrity hash

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -120,7 +120,7 @@ languages p2Scripts = mapˢ language p2Scripts
 allowedLanguagesLegacy : TopLevelTx → UTxO → ℙ Language
 allowedLanguagesLegacy tx utxo =
   (
-    if ¬ usesBootstrapAddr
+    if ¬ usesBootstrapAddr × SpendInputsOf tx ∩ ReferenceInputsOf tx ≡ ∅
       then ❴ PlutusV4 ❵
       else ∅
   )
@@ -155,10 +155,9 @@ allowedLanguagesLegacy tx utxo =
 
 allowedLanguages : Tx ℓ → UTxO → ℙ Language
 allowedLanguages tx utxo =
-  if UsesBootstrapAddress utxo tx
-    then ∅
-  else
-    fromList (PlutusV4 ∷ [])
+  if ¬ UsesBootstrapAddress utxo tx × SpendInputsOf tx ∩ ReferenceInputsOf tx ≡ ∅
+    then ❴ PlutusV4 ❵
+    else ∅
 ```
 
 ```agda

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -119,16 +119,39 @@ languages p2Scripts = mapˢ language p2Scripts
 
 allowedLanguagesLegacy : TopLevelTx → UTxO → ℙ Language
 allowedLanguagesLegacy tx utxo =
-  if UsesBootstrapAddress utxo tx
-    then ∅
-  else if UsesV4Features tx
-    then ∅
-  else if UsesV3Features tx
-    then fromList (PlutusV4 ∷ PlutusV3 ∷ [])
-  else if UsesV2Features tx utxo
-    then fromList (PlutusV4 ∷ PlutusV3 ∷ PlutusV2 ∷ [])
-  else
-    fromList (PlutusV4 ∷ PlutusV3 ∷ PlutusV2 ∷ PlutusV1 ∷ [])
+  (
+    if ¬ usesBootstrapAddr
+      then ❴ PlutusV4 ❵
+      else ∅
+  )
+  ∪
+  (
+    if ¬ usesBootstrapAddr × ¬ usesV4Features × SpendInputsOf tx ∩ ReferenceInputsOf tx ≡ ∅
+      then ❴ PlutusV3 ❵
+      else ∅
+  )
+  ∪
+  (
+    if ¬ usesBootstrapAddr × ¬ usesV4Features × ¬ usesV3Features
+      then ❴ PlutusV2 ❵
+      else ∅
+  )
+  ∪
+  (
+    if ¬ usesBootstrapAddr × ¬ usesV4Features × ¬ usesV3Features × ¬ usesV2Features
+      then ❴ PlutusV1 ❵
+      else ∅
+  )
+  where
+    os = range (TxOutsOf tx) ∪ range (utxo ∣ (SpendInputsOf tx ∪ ReferenceInputsOf tx))
+
+    usesBootstrapAddr = ∃[ (a , _) ∈ os ] IsBootstrapAddr a
+
+    usesV4Features = UsesV4Features tx
+
+    usesV3Features = UsesV3Features tx
+
+    usesV2Features = ∃[ o ∈ os ] HasInlineDatum o
 
 allowedLanguages : Tx ℓ → UTxO → ℙ Language
 allowedLanguages tx utxo =

--- a/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Utxow.lagda.md
@@ -151,7 +151,7 @@ allowedLanguagesLegacy tx utxo =
 
     usesV3Features = UsesV3Features tx
 
-    usesV2Features = ∃[ o ∈ os ] HasInlineDatum o
+    usesV2Features = UsesV2Features tx utxo
 
 allowedLanguages : Tx ℓ → UTxO → ℙ Language
 allowedLanguages tx utxo =


### PR DESCRIPTION
# Description

For backwards compatibility Plutus V1-V2 scripts are allowed in transactions where the inputs and reference inputs are not disjoint sets. In contrast, when this is the case, Plutus V3 scripts are not allowed.

For more info see https://github.com/IntersectMBO/cardano-ledger/pull/5011

In addition, this PR adds the disjointness check to Plutus V4 scripts.
  
~_Blocked by https://github.com/IntersectMBO/formal-ledger-specifications/pull/1265_~

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
