### PR TITLE
Implement missing parts from StakePoolParams specification

### DIFF
--- a/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
+++ b/build-tools/static/hs-src/src/MAlonzo/Code/Ledger/Dijkstra/Foreign/API.hs
@@ -21,7 +21,7 @@ import MAlonzo.Code.Ledger.Dijkstra.Foreign.Cert              as X
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Chain             as X
   (ChainState(..), Block(..), chainStep)
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Certs             as X
-  ( StakePoolParams(..), PState(..), DelegEnv(..), GovCertEnv(..), CertEnv(..), DState(..), DCert(..), GState(..), CertState(..)
+  ( StakePoolParams(..), PState(..), DelegEnv(..), GovCertEnv(..), PoolEnv(..), CertEnv(..), DState(..), DCert(..), GState(..), CertState(..)
   , delegStep, govCertStep, poolStep)
 import MAlonzo.Code.Ledger.Dijkstra.Foreign.Entities          as X
   (EntitiesEnv(..), entitiesStep, SubEntitiesEnv(..), subentitiesStep)

--- a/formal-ledger-test/src/Test/LedgerImplementation.lagda.md
+++ b/formal-ledger-test/src/Test/LedgerImplementation.lagda.md
@@ -61,6 +61,7 @@ module Implementation where
 
   PlutusScript = ℕ × (List Data → Bool)
   ScriptHash = ℕ
+  VRF = ℕ
 
   ExUnits      = ℕ × ℕ
   ExUnit-CommutativeMonoid =

--- a/src/Ledger/Core/Foreign/Crypto/Structure.agda
+++ b/src/Ledger/Core/Foreign/Crypto/Structure.agda
@@ -32,6 +32,7 @@ HSCryptoStructure : CryptoStructure
 HSCryptoStructure = record {
     pkk = HSPKKScheme
   ; ScriptHash = ℕ
+  ; VRF = ℕ
   }
 
 open CryptoStructure HSCryptoStructure

--- a/src/Ledger/Core/Specification/Crypto.lagda.md
+++ b/src/Ledger/Core/Specification/Crypto.lagda.md
@@ -77,6 +77,9 @@ record CryptoStructure : Type₁ where
 
   open isHashableSet khs renaming (THash to KeyHash) hiding (DecEq-T) public
 
--- TODO: KES and VRF
+  field VRF : Type
+        ⦃ DecEq-VRF ⦄ : DecEq VRF
+
+-- TODO: KES
 ```
 -->

--- a/src/Ledger/Dijkstra/Foreign/Certs.agda
+++ b/src/Ledger/Dijkstra/Foreign/Certs.agda
@@ -59,6 +59,11 @@ instance
     • fieldPrefix "ce"
   Conv-CertEnv = autoConvert CertEnv
 
+  HsTy-PoolEnv = autoHsType PoolEnv
+    ⊣ withConstructor "MkPoolEnv"
+    • fieldPrefix "pe"
+  Conv-PoolEnv = autoConvert PoolEnv
+
   HsTy-CertState = autoHsType CertState ⊣ withConstructor "MkCertState"
   Conv-CertState = autoConvert CertState
 
@@ -69,7 +74,7 @@ deleg-step = to (compute Computational-DELEG)
 
 {-# COMPILE GHC deleg-step as delegStep #-}
 
-pool-step : HsType (PParams → PState → DCert → ComputationResult String PState)
+pool-step : HsType (PoolEnv → PState → DCert → ComputationResult String PState)
 pool-step = to (compute Computational-POOL)
 
 {-# COMPILE GHC pool-step as poolStep #-}

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -128,8 +128,10 @@ record DelegEnv : Type where
     pools         : Pools
     delegatees    : ℙ Credential
 
-PoolEnv : Type
-PoolEnv = PParams
+record PoolEnv : Type where
+  field
+    epoch           : Epoch
+    pp              : PParams
 
 record GovCertEnv : Type where
   field
@@ -292,12 +294,13 @@ instance
   HasEpoch-CertEnv : HasEpoch CertEnv
   HasEpoch-CertEnv .EpochOf = CertEnv.epoch
 
-  unquoteDecl HasCast-CertEnv HasCast-DState HasCast-PState HasCast-GState HasCast-CertState HasCast-DelegEnv HasCast-GovCertEnv = derive-HasCast
+  unquoteDecl HasCast-CertEnv HasCast-DState HasCast-PState HasCast-GState HasCast-CertState HasCast-DelegEnv HasCast-PoolEnv HasCast-GovCertEnv = derive-HasCast
     (   (quote CertEnv , HasCast-CertEnv)
     ∷   (quote DState , HasCast-DState)
     ∷   (quote PState , HasCast-PState)
     ∷   (quote GState , HasCast-GState)
     ∷   (quote CertState , HasCast-CertState)
+    ∷   (quote PoolEnv , HasCast-PoolEnv)
     ∷   (quote GovCertEnv , HasCast-GovCertEnv)
     ∷ [ (quote DelegEnv , HasCast-DelegEnv) ])
 
@@ -322,7 +325,7 @@ private variable
   mc          : Maybe Credential
   delegatees  : ℙ Credential
   dCert       : DCert
-  e           : Epoch
+  e e'        : Epoch
   vs          : List GovVote
   kh          : KeyHash
   mkh         : Maybe KeyHash
@@ -421,7 +424,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
     ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range pools ∪ range fPools))
     ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
-    pp ⊢ ⟦ pools
+    ⟦ e , pp ⟧ ⊢ ⟦ pools
          , fPools
          , retiring
          , deposits
@@ -437,7 +440,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
     ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range (pools ∣ ❴ kh ❵ ᶜ) ∪ range (fPools ∣ ❴ kh ❵ ᶜ)))
     ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
-    pp ⊢ ⟦ pools
+    ⟦ e , pp ⟧ ⊢ ⟦ pools
          , fPools
          , retiring
          , deposits
@@ -450,15 +453,17 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
 
   POOL-retirepool :
     ∙ IsPoolRegistered pools kh
+    ∙ e < e'
+    ∙ e' ≤ e + pp .Emax
     ────────────────────────────────
-    pp ⊢ ⟦ pools
+    ⟦ e , pp ⟧ ⊢ ⟦ pools
          , fPools
          , retiring
          , deposits
-         ⟧ ⇀⦇ retirepool kh e ,POOL⦈ ⟦
+         ⟧ ⇀⦇ retirepool kh e' ,POOL⦈ ⟦
            pools
          , fPools
-         , ❴ kh , e ❵ ∪ˡ retiring
+         , ❴ kh , e' ❵ ∪ˡ retiring
          , deposits
          ⟧
 ```
@@ -497,7 +502,7 @@ data _⊢_⇀⦇_,CERT⦈_  : CertEnv → CertState → DCert → CertState → 
       ⟦ e , pp , cc ⟧ ⊢ ⟦ stᵈ , stᵖ , stᵍ ⟧ ⇀⦇ dCert ,CERT⦈ ⟦ stᵈ' , stᵖ , stᵍ ⟧
 
   CERT-pool :
-    ∙ pp ⊢ stᵖ ⇀⦇ dCert ,POOL⦈ stᵖ'
+    ∙ ⟦ e , pp ⟧ ⊢ stᵖ ⇀⦇ dCert ,POOL⦈ stᵖ'
       ────────────────────────────────
       ⟦ e , pp , cc ⟧ ⊢ ⟦ stᵈ , stᵖ , stᵍ ⟧ ⇀⦇ dCert ,CERT⦈ ⟦ stᵈ , stᵖ' , stᵍ ⟧
 

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -140,7 +140,7 @@ record GovCertEnv : Type where
 
 <!--
 ```agda
-open StakePoolParams using (vrf)
+open StakePoolParams using (vrf; cost)
 
 IsConwayCert? : IsConwayCert ⁇¹
 IsConwayCert? {x} .dec with x
@@ -419,6 +419,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
   POOL-reg :
     ∙ ¬ (IsPoolRegistered pools kh)
     ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range pools ∪ range fPools))
+    ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
     pp ⊢ ⟦ pools
          , fPools
@@ -434,6 +435,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
   POOL-rereg :
     ∙ IsPoolRegistered pools kh
     ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range (pools ∣ ❴ kh ❵ ᶜ) ∪ range (fPools ∣ ❴ kh ❵ ᶜ)))
+    ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
     pp ⊢ ⟦ pools
          , fPools

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -426,15 +426,15 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
     ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
     ⟦ e , pp ⟧ ⊢ ⟦ pools
-         , fPools
-         , retiring
-         , deposits
-         ⟧ ⇀⦇ regpool kh poolParams ,POOL⦈ ⟦
-           pools ∪ˡ ❴ kh , poolParams ❵
-         , fPools
-         , retiring
-         , deposits ∪ˡ ❴ kh , pp .poolDeposit ❵
-         ⟧
+                 , fPools
+                 , retiring
+                 , deposits
+                 ⟧ ⇀⦇ regpool kh poolParams ,POOL⦈ ⟦
+                   pools ∪ˡ ❴ kh , poolParams ❵
+                 , fPools
+                 , retiring
+                 , deposits ∪ˡ ❴ kh , pp .poolDeposit ❵
+                 ⟧
 
   POOL-rereg :
     ∙ IsPoolRegistered pools kh
@@ -443,15 +443,15 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
     ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
     ⟦ e , pp ⟧ ⊢ ⟦ pools
-         , fPools
-         , retiring
-         , deposits
-         ⟧ ⇀⦇ regpool kh poolParams ,POOL⦈ ⟦
-           pools
-         , ❴ kh , poolParams ❵ ∪ˡ fPools
-         , retiring ∣ ❴ kh ❵ ᶜ
-         , deposits
-         ⟧
+                 , fPools
+                 , retiring
+                 , deposits
+                 ⟧ ⇀⦇ regpool kh poolParams ,POOL⦈ ⟦
+                   pools
+                 , ❴ kh , poolParams ❵ ∪ˡ fPools
+                 , retiring ∣ ❴ kh ❵ ᶜ
+                 , deposits
+                 ⟧
 
   POOL-retirepool :
     ∙ IsPoolRegistered pools kh
@@ -459,15 +459,15 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
     ∙ e' ≤ e + pp .Emax
     ────────────────────────────────
     ⟦ e , pp ⟧ ⊢ ⟦ pools
-         , fPools
-         , retiring
-         , deposits
-         ⟧ ⇀⦇ retirepool kh e' ,POOL⦈ ⟦
-           pools
-         , fPools
-         , ❴ kh , e' ❵ ∪ˡ retiring
-         , deposits
-         ⟧
+                 , fPools
+                 , retiring
+                 , deposits
+                 ⟧ ⇀⦇ retirepool kh e' ,POOL⦈ ⟦
+                   pools
+                 , fPools
+                 , ❴ kh , e' ❵ ∪ˡ retiring
+                 , deposits
+                 ⟧
 ```
 
 ## `GOVCERT`{.AgdaDatatype} Transition System

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -142,7 +142,7 @@ record GovCertEnv : Type where
 
 <!--
 ```agda
-open StakePoolParams using (vrf; cost)
+open StakePoolParams
 
 IsConwayCert? : IsConwayCert ⁇¹
 IsConwayCert? {x} .dec with x
@@ -422,6 +422,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
   POOL-reg :
     ∙ ¬ (IsPoolRegistered pools kh)
     ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range pools ∪ range fPools))
+    ∙ NetworkIdOf (poolParams .rewardAccount) ≡ NetworkId
     ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
     ⟦ e , pp ⟧ ⊢ ⟦ pools
@@ -438,6 +439,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
   POOL-rereg :
     ∙ IsPoolRegistered pools kh
     ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range (pools ∣ ❴ kh ❵ ᶜ) ∪ range (fPools ∣ ❴ kh ❵ ᶜ)))
+    ∙ NetworkIdOf (poolParams .rewardAccount) ≡ NetworkId
     ∙ pp .minPoolCost ≤ poolParams .cost
     ────────────────────────────────
     ⟦ e , pp ⟧ ⊢ ⟦ pools

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -30,7 +30,8 @@ record StakePoolParams : Type where
     cost            : Coin
     margin          : UnitInterval
     pledge          : Coin
-    rewardAccount   : Credential
+    rewardAccount   : RewardAddress
+    vrf             : VRF
 
 CCHotKeys : Type
 CCHotKeys = Credential ⇀ Maybe Credential
@@ -139,6 +140,8 @@ record GovCertEnv : Type where
 
 <!--
 ```agda
+open StakePoolParams using (vrf)
+
 IsConwayCert? : IsConwayCert ⁇¹
 IsConwayCert? {x} .dec with x
 ... | regdrep _ _ _ = yes tt
@@ -165,6 +168,10 @@ open HasColdCredentials ⦃...⦄ public
 record HasPools {a} (A : Type a) : Type a where
   field PoolsOf : A → Pools
 open HasPools ⦃...⦄ public
+
+record HasFuturePools {a} (A : Type a) : Type a where
+  field FuturePoolsOf : A → Pools
+open HasFuturePools ⦃...⦄ public
 
 record HasRetiring {a} (A : Type a) : Type a where
   field RetiringOf : A → Retiring
@@ -233,6 +240,9 @@ instance
 
   HasPools-PState : HasPools PState
   HasPools-PState .PoolsOf = PState.pools
+
+  HasFuturePools-PState : HasFuturePools PState
+  HasFuturePools-PState .FuturePoolsOf = PState.fPools
 
   HasDeposits-PState : HasDeposits PState
   HasDeposits-PState .DepositsOf = PState.deposits
@@ -408,6 +418,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
 
   POOL-reg :
     ∙ ¬ (IsPoolRegistered pools kh)
+    ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range pools ∪ range fPools))
     ────────────────────────────────
     pp ⊢ ⟦ pools
          , fPools
