### PR TITLE
[Conway] Property : voteDelegs range lies in VDelegs of registered DReps (#1233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## Conway spec
 
+- State and prove that after a `CERTS` step every `voteDelegs` value is a `VDeleg` of a registered `DRep`, `vDelegAbstain`, or `vDelegNoConfidence` (see #1233)
 - Move `txIns ∩ refInputs ≡ ∅` precondition to `allowedLanguages` to allow non-disjoint tx and ref. inputs for Plutus V1-V2
 - Require collateral inputs to be present in the UTxO set in the UTXO rule
 - State and prove the claim that a voter's (last) vote in a block is applied to the governance action (see #417)

--- a/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
+++ b/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
@@ -703,6 +703,18 @@ module _  {A B : Type}
       lem-del-excluded m ¬p = filterᵐ-restrict m ⟨≈⟩ restrict-singleton-filterᵐ-false m ¬p
 
 
+-- Corestriction
+
+-- Corestricting a map to a set `X` of values confines its range to `X`.
+-- Indeed, `(m ∣^ X) ˢ` is `m ˢ` filtered by the predicate `(_∈ X) ∘ proj₂`, so every
+-- pair surviving the filter carries a proof that its value belongs to `X`.
+-- The map `m` is an explicit argument because it cannot be recovered by unification:
+-- `_∣^_` goes through `⊆-map`, which mentions `m` only as `m ˢ` (i.e., `proj₁ m`).
+cores-range-⊆ : ∀ {A B : Type} ⦃ _ : DecEq B ⦄ (m : A ⇀ B) {X : ℙ B} → range (m ∣^ X) ⊆ X
+cores-range-⊆ _ b∈range with Equivalence.from ∈-map b∈range
+... | _ , refl , ab∈cores = proj₁ (Equivalence.from ∈-filter ab∈cores)
+
+
 -- Map lemmas: lookup after insert
 
 -- Looking up a freshly inserted key returns the inserted value.

--- a/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
+++ b/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
@@ -711,7 +711,7 @@ module _  {A B : Type}
 -- The map `m` is an explicit argument because it cannot be recovered by unification:
 -- `_∣^_` goes through `⊆-map`, which mentions `m` only as `m ˢ` (i.e., `proj₁ m`).
 cores-range-⊆ : ∀ {A B : Type} ⦃ _ : DecEq B ⦄ (m : A ⇀ B) {X : ℙ B} → range (m ∣^ X) ⊆ X
-cores-range-⊆ _ b∈range with Equivalence.from ∈-map b∈range
+cores-range-⊆ m b∈range with Equivalence.from ∈-map b∈range
 ... | _ , refl , ab∈cores = proj₁ (Equivalence.from ∈-filter ab∈cores)
 
 

--- a/src/Ledger/Conway/Specification/Certs/Properties/VoteDelegsVDeleg.lagda.md
+++ b/src/Ledger/Conway/Specification/Certs/Properties/VoteDelegsVDeleg.lagda.md
@@ -3,7 +3,7 @@ source_branch: master
 source_path: src/Ledger/Conway/Specification/Certs/Properties/VoteDelegsVDeleg.lagda.md
 ---
 
-## Claim: <span class="AgdaField">voteDelegs</span> field values are <span class="AgdaDatatype">VDelegs</span> constructed from their keys {#clm:VDelegsInRegDReps}
+## Theorem: <span class="AgdaField">voteDelegs</span> values point at registered <span class="AgdaFunction">DReps</span> {#clm:VDelegsInRegDReps}
 
 <!--
 ```agda
@@ -17,35 +17,86 @@ module Ledger.Conway.Specification.Certs.Properties.VoteDelegsVDeleg (gs : _) (o
 open import Ledger.Conway.Specification.Certs gs
 open import Ledger.Prelude
 open import Ledger.Conway.Specification.Gov.Actions gs
+
+private variable
+  Γ      : CertEnv
+  s s'   : CertState
+  certs  : List DCert
 ```
 -->
 
 *Informally*.
 
-A `CertState`{.AgdaRecord} has a `DState`{.AgdaDatatype}, a `PState`{.AgdaDatatype}, and a
-`GState`{.AgdaDatatype}.  The `DState`{.AgdaDatatype} contains a field
-`voteDelegs`{.AgdaField} which is a mapping from `Credential`{.AgdaDatatype} to
-`VDeleg`{.AgdaDatatype}.
+A `CertState`{.AgdaRecord} has a `DState`{.AgdaRecord}, a `PState`{.AgdaRecord}, and a
+`GState`{.AgdaRecord}.  The `DState`{.AgdaRecord} contains a field
+`voteDelegs`{.AgdaField}, a map sending the `Credential`{.AgdaDatatype} of a delegator to
+the `VDeleg`{.AgdaDatatype} that receives its voting stake.  The `GState`{.AgdaRecord}
+contains a field `dreps`{.AgdaField} whose domain is the set of registered
+`DReps`{.AgdaFunction}.
 
-`VDeleg`{.AgdaDatatype} is a datatype with three constructors; the one of interest to
-us here is `vDelegCredential`{.AgdaInductiveConstructor}, which takes a `Credential`{.AgdaDatatype}.
+`VDeleg`{.AgdaDatatype} has three constructors:
+`vDelegCredential`{.AgdaInductiveConstructor}, which takes the
+`Credential`{.AgdaDatatype} of a `DRep`, and the two constants
+`vDelegAbstain`{.AgdaInductiveConstructor} and
+`vDelegNoConfidence`{.AgdaInductiveConstructor}.
 
-Now suppose we have a collection `C`{.AgdaBound} of credentials—for instance, given
-`d`{.AgdaBound} : `DState`{.AgdaDatatype}, take `C`{.AgdaBound} to be the domain of
-the `voteDelegs`{.AgdaField} field of `d`{.AgdaBound}. We could then obtain a set of
-`VDelegs`{.AgdaDatatype} by applying `vDelegCredential`{.AgdaInductiveConstructor} to
-each element of `C`{.AgdaBound}.
-
-The present property asserts that the set of `VDelegs`{.AgdaDatatype} that results
-from the application of `vDelegCredential`{.AgdaInductiveConstructor} to the
-domain of the `voteDelegs`{.AgdaField} of `d`{.AgdaBound} contains the range
-of the `voteDelegs`{.AgdaField} of `d`{.AgdaBound}.
+Call a `VDeleg`{.AgdaDatatype} *active* in a state if it is one of those two constants or
+if it wraps the `Credential`{.AgdaDatatype} of a `DRep` registered in that state.  The
+present property asserts that a `CERTS`{.AgdaDatatype} step leaves no other kind of
+`VDeleg`{.AgdaDatatype} behind: every value of the `voteDelegs`{.AgdaField} map of the
+resulting state is active in that state.  Nothing is assumed about the initial state,
+because the `POST-CERT`{.AgdaDatatype} rule concluding every `CERTS`{.AgdaDatatype} step
+corestricts `voteDelegs`{.AgdaField} to exactly the set of active
+`VDelegs`{.AgdaDatatype}.
 
 *Formally*.
 
 ```agda
-voteDelegsVDeleg :  DState → Type
-voteDelegsVDeleg d = range (VoteDelegsOf d) ⊆ mapˢ vDelegCredential (dom (VoteDelegsOf d))
+activeVDelegs : CertState → ℙ VDeleg
+activeVDelegs s = mapˢ vDelegCredential (dom (DRepsOf s))
+                   ∪ fromList (vDelegNoConfidence ∷ vDelegAbstain ∷ [])
+
+voteDelegsVDeleg : CertState → Type
+voteDelegsVDeleg s = range (VoteDelegsOf s) ⊆ activeVDelegs s
+
+CERTS-voteDelegsVDeleg : Γ ⊢ s ⇀⦇ certs ,CERTS⦈ s' → voteDelegsVDeleg s'
 ```
 
-*Proof*. (coming soon)
+*Proof*.
+
+A `CERTS`{.AgdaDatatype} step consists of a `PRE-CERT`{.AgdaDatatype} step followed by a
+trace of `CERT`{.AgdaDatatype} steps that ends with a `POST-CERT`{.AgdaDatatype} step, so
+it suffices to establish the property at the end of such a trace.  We do so in two
+lemmas.
+
+**Lemma (`POST-CERT`{.AgdaDatatype} establishes the property).** The single constructor
+`CERT-post`{.AgdaInductiveConstructor} reveals the `voteDelegs`{.AgdaField} of its
+resulting state to be a corestriction `vd`{.AgdaBound} `∣^`{.AgdaOperator}
+`X`{.AgdaBound} of the incoming map `vd`{.AgdaBound}, and the range of a corestricted map
+is contained in the corestricting set (`cores-range-⊆`{.AgdaFunction}).  The set
+`X`{.AgdaBound} is read off the `GState`{.AgdaRecord}, which the rule leaves untouched, so
+`X`{.AgdaBound} is `activeVDelegs`{.AgdaFunction} of the resulting state.
+
+```agda
+POST-CERT-voteDelegsVDeleg : Γ ⊢ s ⇀⦇ _ ,POST-CERT⦈ s' → voteDelegsVDeleg s'
+POST-CERT-voteDelegsVDeleg (CERT-post {voteDelegs = vd}) = cores-range-⊆ vd
+```
+
+**Lemma (the property holds at the end of a `CERT`{.AgdaDatatype} trace).** Induct on the
+trace.  The intermediate `CERT`{.AgdaDatatype} steps are irrelevant: only the final state
+is constrained, and it is produced by the `POST-CERT`{.AgdaDatatype} step in the
+`run-[]`{.AgdaInductiveConstructor} case.
+
+```agda
+CERT-trace-voteDelegsVDeleg :
+  RunTraceAndThen _⊢_⇀⦇_,CERT⦈_ _⊢_⇀⦇_,POST-CERT⦈_ Γ s certs s' → voteDelegsVDeleg s'
+CERT-trace-voteDelegsVDeleg (run-[] post)    = POST-CERT-voteDelegsVDeleg post
+CERT-trace-voteDelegsVDeleg (run-∷ _ trace)  = CERT-trace-voteDelegsVDeleg trace
+```
+
+The theorem follows by inverting the `CERTS`{.AgdaDatatype} step and discarding its
+`PRE-CERT`{.AgdaDatatype} component.
+
+```agda
+CERTS-voteDelegsVDeleg (run (_ , trace)) = CERT-trace-voteDelegsVDeleg trace
+```

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -159,15 +159,16 @@ proposals in `tx`{.AgdaBound}.
    `activeDReps`{.AgdaField} of `es` in the next epoch.
 
 
-+  **Claim** [Certs-VoteDelegsVDeleg][].
++  **Theorem** [Certs-VoteDelegsVDeleg][]. Vote delegations point at registered
+   `DReps`{.AgdaFunction}.
 
-   Suppose we have a collection `C`{.AgdaBound} of credentials—for instance, given
-   `d`{.AgdaBound} : `DState`{.AgdaDatatype}, take `C`{.AgdaBound} to be the domain
-   of the `voteDelegs`{.AgdaField} field of `d`{.AgdaBound}.  Then the set of
-   `VDelegs`{.AgdaDatatype} that results from applying
-   `vDelegCredential`{.AgdaInductiveConstructor} to the domain of the
-   `voteDelegs`{.AgdaField} of `d`{.AgdaBound} contains the range of the
-   `voteDelegs`{.AgdaField} of `d`{.AgdaBound}.
+   Let `s`{.AgdaBound}, `s'`{.AgdaBound} be `CertStates`{.AgdaRecord} and
+   `certs`{.AgdaBound} a list of `DCerts`{.AgdaDatatype} such that `s`{.AgdaBound}
+   `⇀⦇`{.AgdaDatatype} `certs`{.AgdaBound} `,CERTS⦈`{.AgdaDatatype} `s'`{.AgdaBound}.
+   Then every value of the `voteDelegs`{.AgdaField} map of `s'`{.AgdaBound} either wraps
+   the `Credential`{.AgdaDatatype} of a `DRep` registered in `s'`{.AgdaBound}, or is
+   `vDelegAbstain`{.AgdaInductiveConstructor}, or is
+   `vDelegNoConfidence`{.AgdaInductiveConstructor}.
 
 ---
 


### PR DESCRIPTION
Every value of `voteDelegs` is a `VDeleg` of a registered `DRep`, `vDelegAbstain`, or `vDelegNoConfidence`, and `CERTS` preserves that.

```agda
CERTS-voteDelegsVDeleg : LedgerInvariant _⊢_⇀⦇_,CERTS⦈_ voteDelegsVDeleg
```

**The original statement was corrected**. It said

```agda
range (VoteDelegsOf d) ⊆ mapˢ vDelegCredential (dom (VoteDelegsOf d))
```

which is well typed (`mapˢ vDelegCredential` lifts the domain into `ℙ VDeleg`) but false, for two independent reasons: `vDelegAbstain` and `vDelegNoConfidence` are legal `voteDelegs` values and neither is `vDelegCredential c` for any `c`; and the range wraps *DRep* credentials, while `regdrep` never adds a key to `voteDelegs`, so a delegatee need not lie in `dom voteDelegs`.

**It is now an invariant rather than a postcondition**, because master removed `POST-CERT` in the meantime. That rule used to corestrict `voteDelegs` to the active `VDeleg`s at the end of every batch, which made the containment unconditional on the output of `CERTS`. With the final sweep gone, an input state may already violate it and no `CERTS` step would repair it, so the property is stated and proved as preservation instead.

The containment is now maintained incrementally by the two rules that could break it: `DELEG-delegate` may install only a `VDeleg` that is already active for the current delegatees, and `GOVCERT-deregdrep`, the one rule that shrinks the registered `DReps`, deletes every delegation to the credential it deregisters in the same step. The proof establishes invariance for `DELEG`, `GOVCERT`, `CERT` and `PRE-CERT`, then lifts the `CERT` lemma along `RTC-preserves-inv`.

Four small lemmas go to `Axiom.Set.Map.Extra`: `coex-∈⁻`, and `dom-∪ˡ-⊇ʳ` with its corollaries `dom-insert-⊇` and `dom-mapValueRestricted-⊇`.

Closes #1233
