### PR TITLE
[Conway] Property: rewards domain is unchanged by NEWEPOCH (#1229)

### DIFF
--- a/build-tools/static/mkdocs/includes/links.md
+++ b/build-tools/static/mkdocs/includes/links.md
@@ -68,7 +68,7 @@
 [Ledger-LastVoteApplied]: Ledger.Conway.Specification.Ledger.Properties.LastVoteApplied.md
 [LEDGER-PoV]: Ledger.Conway.Specification.Ledger.Properties.PoV.md#thm:LEDGER-PoV
 [NEWEPOCH]: Ledger.Conway.Specification.Epoch.md#sec:the-newepoch-transition-system
-[NEWEPOCH-ConstRwds]: Ledger.Conway.Specification.Epoch.Properties.ConstRwds.md#clm:NEWEPOCH-const-rwds
+[NEWEPOCH-ConstRwds]: Ledger.Conway.Specification.Epoch.Properties.ConstRwds.md#thm:NEWEPOCH-const-rwds
 [Notation]: Notation.md
 [Ouroboros Chronos blog post]: https://iohk.io/en/blog/posts/2021/10/27/ouroboros-chronos-provides-the-first-high-resilience-cryptographic-time-source-based-on-blockchain/
 [POOL]: Ledger.Conway.Specification.Certs.md#auxiliary-pool-transition-system

--- a/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
+++ b/src-lib-exts/abstract-set-theory/Axiom/Set/Map/Extra.agda
@@ -751,3 +751,27 @@ lookupᵐ?-insert-≢ m {k₀} {k} {v₀} ne ⦃ ⁇ no k∉ins ⦄ ⦃ ⁇ yes 
       ky∈ins = ∈-insert-≢ {m = m} {v₀ = v₀} ne ky∈m
   in ⊥-elim (k∉ins (Equivalence.to dom∈ (y , ky∈ins)))
 lookupᵐ?-insert-≢ m {k₀} {k} {v₀} ne ⦃ ⁇ no k∉ins ⦄ ⦃ ⁇ no k∉m ⦄ = refl
+
+
+-- Map lemmas: domains of additive unions and pullback maps
+
+-- If `dom n ⊆ dom m`, then the additive union `m ∪⁺ n` has the same domain as `m`
+-- (the map analogue of `⊆→∪` in `Axiom.Set.Properties`).
+module _ {A B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : CommutativeMonoid _ _ B ⦄ where
+
+  dom⊆→dom∪⁺ : {m n : A ⇀ B} → dom n ⊆ dom m → dom (m ∪⁺ n) ≡ᵉ dom m
+  dom⊆→dom∪⁺ {m} {n} domn⊆domm =
+    (λ a∈ → case from ∈-∪ (dom∪⁺⊆∪dom a∈) of λ where
+      (inj₁ a∈m) → a∈m
+      (inj₂ a∈n) → domn⊆domm a∈n)
+    , λ a∈m → ∪dom⊆dom∪⁺ (to ∈-∪ (inj₁ a∈m))
+
+-- The domain of a pullback map is contained in the set being pulled back
+-- (`pullbackMap m f X` only assigns values to keys drawn from `X`).
+dom-pullbackMap-⊆ : {A A' B : Type} ⦃ _ : DecEq A ⦄
+  → (m : A ⇀ B) ⦃ dec : {x : A} → (x ∈ dom (m ˢ)) ⁇ ⦄ (f : A' → A) (X : ℙ A')
+  → dom (pullbackMap m ⦃ dec ⦄ f X) ⊆ X
+dom-pullbackMap-⊆ m ⦃ dec ⦄ f X a∈dom with from dom∈ a∈dom
+... | _ , ab∈ with ∈-mapMaybeWithKey {f = λ a _ → lookupᵐ? m (f a) ⦃ dec ⦄} ab∈
+... | _ , _ , aa∈id with from (∈-map {f = λ y → y , y}) aa∈id
+... | x , eq , x∈X = subst (_∈ X) (sym (proj₁ (×-≡,≡←≡ eq))) x∈X

--- a/src/Ledger/Conway/Specification/Epoch.lagda.md
+++ b/src/Ledger/Conway/Specification/Epoch.lagda.md
@@ -102,6 +102,9 @@ instance
   HasDReps-EpochState : HasDReps EpochState
   HasDReps-EpochState .DRepsOf = DRepsOf ∘ CertStateOf ∘ LStateOf
 
+  HasRewards-EpochState : HasRewards EpochState
+  HasRewards-EpochState .RewardsOf = RewardsOf ∘ CertStateOf ∘ LStateOf
+
   HasTreasury-EpochState : HasTreasury EpochState
   HasTreasury-EpochState .TreasuryOf = Acnt.treasury ∘ EpochState.acnt
 

--- a/src/Ledger/Conway/Specification/Epoch/Properties/ConstRwds.lagda.md
+++ b/src/Ledger/Conway/Specification/Epoch/Properties/ConstRwds.lagda.md
@@ -3,7 +3,7 @@ source_branch: master
 source_path: src/Ledger/Conway/Specification/Epoch/Properties/ConstRwds.lagda.md
 ---
 
-## Claim: The <span class="AgdaDatatype">NEWEPOCH</span> rule leaves rewards unchanged {#clm:NEWEPOCH-const-rwds}
+## Claim: The <span class="AgdaDatatype">NEWEPOCH</span> rule preserves the rewards domain {#clm:NEWEPOCH-const-rwds}
 
 
 <!--
@@ -21,24 +21,106 @@ module Ledger.Conway.Specification.Epoch.Properties.ConstRwds
 
 open import Ledger.Conway.Specification.Certs govStructure
 open import Ledger.Conway.Specification.Epoch txs abs
+open import Ledger.Conway.Specification.PoolReap txs abs
+open import Ledger.Conway.Specification.Rewards txs abs
 open import Ledger.Prelude
+
+open import Axiom.Set.Properties th using (≡ᵉ-isEquivalence)
+open import Relation.Binary using (IsEquivalence)
+
+module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential})
 ```
 -->
 
 *Informally*.
 
-Rewards are left unchanged by the `NEWEPOCH`{.AgdaOperator} rule.  That is, if
-`es`{.AgdaBound} and `es'`{.AgdaBound} are two `NewEpochStates`{.AgdaRecord} such that
+The `NEWEPOCH`{.AgdaDatatype} rule pays out rewards and refunds, but it never
+registers or deregisters a reward account.  That is, if `es`{.AgdaBound} and
+`es'`{.AgdaBound} are two `NewEpochStates`{.AgdaRecord} such that
 `es`{.AgdaBound} `⇀⦇`{.AgdaDatatype} `e`{.AgdaBound} `,NEWEPOCH⦈`{.AgdaDatatype} `es'`{.AgdaBound},
-then the rewards of `es`{.AgdaBound} and `es'`{.AgdaBound} are equal.
+then the rewards maps of `es`{.AgdaBound} and `es'`{.AgdaBound} have the same
+domain.  Only the domain is invariant (the reward values themselves change), and
+domains are abstract sets, so the claim is stated with the set equality
+`_≡ᵉ_`{.AgdaFunction} rather than propositional equality.
+
+A `NEWEPOCH`{.AgdaDatatype} step modifies the rewards map in three places, and
+each modification is an additive union `_∪⁺_`{.AgdaOperator} with a map whose
+domain is contained in the domain of the rewards map:
+
++ `applyRUpd`{.AgdaFunction} adds `regRU`{.AgdaFunction}, the reward update
+  restricted to the existing accounts (`rs ∣ dom rewards`);
+
++ the `POOLREAP`{.AgdaDatatype} rule adds `refunds`{.AgdaFunction}, the deposit
+  refunds of retired pools restricted to `dom (dState .rewards)`;
+
++ the `EPOCH`{.AgdaDatatype} rule adds `refunds`{.AgdaFunction} of
+  `Post-POOLREAPUpdate`{.AgdaModule}, a `pullbackMap`{.AgdaFunction} over
+  `dom (RewardsOf dState')`, so its domain is again contained in the rewards
+  domain.
+
+Since `dom (m ∪⁺ n) ≡ᵉ dom m` whenever `dom n ⊆ dom m` (lemma
+`dom⊆→dom∪⁺`{.AgdaFunction}), each of the three modifications preserves the
+domain.
 
 *Formally*.
 
-```agda
-dom-rwds-const : {e : Epoch} (es es' : NewEpochState)
-  → _ ⊢ es ⇀⦇ e ,NEWEPOCH⦈ es' → Type
+We record one lemma per modification site.  First, `applyRUpd`{.AgdaFunction}
+preserves the rewards domain:
 
-dom-rwds-const es es' step = dom (RewardsOf es) ≡ dom (RewardsOf es')
+```agda
+applyRUpd-dom-rwds-const : (ru : RewardUpdate) (eps : EpochState)
+  → dom (RewardsOf eps) ≡ᵉ dom (RewardsOf (applyRUpd ru eps))
+applyRUpd-dom-rwds-const ru eps = ≡ᵉ.sym (dom⊆→dom∪⁺ res-dom)
 ```
 
-*Proof*. (coming soon)
+Second, the `POOLREAP`{.AgdaDatatype} rule preserves the rewards domain:
+
+```agda
+POOLREAP-dom-rwds-const : {e : Epoch} {prSt prSt' : PoolReapState}
+  → _ ⊢ prSt ⇀⦇ e ,POOLREAP⦈ prSt'
+  → dom (RewardsOf (PoolReapState.dState prSt)) ≡ᵉ dom (RewardsOf (PoolReapState.dState prSt'))
+POOLREAP-dom-rwds-const POOLREAP = ≡ᵉ.sym (dom⊆→dom∪⁺ res-dom)
+```
+
+Third, the `EPOCH`{.AgdaDatatype} rule preserves the rewards domain: the
+`SNAP`{.AgdaDatatype} and `RATIFIES`{.AgdaDatatype} premises do not touch the
+rewards map, so the claim follows by composing the `POOLREAP`{.AgdaDatatype}
+lemma with the domain restriction of the `refunds`{.AgdaFunction} paid out by
+`Post-POOLREAPUpdate`{.AgdaModule}.  The definition of `refunds`{.AgdaFunction}
+is opaque, so we unfold it:
+
+```agda
+opaque
+  unfolding Post-POOLREAPUpdate.refunds
+
+  EPOCH-dom-rwds-const : {e : Epoch} {eps eps' : EpochState}
+    → _ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
+    → dom (RewardsOf eps) ≡ᵉ dom (RewardsOf eps')
+  EPOCH-dom-rwds-const (EPOCH (_ , poolReapStep , _)) =
+    ≡ᵉ.trans  (POOLREAP-dom-rwds-const poolReapStep)
+              (≡ᵉ.sym (dom⊆→dom∪⁺ (dom-pullbackMap-⊆ _ toRewardAddress _)))
+```
+
+The main claim then follows by composing these lemmas:
+
+```agda
+dom-rwds-const : {e : Epoch} {es es' : NewEpochState}
+  → _ ⊢ es ⇀⦇ e ,NEWEPOCH⦈ es'
+  → dom (RewardsOf es) ≡ᵉ dom (RewardsOf es')
+```
+
+*Proof*.
+
+We proceed by cases on the `NEWEPOCH`{.AgdaDatatype} rule:
+`NEWEPOCH-Not-New`{.AgdaInductiveConstructor} leaves the state unchanged, so the
+claim holds by reflexivity; `NEWEPOCH-No-Reward-Update`{.AgdaInductiveConstructor}
+is an `EPOCH`{.AgdaDatatype} step; and `NEWEPOCH-New`{.AgdaInductiveConstructor}
+is `applyRUpd`{.AgdaFunction} followed by an `EPOCH`{.AgdaDatatype} step.
+
+```agda
+dom-rwds-const (NEWEPOCH-New {ru = ru} {eps = eps} (_ , epochStep)) =
+  ≡ᵉ.trans (applyRUpd-dom-rwds-const ru eps) (EPOCH-dom-rwds-const epochStep)
+dom-rwds-const (NEWEPOCH-Not-New _) = ≡ᵉ.refl
+dom-rwds-const (NEWEPOCH-No-Reward-Update (_ , epochStep)) =
+  EPOCH-dom-rwds-const epochStep
+```

--- a/src/Ledger/Conway/Specification/Epoch/Properties/ConstRwds.lagda.md
+++ b/src/Ledger/Conway/Specification/Epoch/Properties/ConstRwds.lagda.md
@@ -3,7 +3,7 @@ source_branch: master
 source_path: src/Ledger/Conway/Specification/Epoch/Properties/ConstRwds.lagda.md
 ---
 
-## Claim: The <span class="AgdaDatatype">NEWEPOCH</span> rule preserves the rewards domain {#clm:NEWEPOCH-const-rwds}
+## Theorem: <span class="AgdaDatatype">NEWEPOCH</span> preserves rewards domain {#thm:NEWEPOCH-const-rwds}
 
 
 <!--
@@ -35,11 +35,14 @@ module ≡ᵉ = IsEquivalence (≡ᵉ-isEquivalence {Credential})
 *Informally*.
 
 The `NEWEPOCH`{.AgdaDatatype} rule pays out rewards and refunds, but it never
-registers or deregisters a reward account.  That is, if `es`{.AgdaBound} and
-`es'`{.AgdaBound} are two `NewEpochStates`{.AgdaRecord} such that
-`es`{.AgdaBound} `⇀⦇`{.AgdaDatatype} `e`{.AgdaBound} `,NEWEPOCH⦈`{.AgdaDatatype} `es'`{.AgdaBound},
-then the rewards maps of `es`{.AgdaBound} and `es'`{.AgdaBound} have the same
-domain.  Only the domain is invariant (the reward values themselves change), and
+registers or deregisters a reward account.
+
+More precisely, if `es`{.AgdaBound} and `es'`{.AgdaBound} are two
+`NewEpochStates`{.AgdaRecord} such that
+`es ``⇀⦇`{.AgdaDatatype}` e ``,NEWEPOCH⦈`{.AgdaDatatype}` es'`,
+then the rewards maps of `es` and `es'` have the same domain.
+
+Only the domain is invariant (the reward values themselves change), and
 domains are abstract sets, so the claim is stated with the set equality
 `_≡ᵉ_`{.AgdaFunction} rather than propositional equality.
 
@@ -47,25 +50,25 @@ A `NEWEPOCH`{.AgdaDatatype} step modifies the rewards map in three places, and
 each modification is an additive union `_∪⁺_`{.AgdaOperator} with a map whose
 domain is contained in the domain of the rewards map:
 
-+ `applyRUpd`{.AgdaFunction} adds `regRU`{.AgdaFunction}, the reward update
-  restricted to the existing accounts (`rs ∣ dom rewards`);
++  `applyRUpd`{.AgdaFunction} adds `regRU`{.AgdaFunction}, the reward update
+   restricted to the existing accounts (`rs ∣ dom rewards`);
 
-+ the `POOLREAP`{.AgdaDatatype} rule adds `refunds`{.AgdaFunction}, the deposit
-  refunds of retired pools restricted to `dom (dState .rewards)`;
++  the `POOLREAP`{.AgdaDatatype} rule adds the deposit `refunds`{.AgdaFunction} of
+   retired pools restricted to `dom (dState .rewards)`;
 
-+ the `EPOCH`{.AgdaDatatype} rule adds `refunds`{.AgdaFunction} of
-  `Post-POOLREAPUpdate`{.AgdaModule}, a `pullbackMap`{.AgdaFunction} over
-  `dom (RewardsOf dState')`, so its domain is again contained in the rewards
-  domain.
++  the `EPOCH`{.AgdaDatatype} rule adds `refunds`{.AgdaFunction} of
+   `Post-POOLREAPUpdate`{.AgdaModule} — a `pullbackMap`{.AgdaFunction} over
+   `dom (RewardsOf dState')` — so its domain is again contained in the rewards
+   domain.
 
-Since `dom (m ∪⁺ n) ≡ᵉ dom m` whenever `dom n ⊆ dom m` (lemma
-`dom⊆→dom∪⁺`{.AgdaFunction}), each of the three modifications preserves the
-domain.
+Since `dom (m ∪⁺ n) ≡ᵉ dom m` whenever `dom n ⊆ dom m`,[^1] each of the three
+modifications preserves the domain.
 
 *Formally*.
 
-We record one lemma per modification site.  First, `applyRUpd`{.AgdaFunction}
-preserves the rewards domain:
+We prove one lemma per modification site.
+
+First, `applyRUpd`{.AgdaFunction} preserves the rewards domain:
 
 ```agda
 applyRUpd-dom-rwds-const : (ru : RewardUpdate) (eps : EpochState)
@@ -78,7 +81,7 @@ Second, the `POOLREAP`{.AgdaDatatype} rule preserves the rewards domain:
 ```agda
 POOLREAP-dom-rwds-const : {e : Epoch} {prSt prSt' : PoolReapState}
   → _ ⊢ prSt ⇀⦇ e ,POOLREAP⦈ prSt'
-  → dom (RewardsOf (PoolReapState.dState prSt)) ≡ᵉ dom (RewardsOf (PoolReapState.dState prSt'))
+  → dom (RewardsOf prSt) ≡ᵉ dom (RewardsOf prSt')
 POOLREAP-dom-rwds-const POOLREAP = ≡ᵉ.sym (dom⊆→dom∪⁺ res-dom)
 ```
 
@@ -86,8 +89,7 @@ Third, the `EPOCH`{.AgdaDatatype} rule preserves the rewards domain: the
 `SNAP`{.AgdaDatatype} and `RATIFIES`{.AgdaDatatype} premises do not touch the
 rewards map, so the claim follows by composing the `POOLREAP`{.AgdaDatatype}
 lemma with the domain restriction of the `refunds`{.AgdaFunction} paid out by
-`Post-POOLREAPUpdate`{.AgdaModule}.  The definition of `refunds`{.AgdaFunction}
-is opaque, so we unfold it:
+`Post-POOLREAPUpdate`{.AgdaModule}.
 
 ```agda
 opaque
@@ -101,26 +103,33 @@ opaque
               (≡ᵉ.sym (dom⊆→dom∪⁺ (dom-pullbackMap-⊆ _ toRewardAddress _)))
 ```
 
-The main claim then follows by composing these lemmas:
+The main claim then follows by composing the above lemmas.
 
 ```agda
-dom-rwds-const : {e : Epoch} {es es' : NewEpochState}
+NEWEPOCH-dom-rwds-const : {e : Epoch} {es es' : NewEpochState}
   → _ ⊢ es ⇀⦇ e ,NEWEPOCH⦈ es'
   → dom (RewardsOf es) ≡ᵉ dom (RewardsOf es')
 ```
 
 *Proof*.
 
-We proceed by cases on the `NEWEPOCH`{.AgdaDatatype} rule:
-`NEWEPOCH-Not-New`{.AgdaInductiveConstructor} leaves the state unchanged, so the
-claim holds by reflexivity; `NEWEPOCH-No-Reward-Update`{.AgdaInductiveConstructor}
-is an `EPOCH`{.AgdaDatatype} step; and `NEWEPOCH-New`{.AgdaInductiveConstructor}
-is `applyRUpd`{.AgdaFunction} followed by an `EPOCH`{.AgdaDatatype} step.
+We proceed by cases on the `NEWEPOCH`{.AgdaDatatype} rule.
+
++  `NEWEPOCH-Not-New`{.AgdaInductiveConstructor} leaves the state unchanged, so the
+   claim holds by reflexivity;
++  `NEWEPOCH-No-Reward-Update`{.AgdaInductiveConstructor} is an
+   `EPOCH`{.AgdaDatatype} step;
++  `NEWEPOCH-New`{.AgdaInductiveConstructor} is `applyRUpd`{.AgdaFunction} followed
+   by an `EPOCH`{.AgdaDatatype} step.
 
 ```agda
-dom-rwds-const (NEWEPOCH-New {ru = ru} {eps = eps} (_ , epochStep)) =
-  ≡ᵉ.trans (applyRUpd-dom-rwds-const ru eps) (EPOCH-dom-rwds-const epochStep)
-dom-rwds-const (NEWEPOCH-Not-New _) = ≡ᵉ.refl
-dom-rwds-const (NEWEPOCH-No-Reward-Update (_ , epochStep)) =
+NEWEPOCH-dom-rwds-const (NEWEPOCH-Not-New _) = ≡ᵉ.refl
+NEWEPOCH-dom-rwds-const (NEWEPOCH-No-Reward-Update (_ , epochStep)) =
   EPOCH-dom-rwds-const epochStep
+NEWEPOCH-dom-rwds-const (NEWEPOCH-New {ru = ru} {eps = eps} (_ , epochStep)) =
+  ≡ᵉ.trans (applyRUpd-dom-rwds-const ru eps) (EPOCH-dom-rwds-const epochStep)
 ```
+
+---
+
+[^1]:  lemma `dom⊆→dom∪⁺`{.AgdaFunction}

--- a/src/Ledger/Conway/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Conway/Specification/PoolReap.lagda.md
@@ -45,6 +45,13 @@ instance
   unquoteDecl HasCast-PoolReapState = derive-HasCast
                 [ (quote PoolReapState , HasCast-PoolReapState) ]
 
+  HasDState-PoolReapState : HasDState PoolReapState
+  HasDState-PoolReapState .DStateOf = PoolReapState.dState
+
+  HasRewards-PoolReapState : HasRewards PoolReapState
+  HasRewards-PoolReapState .RewardsOf = RewardsOf ∘ DStateOf
+
+
 private variable
   e lastEpoch : Epoch
   poolReapState : PoolReapState

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -142,7 +142,7 @@ proposals in `tx`{.AgdaBound}.
    has been produced in epoch `e`{.AgdaBound} or later), that deposit is no longer in the
    deposit pot.
 
-+  **Claim** [NEWEPOCH-ConstRwds][].  The rewards domain is left unchanged by the `NEWEPOCH`{.AgdaOperator} rule.
++  **Theorem** [NEWEPOCH-ConstRwds][].  The rewards domain is left unchanged by the `NEWEPOCH`{.AgdaOperator} rule.
 
    That is, if `es`{.AgdaBound} and `es'`{.AgdaBound} are two
    `NewEpochStates`{.AgdaRecord} such that `es`{.AgdaBound} `⇀⦇`{.AgdaDatatype}

--- a/src/Ledger/Conway/Specification/Properties.lagda.md
+++ b/src/Ledger/Conway/Specification/Properties.lagda.md
@@ -142,12 +142,12 @@ proposals in `tx`{.AgdaBound}.
    has been produced in epoch `e`{.AgdaBound} or later), that deposit is no longer in the
    deposit pot.
 
-+  **Claim** [NEWEPOCH-ConstRwds][].  Rewards are left unchanged by the `NEWEPOCH`{.AgdaOperator} rule.
++  **Claim** [NEWEPOCH-ConstRwds][].  The rewards domain is left unchanged by the `NEWEPOCH`{.AgdaOperator} rule.
 
    That is, if `es`{.AgdaBound} and `es'`{.AgdaBound} are two
    `NewEpochStates`{.AgdaRecord} such that `es`{.AgdaBound} `⇀⦇`{.AgdaDatatype}
-   `e`{.AgdaBound} `,NEWEPOCH⦈`{.AgdaDatatype} `es'`{.AgdaBound}, then the rewards of
-   `es`{.AgdaBound} and `es'`{.AgdaBound} are equal.
+   `e`{.AgdaBound} `,NEWEPOCH⦈`{.AgdaDatatype} `es'`{.AgdaBound}, then the rewards
+   maps of `es`{.AgdaBound} and `es'`{.AgdaBound} have the same domain.
 
 +  **Claim** [Epoch-NoPropSameDReps][]. The set of active `DReps`{.AgdaFunction} remains unchanged if
    there are no governance proposals.


### PR DESCRIPTION
Proves the claim in `Epoch.Properties.ConstRwds`: if `es ⇀⦇ e ,NEWEPOCH⦈ es'`, then the rewards maps of `es` and `es'` have the same domain.

The statement previously used propositional equality `≡`; it is restated with the set equality `≡ᵉ` because the domains are abstract sets.

Closes #1229