@@ -422,6 +433,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
 
   POOL-rereg :
     ∙ IsPoolRegistered pools kh
+    ∙ ¬ (poolParams .vrf ∈ mapˢ vrf (range (pools ∣ ❴ kh ❵ ᶜ) ∪ range (fPools ∣ ❴ kh ❵ ᶜ)))
     ────────────────────────────────
     pp ⊢ ⟦ pools
          , fPools

--- a/src/Ledger/Dijkstra/Specification/Certs.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs.lagda.md
@@ -447,6 +447,7 @@ data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Type wh
          ⟧
 
   POOL-retirepool :
+    ∙ IsPoolRegistered pools kh
     ────────────────────────────────
     pp ⊢ ⟦ pools
          , fPools

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -22,6 +22,7 @@ open GovStructure govStructure
 open RewardAddress
 
 open Computational ⦃...⦄
+open StakePoolParams using (vrf)
 
 instance
   Computational-DELEG : Computational _⊢_⇀⦇_,DELEG⦈_ String
@@ -55,20 +56,33 @@ instance
   ... | no ¬p = ⊥-elim (¬p (p , q))
 
   Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
-  Computational-POOL .computeProof _ stᵖ (regpool c _)
+  Computational-POOL .computeProof _ stᵖ (regpool c poolParams)
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
-  ... | yes p = success (-, (POOL-rereg p))
-  ... | no ¬p = success (-, (POOL-reg ¬p))
+  Computational-POOL .computeProof _ stᵖ (regpool c poolParams) | yes p
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ))) ¿
+  ... | yes q = success (-, POOL-rereg (p , q))
+  ... | no ¬q = failure "poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))"
+  Computational-POOL .computeProof _ stᵖ (regpool c poolParams) | no ¬p
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))) ¿
+  ... | yes q = success (-, (POOL-reg (¬p , q)))
+  ... | no ¬q = failure "poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))"
+
   Computational-POOL .computeProof _ stᵖ (retirepool c e) = success (-, POOL-retirepool)
   Computational-POOL .computeProof _ stᵖ _ = failure "Unexpected certificate in POOL"
