### PR TITLE
Run full CI on leios-main and document the Leios branch workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
     branches:
     - master
     - legacy-latex  # ensure legacy-latex-artifacts branch gets created
+    - leios-main    # Leios integration branch; keeps leios-main-artifacts fresh
   pull_request:
     branches:
     - master
+    - leios-main
   # For running the workflow manually - useful for branches without PRs, for
   # which CI isn't run automatically
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -438,19 +438,44 @@ browser.
 
 Our CI/CD pipeline, defined in `.github/workflows/`, automates the building and publishing of artifacts. Here are some key details:
 
++ **Branches Covered by CI**
+
+   The full pipeline runs on every push to `master` or `leios-main`, and on every
+   pull request targeting one of those branches. For other branches without an open
+   PR, the workflow can be triggered manually from the Actions tab
+   (`workflow_dispatch`).
+
 + **Caching**
 
    The initial `formal-ledger-agda` job type-checks the code and uploads the resulting `_build` directory as a GitHub artifact. Subsequent jobs download this artifact to avoid re-compiling Agda code.
 
 + **Artifact Branches**
 
-   For every push to `master` or a pull request branch, the CI creates a corresponding `<branch-name>-artifacts` branch. This branch stores the generated artifacts (PDFs, HTML, Haskell code).
+   For every push to `master` or `leios-main`, and for every pull request branch, the CI creates a corresponding `<branch-name>-artifacts` branch. This branch stores the generated artifacts (PDFs, HTML, Haskell code).
 
 + **PDF Generation Note**
 
    The CI workflow **does not** build PDFs from the current source. Instead, it
    checks out the `legacy-latex-artifacts` branch and copies the PDFs from
    there.
+
+### Leios development workflow
+
+Formalization of the ledger changes required by Ouroboros Leios is staged on the
+long-lived `leios-main` integration branch, which evolves in parallel with (but
+separate from) the era work on `master`:
+
++  To work on Leios, branch off of `leios-main` and open a pull request targeting
+   `leios-main`. Such PRs run the same full CI as PRs targeting `master`, and each
+   merge to `leios-main` refreshes the browsable `leios-main-artifacts` branch.
+
++  To limit drift, `master` is merged into `leios-main` regularly (merged, not
+   rebased, since the branch is shared).
+
++  Changes to shared infrastructure (e.g. `Ledger.Core`, `Ledger.Prelude`, the STS
+   machinery) that the Leios work requires should land on `master` first and then
+   be synced down to `leios-main`, so that the diff between the two branches stays
+   mostly additive.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -440,8 +440,8 @@ Our CI/CD pipeline, defined in `.github/workflows/`, automates the building and 
 
 + **Branches Covered by CI**
 
-   The full pipeline runs on every push to `master` or `leios-main`, and on every
-   pull request targeting one of those branches. For other branches without an open
+   The full pipeline runs on every push to `master`, `leios-main`, or `legacy-latex`, and on every
+   pull request targeting `master` or `leios-main`. For other branches without an open
    PR, the workflow can be triggered manually from the Actions tab
    (`workflow_dispatch`).
 
@@ -463,10 +463,10 @@ Our CI/CD pipeline, defined in `.github/workflows/`, automates the building and 
 
 Formalization of the ledger changes required by Ouroboros Leios is staged on the `leios-main` branch, which evolves in parallel to `master`:
 
-+  To work on Leios, branch off of `leios-main` and open a pull request targeting
++ To work on Leios, branch off of `leios-main` and open a pull request targeting
    `leios-main`. Such PRs run the same CI as PRs targeting `master`.
-   
-+  Changes required but independent of Leios (e.g. `Ledger.Core`, `Ledger.Prelude`, the STS
+
++ Changes required but independent of Leios (e.g. `Ledger.Core`, `Ledger.Prelude`, the STS
    machinery) should be made first on a PR to `master` and then merged into `leios-main`.
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -461,22 +461,13 @@ Our CI/CD pipeline, defined in `.github/workflows/`, automates the building and 
 
 ### Leios development workflow
 
-Formalization of the ledger changes required by Ouroboros Leios is staged on the
-long-lived `leios-main` integration branch, which evolves in parallel with (but
-separate from) the era work on `master`:
+Formalization of the ledger changes required by Ouroboros Leios is staged on the `leios-main` branch, which evolves in parallel to `master`:
 
 +  To work on Leios, branch off of `leios-main` and open a pull request targeting
-   `leios-main`. Such PRs run the same full CI as PRs targeting `master`, and each
-   merge to `leios-main` refreshes the browsable `leios-main-artifacts` branch.
-
-+  To limit drift, `master` is merged into `leios-main` regularly (merged, not
-   rebased, since the branch is shared).
-
-+  Changes to shared infrastructure (e.g. `Ledger.Core`, `Ledger.Prelude`, the STS
-   machinery) that the Leios work requires should land on `master` first and then
-   be synced down to `leios-main`, so that the diff between the two branches stays
-   mostly additive.
-
+   `leios-main`. Such PRs run the same CI as PRs targeting `master`.
+   
++  Changes required but independent of Leios (e.g. `Ledger.Core`, `Ledger.Prelude`, the STS
+   machinery) should be made first on a PR to `master` and then merged into `leios-main`.
 ---
 
 <a id="setup-without-nix"></a>


### PR DESCRIPTION
# Description

Prepares the repository for the upcoming Leios formalization work, which will be staged on a long-lived `leios-main` integration branch developed in parallel with the era work on `master`.

Two changes:

- **`.github/workflows/ci.yml`**: add `leios-main` to the `push` and `pull_request` branch filters. The `pull_request` filter matches the PR's *base* branch, so this makes every PR targeting `leios-main` run the same full pipeline as PRs to `master` (Agda typecheck, `hs` and `mkdocs` artifacts, `<branch>-artifacts` publication). The `push` entry additionally publishes a browsable `leios-main-artifacts` branch on every merge to `leios-main`.
- **`CONTRIBUTING.md`**: document which branches CI covers and describe the Leios branch conventions (feature PRs target `leios-main`; `master` is merged down regularly to limit drift; shared-infrastructure changes land on `master` first so the diff between the branches stays mostly additive).

No changes to the specifications themselves. `pr_closed.yml` already covers artifact-branch cleanup for PRs to any base, so it needs no change.

Rollout notes for after this merges:

1. Cut `leios-main` from `master` (so it carries the updated workflow from birth).
2. An admin should mirror `master`'s required status checks onto `leios-main` in Settings → Branches/Rulesets — CI *running* on PRs and CI being *required* are configured in different places, and this PR can only provide the former.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md` (not applicable — no changes to the specifications)
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ubxssHMEqBcpQncHM5TMB

---
_Generated by [Claude Code](https://claude.ai/code/session_017ubxssHMEqBcpQncHM5TMB)_