-  Computational-POOL .completeness _ stᵖ (regpool c _) _ (POOL-reg p)
+  Computational-POOL .completeness _ stᵖ (regpool c poolParams) _ (POOL-reg (p , q))
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
-  ... | yes p' = ⊥-elim (p p')
-  ... | no _ = refl
-  Computational-POOL .completeness _ stᵖ (regpool c _) _ (POOL-rereg p)
+  ... | yes r = ⊥-elim (p r)
+  ... | no ¬r
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))) ¿
+  ... | yes s = refl
+  ... | no ¬s = ⊥-elim (¬s q)
+  Computational-POOL .completeness _ stᵖ (regpool c poolParams) _ (POOL-rereg (p , q))
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
-  ... | yes _ = refl
-  ... | no ¬p = ⊥-elim (¬p p)
+  ... | no ¬r = ⊥-elim (¬r p)
+  ... | yes r
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ))) ¿
+  ... | yes s = refl
+  ... | no ¬s = ⊥-elim (¬s q)
   Computational-POOL .completeness _ _ (retirepool _ _) _ POOL-retirepool = refl
 
   Computational-GOVCERT : Computational _⊢_⇀⦇_,GOVCERT⦈_ String

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -66,8 +66,10 @@ instance
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))) ¿
   ... | yes q = success (-, (POOL-reg (¬p , q)))
   ... | no ¬q = failure "poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))"
-
-  Computational-POOL .computeProof _ stᵖ (retirepool c e) = success (-, POOL-retirepool)
+  Computational-POOL .computeProof _ stᵖ (retirepool c e)
+    with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
+  ... | yes p = success (-, POOL-retirepool p)
+  ... | no ¬q = failure "Pool not registered"
   Computational-POOL .computeProof _ stᵖ _ = failure "Unexpected certificate in POOL"
   Computational-POOL .completeness _ stᵖ (regpool c poolParams) _ (POOL-reg (p , q))
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
@@ -83,7 +85,10 @@ instance
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ))) ¿
   ... | yes s = refl
   ... | no ¬s = ⊥-elim (¬s q)
-  Computational-POOL .completeness _ _ (retirepool _ _) _ POOL-retirepool = refl
+  Computational-POOL .completeness _ stᵖ (retirepool c _) _ (POOL-retirepool p)
+    with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
+  ... | yes _ = refl
+  ... | no ¬q = ⊥-elim (¬q p)
 
   Computational-GOVCERT : Computational _⊢_⇀⦇_,GOVCERT⦈_ String
   Computational-GOVCERT .computeProof ce cs (regdrep c d _) =
@@ -138,8 +143,8 @@ instance
   ... | success _ | refl = refl
   Computational-CERT .completeness ce cs
     dCert@(retirepool c e) cs' (CERT-pool h)
-    with completeness _ _ _ _ h
-  ... | refl = refl
+    with computeProof (PParamsOf ce) (PStateOf cs) dCert | completeness _ _ _ _ h
+  ... | success _ | refl = refl
   Computational-CERT .completeness Γ cs
     (regdrep c d an) _ (CERT-gov (GOVCERT-regdrep p))
     rewrite dec-yes

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -22,7 +22,8 @@ open GovStructure govStructure
 open RewardAddress
 
 open Computational ⦃...⦄
-open StakePoolParams using (vrf)
+open StakePoolParams
+open PParams
 
 instance
   Computational-DELEG : Computational _⊢_⇀⦇_,DELEG⦈_ String
@@ -58,32 +59,36 @@ instance
   Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
   Computational-POOL .computeProof _ stᵖ (regpool c poolParams)
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
-  Computational-POOL .computeProof _ stᵖ (regpool c poolParams) | yes p
-    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ))) ¿
+  Computational-POOL .computeProof pp stᵖ (regpool c poolParams) | yes p
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))
+         ∙ pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes q = success (-, POOL-rereg (p , q))
-  ... | no ¬q = failure "poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))"
-  Computational-POOL .computeProof _ stᵖ (regpool c poolParams) | no ¬p
-    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))) ¿
+  ... | no ¬q = failure (genErrors ¬q)
+  Computational-POOL .computeProof pp stᵖ (regpool c poolParams) | no ¬p
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ)))
+         ∙ pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes q = success (-, (POOL-reg (¬p , q)))
-  ... | no ¬q = failure "poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))"
+  ... | no ¬q = failure (genErrors ¬q)
   Computational-POOL .computeProof _ stᵖ (retirepool c e)
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | yes p = success (-, POOL-retirepool p)
-  ... | no ¬q = failure "Pool not registered"
+  ... | no ¬q = failure (genErrors ¬q)
   Computational-POOL .computeProof _ stᵖ _ = failure "Unexpected certificate in POOL"
-  Computational-POOL .completeness _ stᵖ (regpool c poolParams) _ (POOL-reg (p , q))
+  Computational-POOL .completeness pp stᵖ (regpool c poolParams) _ (POOL-reg (p , q))
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | yes r = ⊥-elim (p r)
   ... | no ¬r
-    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ))) ¿
-  ... | yes s = refl
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ)))
+         ∙ pp .minPoolCost ≤ poolParams .cost ¿
+  ... | yes _ = refl
   ... | no ¬s = ⊥-elim (¬s q)
-  Computational-POOL .completeness _ stᵖ (regpool c poolParams) _ (POOL-rereg (p , q))
+  Computational-POOL .completeness pp stᵖ (regpool c poolParams) _ (POOL-rereg (p , q))
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | no ¬r = ⊥-elim (¬r p)
   ... | yes r
-    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ))) ¿
-  ... | yes s = refl
+    with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))
+         ∙ pp .minPoolCost ≤ poolParams .cost ¿
+  ... | yes _ = refl
   ... | no ¬s = ⊥-elim (¬s q)
   Computational-POOL .completeness _ stᵖ (retirepool c _) _ (POOL-retirepool p)
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -62,11 +62,13 @@ instance
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   Computational-POOL .computeProof Γ stᵖ (regpool c poolParams) | yes p
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))
+         ∙ NetworkIdOf (poolParams .rewardAccount) ≡ NetworkId
          ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes q = success (-, POOL-rereg (p , q))
   ... | no ¬q = failure (genErrors ¬q)
   Computational-POOL .computeProof Γ stᵖ (regpool c poolParams) | no ¬p
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ)))
+         ∙ NetworkIdOf (poolParams .rewardAccount) ≡ NetworkId
          ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes q = success (-, (POOL-reg (¬p , q)))
   ... | no ¬q = failure (genErrors ¬q)
@@ -82,6 +84,7 @@ instance
   ... | yes r = ⊥-elim (p r)
   ... | no ¬r
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ)))
+         ∙ NetworkIdOf (poolParams .rewardAccount) ≡ NetworkId
          ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes _ = refl
   ... | no ¬s = ⊥-elim (¬s q)
@@ -90,6 +93,7 @@ instance
   ... | no ¬r = ⊥-elim (¬r p)
   ... | yes r
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))
+         ∙ NetworkIdOf (poolParams .rewardAccount) ≡ NetworkId
          ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes _ = refl
   ... | no ¬s = ⊥-elim (¬s q)

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -132,7 +132,7 @@ instance
   Computational-CERT : Computational _⊢_⇀⦇_,CERT⦈_ String
   Computational-CERT .computeProof ce cs dCert
     with computeProof ⟦ PParamsOf ce , PoolsOf cs , dom (DRepsOf cs) ⟧ (DStateOf cs) dCert
-         | computeProof ⟦ EpochOf ce ,  PParamsOf ce ⟧ (PStateOf cs) dCert
+         | computeProof ⟦ EpochOf ce , PParamsOf ce ⟧ (PStateOf cs) dCert
          | computeProof ⟦ EpochOf ce , PParamsOf ce , ColdCredentialsOf ce ⟧ cs dCert
 
   ... | success (_ , h) | _               | _               = success (-, CERT-deleg h)
@@ -152,7 +152,7 @@ instance
   ... | success _ | refl = refl
   Computational-CERT .completeness ce cs
     dCert@(regpool c poolParams) cs' (CERT-pool h)
-    with computeProof ⟦ CertEnv.epoch ce , CertEnv.pp ce ⟧ (CertState.pState cs) dCert
+    with computeProof ⟦ EpochOf ce , PParamsOf ce ⟧ (PStateOf cs) dCert
     | completeness _ _ _ _ h
   ... | success _ | refl = refl
   Computational-CERT .completeness ce cs

--- a/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Certs/Properties/Computational.lagda.md
@@ -23,6 +23,7 @@ open RewardAddress
 
 open Computational ⦃...⦄
 open StakePoolParams
+open PoolEnv
 open PParams
 
 instance
@@ -59,39 +60,43 @@ instance
   Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_ String
   Computational-POOL .computeProof _ stᵖ (regpool c poolParams)
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
-  Computational-POOL .computeProof pp stᵖ (regpool c poolParams) | yes p
+  Computational-POOL .computeProof Γ stᵖ (regpool c poolParams) | yes p
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))
-         ∙ pp .minPoolCost ≤ poolParams .cost ¿
+         ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes q = success (-, POOL-rereg (p , q))
   ... | no ¬q = failure (genErrors ¬q)
-  Computational-POOL .computeProof pp stᵖ (regpool c poolParams) | no ¬p
+  Computational-POOL .computeProof Γ stᵖ (regpool c poolParams) | no ¬p
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ)))
-         ∙ pp .minPoolCost ≤ poolParams .cost ¿
+         ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes q = success (-, (POOL-reg (¬p , q)))
   ... | no ¬q = failure (genErrors ¬q)
-  Computational-POOL .computeProof _ stᵖ (retirepool c e)
-    with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
+  Computational-POOL .computeProof Γ stᵖ (retirepool c e')
+    with ¿ IsPoolRegistered (PoolsOf stᵖ) c
+         ∙ Γ .epoch < e'
+         ∙ e' ≤  Γ .epoch + Γ .pp .Emax ¿
   ... | yes p = success (-, POOL-retirepool p)
   ... | no ¬q = failure (genErrors ¬q)
   Computational-POOL .computeProof _ stᵖ _ = failure "Unexpected certificate in POOL"
-  Computational-POOL .completeness pp stᵖ (regpool c poolParams) _ (POOL-reg (p , q))
+  Computational-POOL .completeness Γ stᵖ (regpool c poolParams) _ (POOL-reg (p , q))
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | yes r = ⊥-elim (p r)
   ... | no ¬r
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ) ∪ range (FuturePoolsOf stᵖ)))
-         ∙ pp .minPoolCost ≤ poolParams .cost ¿
+         ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes _ = refl
   ... | no ¬s = ⊥-elim (¬s q)
-  Computational-POOL .completeness pp stᵖ (regpool c poolParams) _ (POOL-rereg (p , q))
+  Computational-POOL .completeness Γ stᵖ (regpool c poolParams) _ (POOL-rereg (p , q))
     with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
   ... | no ¬r = ⊥-elim (¬r p)
   ... | yes r
     with ¿ ¬ (poolParams .vrf ∈ mapˢ vrf (range (PoolsOf stᵖ ∣ ❴ c ❵ ᶜ) ∪ range (FuturePoolsOf stᵖ ∣ ❴ c ❵ ᶜ)))
-         ∙ pp .minPoolCost ≤ poolParams .cost ¿
+         ∙ Γ .pp .minPoolCost ≤ poolParams .cost ¿
   ... | yes _ = refl
   ... | no ¬s = ⊥-elim (¬s q)
-  Computational-POOL .completeness _ stᵖ (retirepool c _) _ (POOL-retirepool p)
-    with ¿ IsPoolRegistered (PoolsOf stᵖ) c ¿
+  Computational-POOL .completeness Γ stᵖ (retirepool c e) _ (POOL-retirepool p)
+    with ¿ IsPoolRegistered (PoolsOf stᵖ) c
+         ∙ Γ .epoch < e
+         ∙ e ≤ Γ .epoch + Γ .pp .Emax ¿
   ... | yes _ = refl
   ... | no ¬q = ⊥-elim (¬q p)
 
@@ -123,7 +128,7 @@ instance
   Computational-CERT : Computational _⊢_⇀⦇_,CERT⦈_ String
   Computational-CERT .computeProof ce cs dCert
     with computeProof ⟦ PParamsOf ce , PoolsOf cs , dom (DRepsOf cs) ⟧ (DStateOf cs) dCert
-         | computeProof (PParamsOf ce) (PStateOf cs) dCert
+         | computeProof ⟦ EpochOf ce ,  PParamsOf ce ⟧ (PStateOf cs) dCert
          | computeProof ⟦ EpochOf ce , PParamsOf ce , ColdCredentialsOf ce ⟧ cs dCert
 
   ... | success (_ , h) | _               | _               = success (-, CERT-deleg h)
@@ -143,12 +148,12 @@ instance
   ... | success _ | refl = refl
   Computational-CERT .completeness ce cs
     dCert@(regpool c poolParams) cs' (CERT-pool h)
-    with computeProof (CertEnv.pp ce) (CertState.pState cs) dCert
+    with computeProof ⟦ CertEnv.epoch ce , CertEnv.pp ce ⟧ (CertState.pState cs) dCert
     | completeness _ _ _ _ h
   ... | success _ | refl = refl
   Computational-CERT .completeness ce cs
     dCert@(retirepool c e) cs' (CERT-pool h)
-    with computeProof (PParamsOf ce) (PStateOf cs) dCert | completeness _ _ _ _ h
+    with computeProof ⟦ EpochOf ce , PParamsOf ce ⟧ (PStateOf cs) dCert | completeness _ _ _ _ h
   ... | success _ | refl = refl
   Computational-CERT .completeness Γ cs
     (regdrep c d an) _ (CERT-gov (GOVCERT-regdrep p))

--- a/src/Ledger/Dijkstra/Specification/PParams.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/PParams.lagda.md
@@ -118,6 +118,7 @@ record PParams : Type where
     b                             : ℕ
     keyDeposit                    : Coin
     poolDeposit                   : Coin
+    minPoolCost                   : Coin
     monetaryExpansion             : UnitInterval -- formerly: rho
     treasuryCut                   : UnitInterval -- formerly: tau
     coinsPerUTxOByte              : Coin
@@ -220,6 +221,7 @@ module PParamsUpdate where
           a b                           : Maybe ℕ
           keyDeposit                    : Maybe Coin
           poolDeposit                   : Maybe Coin
+          minPoolCost                   : Maybe Coin
           monetaryExpansion             : Maybe UnitInterval
           treasuryCut                   : Maybe UnitInterval
           coinsPerUTxOByte              : Maybe Coin
@@ -275,6 +277,7 @@ module PParamsUpdate where
       ∷ is-just b
       ∷ is-just keyDeposit
       ∷ is-just poolDeposit
+      ∷ is-just minPoolCost
       ∷ is-just monetaryExpansion
       ∷ is-just treasuryCut
       ∷ is-just coinsPerUTxOByte
@@ -371,6 +374,7 @@ module PParamsUpdate where
       ; b                           = U.b ?↗ P.b
       ; keyDeposit                  = U.keyDeposit ?↗ P.keyDeposit
       ; poolDeposit                 = U.poolDeposit ?↗ P.poolDeposit
+      ; minPoolCost                 = U.minPoolCost ?↗ P.minPoolCost
       ; monetaryExpansion           = U.monetaryExpansion ?↗ P.monetaryExpansion
       ; treasuryCut                 = U.treasuryCut ?↗ P.treasuryCut
       ; coinsPerUTxOByte            = U.coinsPerUTxOByte ?↗ P.coinsPerUTxOByte

--- a/src/Ledger/Dijkstra/Specification/PoolReap.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/PoolReap.lagda.md
@@ -61,7 +61,7 @@ data _⊢_⇀⦇_,POOLREAP⦈_ : ⊤ → PoolReapState → Epoch → PoolReapSta
         retired = retiring ⁻¹ e
 
         rewardAccounts : KeyHash ⇀ Credential
-        rewardAccounts = mapValues rewardAccount (pools ∣ retired)
+        rewardAccounts = mapValues (CredentialOf ∘ rewardAccount) (pools ∣ retired)
 
         rewardAccounts' : Credential ⇀ Coin
         rewardAccounts' = aggregateBy (rewardAccounts ˢ) depositsᵖ

--- a/src/Ledger/Dijkstra/Specification/Ratify.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Ratify.lagda.md
@@ -255,7 +255,7 @@ module AcceptedBySPO (delegatees : VoteDelegs)
   defaultVote : KeyHash → Vote
   defaultVote kh = case lookupᵐ? pools kh of λ where
     nothing   → Vote.no
-    (just  p) → case lookupᵐ? delegatees (StakePoolParams.rewardAccount p) , gaType action of
+    (just  p) → case lookupᵐ? delegatees (CredentialOf (StakePoolParams.rewardAccount p)) , gaType action of
       λ where
       ( _                        , TriggerHardFork  )  → Vote.no
       ( just vDelegNoConfidence  , NoConfidence     )  → Vote.yes

--- a/src/Ledger/Dijkstra/Specification/Rewards.lagda.md
+++ b/src/Ledger/Dijkstra/Specification/Rewards.lagda.md
@@ -133,7 +133,7 @@ rewardOnePool pp rewardPot n N poolParams stakeDistr σ σa tot = memberRewards 
                             (stakeDistr ∣ owners ᶜ)
 
   ownersRewards : Stake
-  ownersRewards =  ❴ poolParams .StakePoolParams.rewardAccount
+  ownersRewards =  ❴ CredentialOf (poolParams .StakePoolParams.rewardAccount)
                    , stakeMap[ rewardOwners ] ownerStake σ ❵ᵐ
 
 poolStake  : KeyHash → StakeDelegs → Stake → Stake


### PR DESCRIPTION
# Description

- Add `minPoolCost` protocol parameter and enforce cost constraint of pool registration
- Add VRF to `StakePoolParams`. Enforce VRF uniqueness wrt registered pools
- Change `StakePoolParams` reward account from `Credential` to `RewardAddress`, and enforce NetworkId coincides during pool registration
- Add pool retirement conditions wrt pp `Emax`

Closes #1272 
Addresses part of #1259 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any semantic changes to the specifications are documented in `CHANGELOG.md`
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
